### PR TITLE
Add e2e test of all rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea
 
 dist/
+
+regal

--- a/bundle/regal/rules/idiomatic/custom_in_construct.rego
+++ b/bundle/regal/rules/idiomatic/custom_in_construct.rego
@@ -28,7 +28,7 @@ report contains violation if {
 	var.value in arg_names
 	ref.value[0].value in arg_names
 	ref.value[1].type == "var"
-	ref.value[1].value == "$0"
+	startswith(ref.value[1].value, "$")
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/style/function_arg_return.rego
+++ b/bundle/regal/rules/style/function_arg_return.rego
@@ -11,7 +11,7 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule(rego.metadata.rule())
+	cfg := config.for_rule({"custom": {"category": "style"}, "title": "function-arg-return"})
 
 	except_functions := array.concat(
 		object.get(cfg, "except-functions", []),

--- a/bundle/regal/rules/style/line_length.rego
+++ b/bundle/regal/rules/style/line_length.rego
@@ -10,7 +10,7 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule({"category": "style", "title": "line-length"})
+	cfg := config.for_rule({"custom": {"category": "style"}, "title": "line-length"})
 
 	some i, line in input.regal.file.lines
 

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -24,16 +24,17 @@ func readProvidedConfig(t *testing.T) config.Config {
 
 	cwd := must(os.Getwd)
 
-	bs, err := os.ReadFile(filepath.Join(cwd, "..", "bundle", "regal", "config", "provided", "data.yaml"))
+	configPath := filepath.Join(cwd, "..", "bundle", "regal", "config", "provided", "data.yaml")
+	bs, err := os.ReadFile(configPath)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatalf("failed to read config from %q: %v", configPath, err)
 	}
 
 	var cfg config.Config
 
 	err = yaml.Unmarshal(bs, &cfg)
 	if err != nil {
-		log.Fatal(err)
+		t.Fatalf("failed to unmarshal config: %v", err)
 	}
 
 	return cfg

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -36,6 +36,8 @@ not_equals_in_loop {
 	"foo" != input.bar[_]
 }
 
+# TODO this can't be here due to the importing of future.keywords
+# Move to another file.
 # rule-named-if
 # if { true }
 

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -1,0 +1,110 @@
+# METADATA
+# description: |
+#   This file is used for e2e tests of most of the provided linter rules. All violations can't
+#   be tested in a single file, as some are mutually exlusive (i.e. implicit-future-keywords and
+#   rule-named-if).
+package all_violations
+
+# Imports
+
+# avoid-importing-input
+import input
+
+# implict-future-keywords
+import future.keywords
+
+# import-shadows-import
+import data.foo
+import data.foo
+
+import data.redundant.alias as alias
+
+# redundant-data-import
+import data
+
+### Bugs ###
+
+constant_condition {
+	1 == 1
+}
+
+# METADATA
+# invalid-metadata-attribute: true
+should := "fail"
+
+not_equals_in_loop {
+	"foo" != input.bar[_]
+}
+
+# rule-named-if
+# if { true }
+
+# rule-shadows-builtin
+contains := true
+
+top_level_iteration := input[_]
+
+unused_return_value {
+	indexof("foo", "o")
+}
+
+### Idiomatic ###
+
+custom_has_key_construct(map, key) {
+	_ = map[key]
+}
+
+custom_in_construct(coll, item) {
+	item == coll[_]
+}
+
+### Style ###
+
+# avoid-get-and-list-prefix
+get_foo(foo) := foo
+
+# METADATA
+# description: detached-metadata
+
+annotation := "detached"
+
+external_reference(_) {
+	data.foo
+}
+
+function_arg_return {
+	indexof("foo", "o", i)
+	i == 1
+}
+
+line_length_should_be_no_longer_than_120_characters_but_this_line_is_really_long_and_will_exceed_that_limit_which_is := "bad"
+
+#no-whitespace-comment
+
+ opa_fmt := "fail"
+
+preferSnakeCase := "fail"
+
+# todo-comment
+
+x := y {
+	y := 1
+}
+
+use_assignment = "oparator"
+
+use_in_operator {
+	"item" == input.coll[_]
+}
+
+# this will also tringger the test-outside-test-package rule
+test_identically_named_tests := true
+test_identically_named_tests := true
+
+todo_test_bad {
+	input.bad
+}
+
+print_or_trace_call {
+	print("forbidden!")
+}

--- a/e2e/testdata/violations/rule_named_if.rego
+++ b/e2e/testdata/violations/rule_named_if.rego
@@ -1,0 +1,5 @@
+package rule_named_if
+
+allow := true if {
+	input.foo == "bar"
+}

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -98,6 +98,9 @@ func CloseFileIgnore(file *os.File) {
 
 func ExcludeTestFilter() filter.LoaderFilter {
 	return func(abspath string, info files.FileInfo, depth int) bool {
-		return strings.HasSuffix(info.Name(), "_test.rego")
+		return strings.HasSuffix(info.Name(), "_test.rego") &&
+			// (anderseknert): This is an outlier, but not sure we need something
+			// more polished to deal with this for the time being.
+			info.Name() != "todo_test.rego"
 	}
 }


### PR DESCRIPTION
Which exposed flaws in a few rules:
- custom-in-construct would not work with multiple wildcards
- function-arg-return wrong input format for fetching config
- line-length wrong input format for fetching config

While we by no means are done with e2e tests, I think it's OK to say we now at least *have* e2e tests, and much of course thanks to @srenatus previous work on this.

Resolves #53