### PR TITLE
VSCode snippets

### DIFF
--- a/rego.json
+++ b/rego.json
@@ -88,10 +88,10 @@
             "package $1",
             "",
             "",
-            "decision := {allow: true} {",
+            "decision := {\"allow\": true} {",
             "\tinput.foo",
             "}",
-            "decision := {allow: false} {",
+            "decision := {\"allow\": false} {",
             "\tnot input.foo",
             "}"
         ],

--- a/rego.json
+++ b/rego.json
@@ -1,0 +1,100 @@
+{
+    "policy template": {
+        "prefix": [
+            "policy",
+            "rule",
+            "template"
+        ],
+        "body": [
+            "# METADATA ",
+            "# description: $1",
+            "package custom.regal.rules.$2",
+            "",
+            "import future.keywords.in",
+            "import future.keywords.if",
+            "import future.keywords.contains",
+            "",
+            "import data.regal.result",
+            "",
+            "report contains violation if {",
+            "\t$3",
+            "\t",
+            "\t",
+            "\tviolation := result.fail(regal.metadata.chain(), result.position($4))",
+            "}"
+        ],
+        "description": "Regal policy template"
+    },
+    "policy test": {
+        "prefix": [
+            "regal_test",
+            "testing",
+            "template"
+        ],
+        "body": [
+            "package custom.regal.rules.$1",
+            "",
+            "import future.keywords.if",
+            "import future.keywords.in",
+            "import future.keywords.contains",
+            "",
+            "import data.regal.ast",
+            "import data.regal.config",
+            "import custom.regal.rules.$2 as rule",
+            "",
+            "test_fail_$3 if {",
+            "\tr := rule.report with input as ast.policy(",
+            "\t`decision := {\"allow\": true} {",
+            "\t\tinput.foo",
+            "\t}`)",
+            "\tres := {",
+            "\t\t{",
+            "\t\t\t\"category\": \"structure\",",
+            "\t\t\t\"description\": \"Exactly two decision rules (1. allow = true, 2. allow = false) should be present in the policy.\",",
+            "\t\t\t\"level\": \"error\",",
+            "\t\t\t\"location\": {",
+            "\t\t\t\t\"col\": 1,",
+            "\t\t\t\t\"file\": \"policy.rego\",",
+            "\t\t\t\t\"row\": 3,",
+            "\t\t\t\t\"text\": \"decision := {\"allow\": true} {\"",
+            "\t\t\t},",
+            "\t\t\t\"title\": \"two-decision-clauses\"",
+            "\t\t}",
+            "\t}",
+            "\tr == res",
+            "}",
+            "",
+            "",
+            "test_success_$4 if {",
+            "\tr := rule.report with input as ast.policy(`",
+            "\tdecision := {allow: true} {",
+            "\t\tinput.foo",
+            "\t}",
+            "\tdecision := {allow: false} {",
+            "\t\tnot input.foo",
+            "\t}`)",
+            "\tr == set()",
+            "}",
+            ""
+        ],
+        "description": "Regal testing template"
+    },
+    "policy example": {
+        "prefix": [
+            "regal_example",
+            "template"
+        ],
+        "body": [
+            "package $1",
+            "",
+            "",
+            "decision := {allow: true} {",
+            "\tinput.foo",
+            "}",
+            "decision := {allow: false} {",
+            "\tnot input.foo",
+            "}"
+        ],
+        "description": "Regal example template"
+    }
+}

--- a/rego.json
+++ b/rego.json
@@ -56,7 +56,7 @@
             "\t\t\t\t\"col\": 1,",
             "\t\t\t\t\"file\": \"policy.rego\",",
             "\t\t\t\t\"row\": 3,",
-            "\t\t\t\t\"text\": \"decision := {\"allow\": true} {\"",
+            "\t\t\t\t\"text\": \"decision := {\\\"allow\\\": true} {\"",
             "\t\t\t},",
             "\t\t\t\"title\": \"two-decision-clauses\"",
             "\t\t}",

--- a/rego.json
+++ b/rego.json
@@ -40,7 +40,7 @@
             "",
             "import data.regal.ast",
             "import data.regal.config",
-            "import custom.regal.rules.$2 as rule",
+            "import data.custom.regal.rules.$2 as rule",
             "",
             "test_fail_$3 if {",
             "\tr := rule.report with input as ast.policy(",

--- a/rego.json
+++ b/rego.json
@@ -20,7 +20,7 @@
             "\t$3",
             "\t",
             "\t",
-            "\tviolation := result.fail(regal.metadata.chain(), result.position($4))",
+            "\tviolation := result.fail(rego.metadata.chain(), result.location($4))",
             "}"
         ],
         "description": "Regal policy template"


### PR DESCRIPTION
Added snippets for VSCode to pre-populate 3 types of files: 
1. Policy file
2. Test file
3. Example policy (e.g. for parsing)

On Mac, it is to be placed in Users/username/Library/Application_Support/Code/User/Snippets. 
On Windows, it is to be placed in Windows/Users/username/AppData/Roaming/Code/User/Snippets.

Otherwise you can do the following in VSCode:
Preferences -> Configure User Snippets -> Type "rego" -> Copy paste this file. 

The snippets are known by their prefix/keywords. 
1. Policy: "policy", "rule", "template"
2. Test: "regal_test", "testing", "template"
3. Example: "regal_example", "template"