### PR TITLE
Don't crash on identically named functions

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -144,10 +144,15 @@ function_decls(rules) := {name: args |
 	rule.head.args
 
 	name := rule.head.name
-	args := {"args": [item |
+
+	# ensure we only get one set of args, or we'll have a conflict
+	args := [{"args": [item |
 		some arg in rule.head.args
 		item := {"name": arg.value}
-	]}
+	]} |
+		some rule in rules
+		rule.head.name == name
+	][0]
 }
 
 function_ret_in_args(fn_name, terms) if {

--- a/bundle/regal/ast_test.rego
+++ b/bundle/regal/ast_test.rego
@@ -54,3 +54,20 @@ test_find_vars if {
 
 	names == ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t"]
 }
+
+# https://github.com/StyraInc/regal/issues/168
+test_function_decls_multiple_same_name if {
+	policy := `package p
+
+	import future.keywords.if
+
+	f(x) := x if true
+	f(y) := y if false
+	`
+	module := regal.parse_module("p.rego", policy)
+	custom := ast.function_decls(module.rules)
+
+	# we only need to assert there wasn't a conflict in the above
+	# call, not what value was returned
+	is_object(custom)
+}


### PR DESCRIPTION
Fix ast.function_decls so that identically named functions won't result in eval_conflict_error as the map is created

Fixes #168