### PR TITLE
Use lowercase chars in registry name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,7 +36,7 @@ builds:
 kos:
   - # build settings are imported from this build
     build: linux-windows-build
-    repository: ghcr.io/StyraInc/regal
+    repository: ghcr.io/styrainc/regal
     tags:
       - '{{.Version}}'
       - latest


### PR DESCRIPTION
This is to address this error:

```
failed to publish artifacts: publish: repository can only contain the
characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: StyraInc/regal
```

See run https://github.com/StyraInc/regal/actions/runs/5254120685/jobs/9492333809