### PR TITLE
Remove unused imports

### DIFF
--- a/bundle/regal/rules/bugs/constant_condition_test.rego
+++ b/bundle/regal/rules/bugs/constant_condition_test.rego
@@ -2,7 +2,6 @@ package regal.rules.bugs_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
 import data.regal.rules.bugs.common_test.report
 

--- a/bundle/regal/rules/bugs/not_equals_in_loop_test.rego
+++ b/bundle/regal/rules/bugs/not_equals_in_loop_test.rego
@@ -2,7 +2,6 @@ package regal.rules.bugs_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.rules.bugs.common_test.report
 import data.regal.rules.bugs.common_test.report_with_fk
 

--- a/bundle/regal/rules/bugs/rule_named_if_test.rego
+++ b/bundle/regal/rules/bugs/rule_named_if_test.rego
@@ -2,7 +2,6 @@ package regal.rules.bugs_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
 import data.regal.rules.bugs.common_test.report
 

--- a/bundle/regal/rules/bugs/rule_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/rule_shadows_builtin_test.rego
@@ -2,9 +2,7 @@ package regal.rules.bugs_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.bugs
 import data.regal.rules.bugs.common_test.report
 
 test_fail_rule_name_shadows_builtin if {

--- a/bundle/regal/rules/bugs/top_level_iteration_test.rego
+++ b/bundle/regal/rules/bugs/top_level_iteration_test.rego
@@ -2,9 +2,7 @@ package regal.rules.bugs_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.bugs
 import data.regal.rules.bugs.common_test.report_with_fk
 
 test_fail_top_level_iteration_wildcard if {

--- a/bundle/regal/rules/bugs/unused_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unused_return_value_test.rego
@@ -2,9 +2,7 @@ package regal.rules.bugs_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.bugs
 import data.regal.rules.bugs.common_test.report_with_fk
 
 test_fail_unused_return_value if {

--- a/bundle/regal/rules/idiomatic/custom_has_key_construct.rego
+++ b/bundle/regal/rules/idiomatic/custom_has_key_construct.rego
@@ -4,7 +4,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
 
@@ -31,7 +30,7 @@ report contains violation if {
 	terms[0].value[0].type == "var"
 	terms[0].value[0].value == "eq"
 
-	[var, ref] := normalize_eq_terms(terms)
+	[_, ref] := normalize_eq_terms(terms)
 
 	ref.value[0].type == "var"
 	ref.value[0].value in arg_names

--- a/bundle/regal/rules/idiomatic/custom_has_key_construct_test.rego
+++ b/bundle/regal/rules/idiomatic/custom_has_key_construct_test.rego
@@ -2,9 +2,7 @@ package regal.rules.idiomatic_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.idiomatic
 import data.regal.rules.idiomatic.common_test.report
 
 test_fail_unnecessary_construct_in if {

--- a/bundle/regal/rules/idiomatic/custom_in_construct.rego
+++ b/bundle/regal/rules/idiomatic/custom_in_construct.rego
@@ -4,7 +4,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
 

--- a/bundle/regal/rules/idiomatic/custom_in_construct_test.rego
+++ b/bundle/regal/rules/idiomatic/custom_in_construct_test.rego
@@ -2,9 +2,7 @@ package regal.rules.idiomatic_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.idiomatic
 import data.regal.rules.idiomatic.common_test.report
 
 test_fail_unnecessary_construct_in if {

--- a/bundle/regal/rules/imports/avoid_importing_input_test.rego
+++ b/bundle/regal/rules/imports/avoid_importing_input_test.rego
@@ -2,7 +2,6 @@ package regal.rules.imports_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
 import data.regal.rules.imports.common_test.report
 

--- a/bundle/regal/rules/imports/implicit_future_keywords_test.rego
+++ b/bundle/regal/rules/imports/implicit_future_keywords_test.rego
@@ -2,9 +2,7 @@ package regal.rules.imports_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.imports
 import data.regal.rules.imports.common_test.report
 
 test_fail_future_keywords_import_wildcard if {

--- a/bundle/regal/rules/imports/import_shadows_import_test.rego
+++ b/bundle/regal/rules/imports/import_shadows_import_test.rego
@@ -2,9 +2,7 @@ package regal.rules.imports_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.imports
 import data.regal.rules.imports.common_test.report
 
 test_fail_duplicate_import if {

--- a/bundle/regal/rules/imports/redundant_alias_test.rego
+++ b/bundle/regal/rules/imports/redundant_alias_test.rego
@@ -2,9 +2,7 @@ package regal.rules.imports_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.imports
 import data.regal.rules.imports.common_test.report
 
 test_fail_redundant_alias if {

--- a/bundle/regal/rules/imports/redundant_data_import_test.rego
+++ b/bundle/regal/rules/imports/redundant_data_import_test.rego
@@ -2,9 +2,7 @@ package regal.rules.imports_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.imports
 import data.regal.rules.imports.common_test.report
 
 test_fail_import_data if {

--- a/bundle/regal/rules/style/avoid_get_and_list_prefix_test.rego
+++ b/bundle/regal/rules/style/avoid_get_and_list_prefix_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 test_fail_rule_name_starts_with_get if {

--- a/bundle/regal/rules/style/external_reference_test.rego
+++ b/bundle/regal/rules/style/external_reference_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 test_fail_function_references_input if {

--- a/bundle/regal/rules/style/line_length.rego
+++ b/bundle/regal/rules/style/line_length.rego
@@ -4,7 +4,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
 

--- a/bundle/regal/rules/style/line_length_test.rego
+++ b/bundle/regal/rules/style/line_length_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 test_fail_line_too_long if {

--- a/bundle/regal/rules/style/prefer_snake_case_test.rego
+++ b/bundle/regal/rules/style/prefer_snake_case_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 snake_case_violation := {

--- a/bundle/regal/rules/style/todo_comment.rego
+++ b/bundle/regal/rules/style/todo_comment.rego
@@ -4,7 +4,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
 

--- a/bundle/regal/rules/style/todo_comment_test.rego
+++ b/bundle/regal/rules/style/todo_comment_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 test_fail_todo_comment if {

--- a/bundle/regal/rules/style/unconditional_assignment.rego
+++ b/bundle/regal/rules/style/unconditional_assignment.rego
@@ -4,7 +4,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
 

--- a/bundle/regal/rules/style/unconditional_assignment_test.rego
+++ b/bundle/regal/rules/style/unconditional_assignment_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 test_fail_unconditional_assignment_in_body if {

--- a/bundle/regal/rules/style/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use_assignment_operator.rego
@@ -4,10 +4,8 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
-import data.regal.util
 
 # Some cases blocked by https://github.com/StyraInc/regal/issues/6 - e.g:
 #

--- a/bundle/regal/rules/style/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use_assignment_operator_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 test_fail_unification_in_default_assignment if {

--- a/bundle/regal/rules/style/use_in_operator_test.rego
+++ b/bundle/regal/rules/style/use_in_operator_test.rego
@@ -2,9 +2,7 @@ package regal.rules.style_test
 
 import future.keywords.if
 
-import data.regal.ast
 import data.regal.config
-import data.regal.rules.style
 import data.regal.rules.style.common_test.report
 
 test_fail_use_in_operator_string_lhs if {

--- a/bundle/regal/rules/testing/todo_test.rego
+++ b/bundle/regal/rules/testing/todo_test.rego
@@ -4,7 +4,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
 


### PR DESCRIPTION
We really need this as a linter rule, but using the strict mode compiler from OPA is not straightforward at the moment, so this had to be done manually. Looking for a proper fix later.