### PR TITLE
test-outside-test-package: functions prefixed test_ aren't tests

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -20,6 +20,7 @@ package_name := concat(".", [path.value |
 
 tests := [rule |
 	some rule in input.rules
+	not rule.head.args
 	startswith(rule.head.name, "test_")
 ]
 

--- a/bundle/regal/rules/testing/test_outside_test_package_test.rego
+++ b/bundle/regal/rules/testing/test_outside_test_package_test.rego
@@ -35,3 +35,14 @@ test_success_test_inside_test_package if {
 	result := rule.report with input as ast
 	result == set()
 }
+
+# https://github.com/StyraInc/regal/issues/176
+test_success_test_prefixed_function if {
+	ast := regal.parse_module("foo_test.rego", `
+	package foo
+
+	test_foo(x) { x == 1 }
+	`)
+	result := rule.report with input as ast
+	result == set()
+}


### PR DESCRIPTION
Fixes #176