### PR TITLE
Update to the opa-fmt url as it was returning 404s from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The following rules are currently available:
 | style    | [avoid-get-and-list-prefix](https://github.com/StyraInc/regal/blob/main/docs/rules/style/avoid-get-and-list-prefix.md)   | Avoid get_ and list_ prefix for rules and functions    |
 | style    | [prefer-snake-case](https://github.com/StyraInc/regal/blob/main/docs/rules/style/prefer-snake-case.md)                   | Prefer snake_case for names                            |
 | style    | [function-arg-return](https://github.com/StyraInc/regal/blob/main/docs/rules/style/function-arg-return.md)               | Function argument used for return value                |
-| style    | [opa-fmt](https:/github.com/StyraInc/regal/blob/main/docs/rules/style/opa-fmt.md)                                        | File should be formatted with `opa fmt`                |
+| style    | [opa-fmt](https://github.com/StyraInc/regal/blob/main/docs/rules/style/opa-fmt.md)                                       | File should be formatted with `opa fmt`                |
 | testing  | [file-missing-test-suffix](https://github.com/StyraInc/regal/blob/main/docs/rules/testing/file-missing-test-suffix.md)   | Files containing tests should have a _test.rego suffix |
 | testing  | [identically-named-tests](https://github.com/StyraInc/regal/blob/main/docs/rules/testing/identically-named-tests.md)     | Multiple tests with same name                          |
 | testing  | [todo-test](https://github.com/StyraInc/regal/blob/main/docs/rules/testing/todo-test.md)                                 | TODO test encountered                                  |

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,3 +46,10 @@ gci write \
   -s blank \
   -s dot .
 ```
+## Documentation
+
+The table in the [Rules](../README.md#rules) section of the README is generated with the following command:
+
+```shell
+go run main.go table --write-to-readme bundle
+```

--- a/pkg/rules/fmt.go
+++ b/pkg/rules/fmt.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"path"
 
 	"github.com/open-policy-agent/opa/format"
 
@@ -86,7 +85,7 @@ func (f *OpaFmtRule) Description() string {
 }
 
 func (f *OpaFmtRule) Documentation() string {
-	return path.Join(docs.DocsBaseURL, category, title+".md")
+	return docs.DocsBaseURL + "/" + category + "/" + title + ".md"
 }
 
 func (f *OpaFmtRule) Config() config.Rule {


### PR DESCRIPTION
Hey Team! 👋 

The project looks awesome and I can't wait to use it on some projects I have ideas for.

While reading the `README` and going through all the URLs I noticed the `opa-fmt` one was missing a `/` and would give you a `404`.

A bit of a silly `pr` I know in terms of scope but just thought I'd send a quick fix 😅 