### PR TITLE
add testing helper for creating policy bundles

### DIFF
--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -45,3 +45,18 @@ func InputPolicy(filename string, policy string) rules.Input {
 
 	return rules.NewInput(content, modules)
 }
+
+// InputBundle allows for constructing a policy bundle
+// for testing rules that perform linting of an entire policy bundle.
+// policyBundle represents the bundle as a map from filename to filecontent.
+func InputBundle(policyBundle map[string]string) rules.Input {
+	content := make(map[string]string)
+	modules := make(map[string]*ast.Module)
+
+	for filename, filecontent := range policyBundle {
+		content[filename] = filecontent
+		modules[filename] = parse.MustParseModule(filecontent)
+	}
+
+	return rules.NewInput(content, modules)
+}


### PR DESCRIPTION
I was creating a custom rule implemented in Go, just like OpaFmtRule.
The rule lints an entire policy bundle. In this case, it asserts that masking is implemented under system/log/log.rego.

When testing the rule, I was missing a way to provide a set of policy files as input.

**Usage**
```
policyFileName := "api/authz/policy.rego"
policyFileContent := `
package api.authz

##content of policy##
`
systemLogFileName := "system/log/log.rego"
systemLogFileContent := `
package system.log

##content of policy##
`

bundle := map[string]string{
    policyFileName:    policyFileContent,
    systemLogFileName: systemLogFileContent,
}

result, err := rules.NewMaskingRule(config.Config{}).Run(ctx, test.InputBundle(bundle))
```

I am new to regal, so I am open for any suggestions :) 