### PR TITLE
Run GitHub Actions workflow only once

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
On PRs we receive both the `on.push` and `on.pull_request` events and triggering multiple events at the same time ends up in triggering workflow runs multiple times as noticed by @anderseknert. Thanks Anders!

Avoid using wildcard in push branches and only limit to known branch names only used outside PRs.

Fix #230.

Signed-off-by: Leonardo Taccari <leonardo@faire.ai>

---

For possible further references... If we give a look to <https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#using-multiple-events>, quoting interesting part directly here:

> If multiple triggering events for your workflow occur at the same time, multiple workflow runs will be triggered.

...and indeed if we look at the last PR merged, i.e. #228 we can see that the `build` was run once for `pull_request` event and once for `push` at the same time.

---

Discussed on `#regal` Slack channel too with Anders and Charlie.
