### PR TITLE
Improve use-assignment-operator rule

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -178,6 +178,15 @@ function_ret_in_args(fn_name, terms) if {
 	count(rest) > count(all_functions[fn_name].args)
 }
 
+# METADATA
+# description: |
+#   answers if provided rule is implicitly assigned boolean true, i.e. allow { .. } or not
+implicit_boolean_assignment(rule) if {
+	# note the missing location attribute here, which is how we distinguish
+	# between implicit and explicit assignments
+	rule.head.value == {"type": "boolean", "value": true}
+}
+
 all_functions := object.union(opa.builtins, function_decls(input.rules))
 
 all_function_names := object.keys(all_functions)

--- a/bundle/regal/rules/style/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use_assignment_operator_test.rego
@@ -6,6 +6,56 @@ import data.regal.ast
 import data.regal.config
 import data.regal.rules.style["use-assignment-operator"] as rule
 
+test_fail_unification_in_regular_assignment if {
+	r := rule.report with input as ast.policy(`foo = false`)
+	r == {{
+		"category": "style",
+		"description": "Prefer := over = for assignment",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+		}],
+		"title": "use-assignment-operator",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo = false"},
+		"level": "error",
+	}}
+}
+
+test_fail_not_implicit_boolean_assignment_with_body if {
+	r := rule.report with input as ast.policy(`allow = true { true }`)
+	r == {{
+		"category": "style",
+		"description": "Prefer := over = for assignment",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+		}],
+		"title": "use-assignment-operator",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "allow = true { true }"},
+		"level": "error",
+	}}
+}
+
+test_fail_not_implicit_boolean_assignment if {
+	r := rule.report with input as ast.policy(`foo = true`)
+	r == {{
+		"category": "style",
+		"description": "Prefer := over = for assignment",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+		}],
+		"title": "use-assignment-operator",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo = true"},
+		"level": "error",
+	}}
+}
+
+test_success_implicit_boolean_assignment if {
+	r := rule.report with input as ast.policy(`allow { true }`)
+	r == set()
+}
+
 test_fail_unification_in_default_assignment if {
 	r := rule.report with input as ast.policy(`default x = false`)
 	r == {{
@@ -43,5 +93,35 @@ test_fail_unification_in_object_rule_assignment if {
 
 test_success_assignment_in_object_rule_assignment if {
 	r := rule.report with input as ast.policy(`x["a"] := 1`)
+	r == set()
+}
+
+test_fail_unification_in_function_assignment if {
+	r := rule.report with input as ast.policy(`foo(bar) = "baz"`)
+	r == {{
+		"category": "style",
+		"description": "Prefer := over = for assignment",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+		}],
+		"title": "use-assignment-operator",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": `foo(bar) = "baz"`},
+		"level": "error",
+	}}
+}
+
+test_success_implicit_boolean_assignment_function if {
+	r := rule.report with input as ast.policy(`f(x) { 1 == 1 }`)
+	r == set()
+}
+
+test_success_assignment_operator_function if {
+	r := rule.report with input as ast.policy(`f(x) := true { 1 == 1 }`)
+	r == set()
+}
+
+test_success_partial_rule if {
+	r := rule.report with input as ast.policy(`partial["works"] { 1 == 1 }`)
 	r == set()
 }

--- a/p.rego
+++ b/p.rego
@@ -1,3 +1,0 @@
-package p
-
-fooBar := "true"


### PR DESCRIPTION
Using missing location attribute as an indicator of a "generated" boolean assignment, we're now able to finish the cases where this was previously not possible to discern from the AST alone. The `use-assignment-operator` rule now additionally flags unification in the following cases:

- `foo = bar`
- `foo(x) = bar`