### PR TITLE
Add self-downloading pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -15,3 +15,12 @@
   description: policy file linting with Regal from Styra using system $PATH
   entry: regal lint
   files: (\.rego)$
+
+- id: regal-download
+  stages:
+    - pre-commit
+  language: script
+  name: policy file linting
+  description: policy file linting with Regal downloaded from Github
+  entry: build/download-and-run.sh lint
+  files: (\.rego)$

--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ Runs Regal against all staged `.rego` files, aborting the commit if any fail.
 
 - requires the `regal` package is already installed and available on `$PATH`.
 
+#### `regal-download`
+
+![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
+
+Runs Regal against all staged `.rego` files, aborting the commit if any fail.
+
+- Downloads the latest `regal` binary from Github.
+
 ## Resources
 
 ### Documentation

--- a/build/download-and-run.sh
+++ b/build/download-and-run.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# pre-commit helper to run download latest release binary if missing before executing
+# linting with it.
+
+set -e
+
+REPO=StyraInc/regal
+BASE_URL=https://github.com/${REPO}
+
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+BIN_PATH="${SCRIPTPATH}/regal"
+
+download()
+{
+    DETECTED_SYSTEM=$(uname -s)
+    DETECTED_ARCHITECTURE=$(uname -m)
+
+    REGAL_VERSION=${REGAL_VERSION:-latest}
+    SYSTEM=${REGAL_SYSTEM:-${DETECTED_SYSTEM}}
+    ARCHITECTURE=${REGAL_ARCHITECTURE:-${DETECTED_ARCHITECTURE}}
+
+    echo "Downloading regal for ${SYSTEM} ${ARCHITECTURE}, ${REGAL_VERSION}…"
+    BINARY_URL=${BASE_URL}/releases/${REGAL_VERSION}/download/regal_${SYSTEM}_${ARCHITECTURE}
+    curl --fail -Lo "${BIN_PATH}" ${BINARY_URL}
+    chmod +x "${BIN_PATH}"
+}
+
+if [ ! -x "${BIN_PATH}" ]; then download; fi
+"${BIN_PATH}" $@


### PR DESCRIPTION
- Using a shell script, check if `regal` binary is not yet present in pre-commit repo clone and download right binary for system and architecture.
  - should work for Linux and MacOS, only tested on Linux atm.