### PR TITLE
#185, moving the use-in-operator to idiomatic and its relevant files

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,22 +143,22 @@ The following rules are currently available:
 | bugs      | [unused-return-value](https://github.com/StyraInc/regal/blob/main/docs/rules/bugs/unused-return-value.md)                | Non-boolean return value unused                           |
 | idiomatic | [custom-has-key-construct](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/custom-has-key-construct.md) | Custom function may be replaced by `in` and `object.keys` |
 | idiomatic | [custom-in-construct](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/custom-in-construct.md)           | Custom function may be replaced by `in` keyword           |
-| imports   | [avoid-importing-input](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/avoid-importing-input.md)         | Avoid importing input                                     |
+| idiomatic | [use-in-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/use-in-operator.md)                   | Use in to check for membership                            |
+| imports   | [redundant-data-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-data-import.md)         | Redundant import of data                                  |
 | imports   | [implicit-future-keywords](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/implicit-future-keywords.md)   | Use explicit future keyword imports                       |
 | imports   | [import-shadows-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/import-shadows-import.md)         | Import shadows another import                             |
 | imports   | [redundant-alias](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-alias.md)                     | Redundant alias                                           |
-| imports   | [redundant-data-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-data-import.md)         | Redundant import of data                                  |
-| style     | [avoid-get-and-list-prefix](https://github.com/StyraInc/regal/blob/main/docs/rules/style/avoid-get-and-list-prefix.md)   | Avoid get_ and list_ prefix for rules and functions       |
-| style     | [use-assignment-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/style/use-assignment-operator.md)       | Prefer := over = for assignment                           |
+| imports   | [avoid-importing-input](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/avoid-importing-input.md)         | Avoid importing input                                     |
+| style     | [prefer-snake-case](https://github.com/StyraInc/regal/blob/main/docs/rules/style/prefer-snake-case.md)                   | Prefer snake_case for names                               |
+| style     | [todo-comment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/todo-comment.md)                             | Avoid TODO comments                                       |
 | style     | [external-reference](https://github.com/StyraInc/regal/blob/main/docs/rules/style/external-reference.md)                 | Reference to input, data or rule ref in function body     |
 | style     | [function-arg-return](https://github.com/StyraInc/regal/blob/main/docs/rules/style/function-arg-return.md)               | Function argument used for return value                   |
 | style     | [line-length](https://github.com/StyraInc/regal/blob/main/docs/rules/style/line-length.md)                               | Line too long                                             |
 | style     | [no-whitespace-comment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/no-whitespace-comment.md)           | Comment should start with whitespace                      |
-| style     | [prefer-snake-case](https://github.com/StyraInc/regal/blob/main/docs/rules/style/prefer-snake-case.md)                   | Prefer snake_case for names                               |
-| style     | [todo-comment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/todo-comment.md)                             | Avoid TODO comments                                       |
-| style     | [unconditional-assignment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/unconditional-assignment.md)     | Unconditional assignment in rule body                     |
+| style     | [avoid-get-and-list-prefix](https://github.com/StyraInc/regal/blob/main/docs/rules/style/avoid-get-and-list-prefix.md)   | Avoid get_ and list_ prefix for rules and functions       |
 | style     | [detached-metadata](https://github.com/StyraInc/regal/blob/main/docs/rules/style/detached-metadata.md)                   | Detached metadata annotation                              |
-| style     | [use-in-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/style/use-in-operator.md)                       | Use in to check for membership                            |
+| style     | [unconditional-assignment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/unconditional-assignment.md)     | Unconditional assignment in rule body                     |
+| style     | [use-assignment-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/style/use-assignment-operator.md)       | Prefer := over = for assignment                           |
 | style     | [opa-fmt](https://github.com/StyraInc/regal/blob/main/docs/rules/style/opa-fmt.md)                                       | File should be formatted with `opa fmt`                   |
 | testing   | [identically-named-tests](https://github.com/StyraInc/regal/blob/main/docs/rules/testing/identically-named-tests.md)     | Multiple tests with same name                             |
 | testing   | [print-or-trace-call](https://github.com/StyraInc/regal/blob/main/docs/rules/testing/print-or-trace-call.md)             | Call to print or trace function                           |

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -19,6 +19,8 @@ rules:
       level: error
     custom-in-construct:
       level: error
+    use-in-operator:
+      level: error
   imports:
     avoid-importing-input:
       level: error
@@ -53,8 +55,6 @@ rules:
     unconditional-assignment:
       level: error
     use-assignment-operator:
-      level: error
-    use-in-operator:
       level: error
   testing:
     file-missing-test-suffix:

--- a/bundle/regal/rules/idiomatic/use_in_operator.rego
+++ b/bundle/regal/rules/idiomatic/use_in_operator.rego
@@ -1,6 +1,6 @@
 # METADATA
 # description: Use in to check for membership
-package regal.rules.style["use-in-operator"]
+package regal.rules.idiomatic["use-in-operator"]
 
 import future.keywords.contains
 import future.keywords.if

--- a/bundle/regal/rules/idiomatic/use_in_operator_test.rego
+++ b/bundle/regal/rules/idiomatic/use_in_operator_test.rego
@@ -1,21 +1,21 @@
-package regal.rules.style["use-in-operator_test"]
+package regal.rules.idiomatic["use-in-operator_test"]
 
 import future.keywords.if
 
 import data.regal.ast
 import data.regal.config
-import data.regal.rules.style["use-in-operator"] as rule
+import data.regal.rules.idiomatic["use-in-operator"] as rule
 
 test_fail_use_in_operator_string_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	"admin" == input.user.roles[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 13, "file": "policy.rego", "row": 4, "text": "\t\"admin\" == input.user.roles[_]"},
@@ -28,11 +28,11 @@ test_fail_use_in_operator_number_lhs if {
 	1 == input.lucky_numbers[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 7, "file": "policy.rego", "row": 4, "text": "\t1 == input.lucky_numbers[_]"},
@@ -45,11 +45,11 @@ test_fail_use_in_operator_array_lhs if {
 	[1] == input.arrays[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 9, "file": "policy.rego", "row": 4, "text": "\t[1] == input.arrays[_]"},
@@ -62,11 +62,11 @@ test_fail_use_in_operator_boolean_lhs if {
 	true == input.booleans[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 10, "file": "policy.rego", "row": 4, "text": "\ttrue == input.booleans[_]"},
@@ -79,11 +79,11 @@ test_fail_use_in_operator_object_lhs if {
 	{"x": "y"} == input.objects[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 16, "file": "policy.rego", "row": 4, "text": "\t{\"x\": \"y\"} == input.objects[_]"},
@@ -96,11 +96,11 @@ test_fail_use_in_operator_null_lhs if {
 	null == input.objects[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 10, "file": "policy.rego", "row": 4, "text": "\tnull == input.objects[_]"},
@@ -113,11 +113,11 @@ test_fail_use_in_operator_set_lhs if {
 	{"foo"} == input.objects[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 13, "file": "policy.rego", "row": 4, "text": "\t{\"foo\"} == input.objects[_]"},
@@ -130,11 +130,11 @@ test_fail_use_in_operator_var_lhs if {
 	admin == input.user.roles[_]
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 11, "file": "policy.rego", "row": 4, "text": "\tadmin == input.user.roles[_]"},
@@ -147,11 +147,11 @@ test_fail_use_in_operator_string_rhs if {
 	input.user.roles[_] == "admin"
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 2, "file": "policy.rego", "row": 4, "text": "\tinput.user.roles[_] == \"admin\""},
@@ -164,11 +164,11 @@ test_fail_use_in_operator_var_rhs if {
 		input.user.roles[_] == admin
 	}`)
 	r == {{
-		"category": "style",
+		"category": "idiomatic",
 		"description": "Use in to check for membership",
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "style"),
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 		}],
 		"title": "use-in-operator",
 		"location": {"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tinput.user.roles[_] == admin"},

--- a/docs/rules/idiomatic/use-in-operator.md
+++ b/docs/rules/idiomatic/use-in-operator.md
@@ -2,7 +2,7 @@
 
 **Summary**: Use `in` to check for membership
 
-**Category**: Style
+**Category**: Idiomatic
 
 **Avoid**
 ```rego
@@ -39,12 +39,8 @@ This linter rule provides the following configuration options:
 
 ```yaml
 rules: 
-  style:
+  idiomatic:
     use-in-operator:
       # one of "error", "warning", "ignore"
       level: error
 ```
-
-## Related Resources
-
-- Rego Style Guide [Use `in` to check for membership](https://github.com/StyraInc/rego-style-guide#use-in-to-check-for-membership)

--- a/docs/rules/idiomatic/use-in-operator.md
+++ b/docs/rules/idiomatic/use-in-operator.md
@@ -44,3 +44,7 @@ rules:
       # one of "error", "warning", "ignore"
       level: error
 ```
+
+## Related Resources
+
+- Rego Style Guide [Use `in` to check for membership](https://github.com/StyraInc/rego-style-guide#use-in-to-check-for-membership)

--- a/docs/rules/style/use-in-operator.md
+++ b/docs/rules/style/use-in-operator.md
@@ -1,0 +1,5 @@
+# use-in-operator
+
+## Please Note!
+
+This rule has been moved to *idiomatic* category and can be found [here](../idiomatic/use-in-operator.md).


### PR DESCRIPTION
Hey @anderseknert and Team! 👋 

Thought I'd try to lend a hand!

In terms of the `README`, I was not 100% sure how you envisioned it e.g.:

- Leave the readme where it is and update it saying it moved.
- Move the readme to the new location under `idiomatic` and update it saying it was previously under `style`

Let me know what you think is best here and I will update it 😄 

Not sure if I missed anything else! Please LMK and I'll get back to it!

This Fixes https://github.com/StyraInc/regal/issues/185

Thanks 🚀 

