### PR TITLE
feat: add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,17 @@
+- id: regal-lint
+  stages:
+    - pre-commit
+  language: golang
+  name: policy file linting
+  description: policy file linting with Regal from Styra built from source
+  entry: regal lint
+  files: (\.rego)$
+
+- id: regal-lint-use-path
+  stages:
+    - pre-commit
+  language: system
+  name: policy file linting
+  description: policy file linting with Regal from Styra using system $PATH
+  entry: regal lint
+  files: (\.rego)$

--- a/README.md
+++ b/README.md
@@ -281,6 +281,40 @@ Note that at this point in time, Regal only considers the line following the ign
 entire blocks of code (like rules, functions or even packages). See [configuration](#configuration) if you want to
 ignore certain rules altogether.
 
+## Using Regal with Pre-Commit
+
+[Pre-Commit](https://pre-commit.com) is a framework for managing and maintaining multi-language pre-commit hooks.
+
+To use Regal with pre-commit, add this to your `.pre-commit-config.yaml`
+
+```yaml
+- repo: https://github.com/StyraInc/regal
+  rev: v0.5.0 # Use the ref you want to point at
+  hooks:
+    - id: regal-lint
+  # -   id: ...
+```
+
+### Hooks Available
+
+#### `regal-lint`
+
+![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
+
+Runs Regal against all staged `.rego` files, aborting the commit if any fail.
+
+- requires the `go` build chain is installed and available on `$PATH`
+- will build and install the tagged version of Regal in an isolated `GOPATH`
+- ensures compatibility between versions
+
+#### `regal-lint-use-path`
+
+![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
+
+Runs Regal against all staged `.rego` files, aborting the commit if any fail.
+
+- requires the `regal` package is already installed and available on `$PATH`.
+
 ## Resources
 
 ### Documentation


### PR DESCRIPTION
Add a `.pre-commit-hooks.yaml` file so that `regal`, more specifically `regal lint` can be utilised as a pre-commit hook via the popular [pre-commit](https://pre-commit.com) project.

