### PR TITLE
Enhanced type checking using Regal AST schema

### DIFF
--- a/bundle/regal/regal.rego
+++ b/bundle/regal/regal.rego
@@ -4,4 +4,6 @@
 # - Styra
 # related_resources:
 # - https://www.styra.com
+# schemas:
+# - input: schema.regal.ast
 package regal

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"embed"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/styrainc/regal/internal/embeds"
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/linter"
@@ -62,8 +62,6 @@ func (f *repeatedStringFlag) Set(s string) error {
 
 	return nil
 }
-
-var EmbedBundleFS embed.FS //nolint:gochecknoglobals
 
 func init() {
 	params := lintCommandParams{}
@@ -173,7 +171,7 @@ func lint(args []string, params lintCommandParams) (report.Report, error) {
 
 	// Create new fs from root of bundle, to avoid having to deal with
 	// "bundle" in paths (i.e. `data.bundle.regal`)
-	bfs, err := fs.Sub(EmbedBundleFS, "bundle")
+	bfs, err := fs.Sub(embeds.EmbedBundleFS, "bundle")
 	if err != nil {
 		return report.Report{}, fmt.Errorf("failed reading embedded bundle %w", err)
 	}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/open-policy-agent/opa/version"
 
 	"github.com/styrainc/regal/internal/compile"
+	"github.com/styrainc/regal/internal/embeds"
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/pkg/builtins"
 )
@@ -132,7 +133,7 @@ func opaTest(args []string) int {
 
 	// Create new fs from root of bundle, to avoid having to deal with
 	// "bundle" in paths (i.e. `data.bundle.regal`)
-	bfs, err := fs.Sub(EmbedBundleFS, "bundle")
+	bfs, err := fs.Sub(embeds.EmbedBundleFS, "bundle")
 	if err != nil {
 		fmt.Fprintln(os.Stderr, fmt.Errorf("failed reading embedded bundle %w", err))
 
@@ -158,7 +159,9 @@ func opaTest(args []string) int {
 
 	compiler := compile.NewCompilerWithRegalBuiltins().
 		WithPathConflictsCheck(storage.NonEmpty(ctx, store, txn)).
-		WithEnablePrintStatements(!testParams.benchmark)
+		WithEnablePrintStatements(!testParams.benchmark).
+		WithSchemas(compile.SchemaSet(embeds.ASTSchema)).
+		WithUseTypeCheckAnnotations(true)
 
 	if testParams.threshold > 0 && !testParams.coverage {
 		testParams.coverage = true

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -73,6 +73,8 @@ An example policy to implement this requirement might look something like this:
 # related_resources:
 # - description: documentation
 #   ref: https://www.acmecorp.example.org/docs/regal/package
+# schemas:
+# - input: schema.regal.ast
 package custom.regal.rules.naming["acme-corp-package"]
 
 import future.keywords.contains
@@ -107,6 +109,11 @@ Starting from top to bottom, these are the components comprising our custom rule
    order to document the purpose of the rule, along with any other information that could potentially be useful.
    All rule packages **must** have a `description`. Providing links to additional documentation under
    `related_resources` is recommended, but not required.
+1. Note the `schema` attribute present in the metadata annotation. Adding this is optional, but highly recommended, as
+   it will make the compiler aware of the structure of the input, i.e. the AST. This allows the compiler to fail when
+   unknown attributes are referenced, due to typos or other mistakes. The compiler will also fail when an attribute is
+   referenced using a type it does not have, like referring to a string as if it was a number. Set to `schema.regal.ast`
+   to use the AST schema provided by Regal.
 1. Regal will evaluate any rule named `report` in each linter policy, so at least one `report` rule **must** be present.
 1. In our example `report` rule, we evaluate another rule (`acme_corp_package`) in order to know if the package name
    starts with `acme.corp`, and another rule (`system_log_package`) to know if it starts with `system.log`. If neither

--- a/e2e/testdata/ast_type_failure/custom_type_fail.rego
+++ b/e2e/testdata/ast_type_failure/custom_type_fail.rego
@@ -1,0 +1,15 @@
+# METADATA
+# description: Custom rule with type checker failure
+# schemas:
+# - input: schema.regal.ast
+package custom.regal.rules.naming.type_fail
+
+import future.keywords.contains
+import future.keywords.if
+
+report contains foo if {
+	# There is no "foo" attrinbute in the AST,
+	# so this should fail at compile time
+	foo := input.foo
+	foo == "bar"
+}

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -2,11 +2,12 @@ package compile
 
 import (
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/util"
 
 	"github.com/styrainc/regal/pkg/builtins"
 )
 
-func NewCompilerWithRegalBuiltins() *ast.Compiler {
+func Capabilities() *ast.Capabilities {
 	caps := ast.CapabilitiesForThisVersion()
 	caps.Builtins = append(caps.Builtins, &ast.Builtin{
 		Name: builtins.RegalParseModuleMeta.Name,
@@ -21,5 +22,17 @@ func NewCompilerWithRegalBuiltins() *ast.Compiler {
 		Decl: builtins.RegalLastMeta.Decl,
 	})
 
-	return ast.NewCompiler().WithCapabilities(caps)
+	return caps
+}
+
+func SchemaSet(s []byte) *ast.SchemaSet {
+	schema := util.MustUnmarshalJSON(s)
+	schemaSet := ast.NewSchemaSet()
+	schemaSet.Put(ast.MustParseRef("schema.regal.ast"), schema)
+
+	return schemaSet
+}
+
+func NewCompilerWithRegalBuiltins() *ast.Compiler {
+	return ast.NewCompiler().WithCapabilities(Capabilities())
 }

--- a/internal/embeds/embeds.go
+++ b/internal/embeds/embeds.go
@@ -1,0 +1,8 @@
+//nolint:gochecknoglobals
+package embeds
+
+import "embed"
+
+var EmbedBundleFS embed.FS
+
+var ASTSchema []byte

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -62,16 +62,6 @@ func MustLoadRegalBundlePath(path string) bundle.Bundle {
 	return regalBundle
 }
 
-// MustJSON parses JSON from reader, exit on failure.
-func MustJSON(from any) []byte {
-	bs, err := json.MarshalIndent(from, "", "   ")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return bs
-}
-
 // JSONRoundTrip convert any value to JSON and back again.
 func JSONRoundTrip(from any, to any) error {
 	bs, err := json.Marshal(from)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/styrainc/regal/cmd"
+	"github.com/styrainc/regal/internal/embeds"
 )
 
 // Note: this will bundle the tests as well, but since that has negligible impact on the size of the binary,
@@ -14,14 +15,19 @@ import (
 //go:embed all:bundle
 var bundle embed.FS
 
+//go:embed schemas/regal-ast.json
+var schema []byte
+
 func main() {
 	// Remove date and time from any `log.*` calls, as that doesn't add much of value here
 	// Evaluate options for logging later..
 	log.SetFlags(0)
 
-	// The embedded FS can't point to parent directories, so while not pretty, we'll
-	// need to pass it from here to the next command
-	cmd.EmbedBundleFS = bundle
+	// Embedded files and directories can only traverse down in the tree, i.e. no parent paths,
+	// so while this isn't pretty, we'll use a separate package to carry state from here. If you
+	// know of a better way of doing this, don't hesitate to fix this.
+	embeds.EmbedBundleFS = bundle
+	embeds.ASTSchema = schema
 
 	if err := cmd.RootCommand.Execute(); err != nil {
 		os.Exit(1)

--- a/schemas/regal-ast.json
+++ b/schemas/regal-ast.json
@@ -1,0 +1,397 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/open-policy-agent/opa/ast/module",
+  "$ref": "#/$defs/module",
+  "$defs": {
+    "module": {
+      "properties": {
+        "package": {
+          "$ref": "#/$defs/package"
+        },
+        "imports": {
+          "items": {
+            "$ref": "#/$defs/import"
+          },
+          "type": "array"
+        },
+        "annotations": {
+          "items": {
+            "$ref": "#/$defs/annotations"
+          },
+          "type": "array"
+        },
+        "rules": {
+          "items": {
+            "$ref": "#/$defs/rule"
+          },
+          "type": "array"
+        },
+        "comments": {
+          "items": {
+            "$ref": "#/$defs/comment"
+          },
+          "type": "array"
+        },
+        "regal": {
+          "$ref": "#/$defs/regal"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "package"
+      ]
+    },
+    "import": {
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/term"
+        },
+        "alias": {
+          "type": "string"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ]
+    },
+    "annotations": {
+      "properties": {
+        "scope": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "entrypoint": {
+          "type": "boolean"
+        },
+        "description": {
+          "type": "string"
+        },
+        "organizations": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "related_resources": {
+          "items": {
+            "$ref": "#/$defs/related_resource_annotation"
+          },
+          "type": "array"
+        },
+        "authors": {
+          "items": {
+            "$ref": "#/$defs/author_annotation"
+          },
+          "type": "array"
+        },
+        "schemas": {
+          "items": {
+            "$ref": "#/$defs/schema_annotation"
+          },
+          "type": "array"
+        },
+        "custom": {
+          "type": "object"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "scope"
+      ]
+    },
+    "rule": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "head": {
+          "$ref": "#/$defs/head"
+        },
+        "body": {
+          "$ref": "#/$defs/body"
+        },
+        "else": {
+          "description": "should reference #/$defs/rule. temporary workaround for https://github.com/open-policy-agent/opa/issues/6099",
+          "$ref": "#/$defs/else"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "head",
+        "body"
+      ]
+    },
+    "else": {
+      "properties": {
+        "default": {
+          "type": "boolean"
+        },
+        "head": {
+          "$ref": "#/$defs/head"
+        },
+        "body": {
+          "$ref": "#/$defs/body"
+        },
+        "else": {
+          "description": "temporary workaround for https://github.com/open-policy-agent/opa/issues/6099",
+          "type": "object"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "head",
+        "body"
+      ]
+    },
+    "args": {
+      "items": {
+        "$ref": "#/$defs/term"
+      },
+      "type": "array"
+    },
+    "author_annotation": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name"
+      ]
+    },
+    "body": {
+      "items": {
+        "$ref": "#/$defs/expr"
+      },
+      "type": "array"
+    },
+    "comment": {
+      "properties": {
+        "Text": {
+          "type": "string",
+          "contentEncoding": "base64"
+        },
+        "Location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "Text",
+        "Location"
+      ]
+    },
+    "expr": {
+      "properties": {
+        "with": {
+          "items": {
+            "$ref": "#/$defs/with"
+          },
+          "type": "array"
+        },
+        "terms": true,
+        "index": {
+          "type": "integer"
+        },
+        "generated": {
+          "type": "boolean"
+        },
+        "negated": {
+          "type": "boolean"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "terms",
+        "index"
+      ]
+    },
+    "head": {
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "ref": {
+          "$ref": "#/$defs/ref"
+        },
+        "args": {
+          "$ref": "#/$defs/args"
+        },
+        "key": {
+          "$ref": "#/$defs/term"
+        },
+        "value": {
+          "$ref": "#/$defs/term"
+        },
+        "assign": {
+          "type": "boolean"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "location": {
+      "properties": {
+        "file": {
+          "type": "string"
+        },
+        "row": {
+          "type": "integer"
+        },
+        "col": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file",
+        "row",
+        "col"
+      ]
+    },
+    "package": {
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/ref"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ]
+    },
+    "ref": {
+      "items": {
+        "$ref": "#/$defs/term"
+      },
+      "type": "array"
+    },
+    "related_resource_annotation": {
+      "properties": {
+        "ref": {
+          "type": "string",
+          "format": "uri"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ref"
+      ]
+    },
+    "schema_annotation": {
+      "properties": {
+        "path": {
+          "$ref": "#/$defs/ref"
+        },
+        "schema": {
+          "$ref": "#/$defs/ref"
+        },
+        "definition": true
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ]
+    },
+    "term": {
+      "properties": {
+        "value": true,
+        "location": {
+          "$ref": "#/$defs/location"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "value"
+      ]
+    },
+    "with": {
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/term"
+        },
+        "value": {
+          "$ref": "#/$defs/term"
+        },
+        "location": {
+          "$ref": "#/$defs/location"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "target",
+        "value"
+      ]
+    },
+    "regal": {
+      "properties": {
+        "file": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "lines": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "type": "object"
+        }
+      },
+      "type": "object",
+      "required": [
+        "file"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Currently enabled for the `regal test` command, which is the most likely entrypoint for rule authors, whether for built-in Regal rules or custom ones.

While it would be useful to provide this also for `regal lint` — we'll probably want to do this together with the strictness rules, as we currently don't require compilation, and it's not clear that we'll want to unless a rule is configured that needs this, like most of the strictness rules would.

Additionally, the schema is provided when running the Rego tests via `go test ./...`, which should help catch errors we make ourselves.

It would be nice if custom rule authors didn't have to include the schema in the metadata annotation, but I've yet to figure out the best way of doing that, as we can't bundle a custom policy and also have them read from disk without the bundle "owning" that path. I suppose we could just parse a policy from a string, including a subpackage scoped custom.regal.rules package annotation... but I'll need to think more about this.

Fixes #52