### PR TITLE
Rule: non-raw-regex-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,19 +149,20 @@ The following rules are currently available:
 | bugs      | [unused-return-value](https://github.com/StyraInc/regal/blob/main/docs/rules/bugs/unused-return-value.md)                | Non-boolean return value unused                           |
 | idiomatic | [custom-has-key-construct](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/custom-has-key-construct.md) | Custom function may be replaced by `in` and `object.keys` |
 | idiomatic | [custom-in-construct](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/custom-in-construct.md)           | Custom function may be replaced by `in` keyword           |
+| idiomatic | [non-raw-regex-pattern](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/non-raw-regex-pattern.md)       | Use raw strings for regex patterns                        |
 | idiomatic | [use-in-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/use-in-operator.md)                   | Use in to check for membership                            |
-| imports   | [redundant-data-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-data-import.md)         | Redundant import of data                                  |
+| imports   | [avoid-importing-input](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/avoid-importing-input.md)         | Avoid importing input                                     |
 | imports   | [implicit-future-keywords](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/implicit-future-keywords.md)   | Use explicit future keyword imports                       |
 | imports   | [import-shadows-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/import-shadows-import.md)         | Import shadows another import                             |
 | imports   | [redundant-alias](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-alias.md)                     | Redundant alias                                           |
-| imports   | [avoid-importing-input](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/avoid-importing-input.md)         | Avoid importing input                                     |
-| style     | [prefer-snake-case](https://github.com/StyraInc/regal/blob/main/docs/rules/style/prefer-snake-case.md)                   | Prefer snake_case for names                               |
+| imports   | [redundant-data-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-data-import.md)         | Redundant import of data                                  |
+| style     | [avoid-get-and-list-prefix](https://github.com/StyraInc/regal/blob/main/docs/rules/style/avoid-get-and-list-prefix.md)   | Avoid get_ and list_ prefix for rules and functions       |
 | style     | [todo-comment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/todo-comment.md)                             | Avoid TODO comments                                       |
 | style     | [external-reference](https://github.com/StyraInc/regal/blob/main/docs/rules/style/external-reference.md)                 | Reference to input, data or rule ref in function body     |
 | style     | [function-arg-return](https://github.com/StyraInc/regal/blob/main/docs/rules/style/function-arg-return.md)               | Function argument used for return value                   |
 | style     | [line-length](https://github.com/StyraInc/regal/blob/main/docs/rules/style/line-length.md)                               | Line too long                                             |
 | style     | [no-whitespace-comment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/no-whitespace-comment.md)           | Comment should start with whitespace                      |
-| style     | [avoid-get-and-list-prefix](https://github.com/StyraInc/regal/blob/main/docs/rules/style/avoid-get-and-list-prefix.md)   | Avoid get_ and list_ prefix for rules and functions       |
+| style     | [prefer-snake-case](https://github.com/StyraInc/regal/blob/main/docs/rules/style/prefer-snake-case.md)                   | Prefer snake_case for names                               |
 | style     | [detached-metadata](https://github.com/StyraInc/regal/blob/main/docs/rules/style/detached-metadata.md)                   | Detached metadata annotation                              |
 | style     | [unconditional-assignment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/unconditional-assignment.md)     | Unconditional assignment in rule body                     |
 | style     | [use-assignment-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/style/use-assignment-operator.md)       | Prefer := over = for assignment                           |

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -19,6 +19,8 @@ rules:
       level: error
     custom-in-construct:
       level: error
+    non-raw-regex-pattern:
+      level: error
     use-in-operator:
       level: error
   imports:

--- a/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
@@ -1,0 +1,46 @@
+# METADATA
+# description: Use raw strings for regex patterns
+package regal.rules.idiomatic["non-raw-regex-pattern"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.result
+
+# Mapping of regex.* functions and the position(s)
+# of their "pattern" attributes
+re_pattern_functions := {
+	"find_all_string_submatch_n": [1],
+	"find_n": [1],
+	"globs_match": [1, 2],
+	"is_valid": [1],
+	"match": [1],
+	"replace": [2],
+	"split": [1],
+	"template_match": [1],
+}
+
+report contains violation if {
+	# regal ignore:unused-return-value,function-arg-return
+	walk(input.rules, [_, value])
+
+	value[0].type == "ref"
+	value[0].value[0].type == "var"
+	value[0].value[0].value == "regex"
+
+	# The name following "regex.", e.g. "match"
+	name := value[0].value[1].value
+
+	some pos in re_pattern_functions[name]
+
+	value[pos].type == "string"
+
+	loc := value[pos].location
+	row := input.regal.file.lines[loc.row - 1]
+	chr := substring(row, loc.col - 1, 1)
+
+	chr == `"`
+
+	violation := result.fail(rego.metadata.chain(), result.location(value[pos]))
+}

--- a/bundle/regal/rules/idiomatic/non_raw_regex_pattern_test.rego
+++ b/bundle/regal/rules/idiomatic/non_raw_regex_pattern_test.rego
@@ -1,0 +1,60 @@
+package regal.rules.idiomatic["non-raw-regex-pattern_test"]
+
+import future.keywords.if
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.idiomatic["non-raw-regex-pattern"] as rule
+
+test_fail_non_raw_rule_head if {
+	r := rule.report with input as ast.policy(`x := regex.match("[0-9]+", "1")`)
+	r == {{
+		"category": "idiomatic",
+		"description": "Use raw strings for regex patterns",
+		"level": "error",
+		"location": {"col": 18, "file": "policy.rego", "row": 3, "text": "x := regex.match(\"[0-9]+\", \"1\")"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/non-raw-regex-pattern.md",
+		}],
+		"title": "non-raw-regex-pattern",
+	}}
+}
+
+test_fail_non_raw_rule_body if {
+	r := rule.report with input as ast.policy(`allow {
+		regex.is_valid("[0-9]+")
+	}`)
+	r == {{
+		"category": "idiomatic",
+		"description": "Use raw strings for regex patterns",
+		"level": "error",
+		"location": {"col": 18, "file": "policy.rego", "row": 4, "text": "\t\tregex.is_valid(\"[0-9]+\")"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/non-raw-regex-pattern.md",
+		}],
+		"title": "non-raw-regex-pattern",
+	}}
+}
+
+test_fail_pattern_in_second_arg if {
+	r := rule.report with input as ast.policy(`r := regex.replace("a", "[a]", "b")`)
+	r == {{
+		"category": "idiomatic",
+		"description": "Use raw strings for regex patterns",
+		"level": "error",
+		"location": {"col": 25, "file": "policy.rego", "row": 3, "text": "r := regex.replace(\"a\", \"[a]\", \"b\")"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": "https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/non-raw-regex-pattern.md",
+		}],
+		"title": "non-raw-regex-pattern",
+	}}
+}
+
+test_success_when_using_raw_string if {
+	r := rule.report with input as ast.policy("v := regex.is_valid(`[0-9]+`)")
+	r == set()
+}

--- a/docs/rego-style-guide.md
+++ b/docs/rego-style-guide.md
@@ -62,7 +62,7 @@ determine whether the author has done, and both have valid use cases.
 Almost all of these should be doable, with some possibly being quite challenging.
 One that could be very hard to implement is the `every` rule, as that would
 require us to determine what **other** method was used and that `every` is a
-suitable replacement. With the exception of "Use `in` to check for membership",
+suitable replacement. Except for "Use `in` to check for membership",
 none of the above rules can be enforced using the AST alone.
 
 ## Functions
@@ -72,7 +72,7 @@ none of the above rules can be enforced using the AST alone.
 
 ## Regex
 
-- [ ] Use raw strings for regex patterns
+- [x] Use raw strings for regex patterns
 
 ### Notes
 Can only be done by scanning the original code, as this is lost in the AST.

--- a/docs/rules/idiomatic/non-raw-regex-pattern.md
+++ b/docs/rules/idiomatic/non-raw-regex-pattern.md
@@ -1,0 +1,60 @@
+# non-raw-regex-pattern
+
+**Summary**: Use raw strings for regex patterns
+
+**Category**: Idiomatic
+
+**Avoid**
+```rego
+all_digits if {
+    regex.match("[\\d]+", "12345")
+}
+```
+
+**Prefer**
+```rego
+all_digits if {
+    regex.match(`[\d]+`, "12345")
+}
+```
+
+## Rationale
+
+[Raw strings](https://www.openpolicyagent.org/docs/edge/policy-language/#strings) are interpreted literally, allowing
+you to avoid having to escape special characters like `\` in your regex patterns. Using raw strings for regex patterns
+additionally makes them easier to identify as such.
+
+## Limitations
+
+This rule currently only scans regex string literals in the place of the `pattern` argument of the various
+[regex built-in functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#regex). It will not **not**
+try to "resolve" patterns assigned to variables. The following example would as such not render a warning:
+
+```rego
+package policy
+
+import future.keywords.if
+
+# Pattern assigned to variable
+pattern := "[\\d]+"
+
+# This won't trigger a violation
+allow if regex.match(pattern, "12345")
+```
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  idiomatic:
+    non-raw-regex-pattern:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Rego Style Guide [Use raw strings for regex patterns](https://github.com/StyraInc/rego-style-guide#use-raw-strings-for-regex-patterns)
+- OPA docs: [Regex Functions Reference](https://www.openpolicyagent.org/docs/latest/policy-reference/#regex)

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -105,3 +105,5 @@ todo_test_bad {
 print_or_trace_call {
 	print("forbidden!")
 }
+
+non_raw_regex_pattern := regex.match("[0-9]", "1")


### PR DESCRIPTION
Following the Rego Style Guide, this rule ensures regex patterns are provided as raw strings in order to avoid having to escape things like `\` inside of the regex.

Fixes #222