### PR TITLE
Add custom category and rule for naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Documentation:	https://github.com/StyraInc/regal/blob/main/docs/rules/style/use-
 Regal comes with a set of built-in rules, grouped by category.
 
 - **bugs**: Common mistakes, potential bugs and inefficiencies in Rego policies.
+- **custom**: Custom, rules where enforcement can be adjusted to match your preferences.
 - **idiomatic**: Suggestions for more idiomatic constructs.
 - **imports**: Best practices for imports.
 - **style**: [Rego Style Guide](https://github.com/StyraInc/rego-style-guide) rules.
@@ -147,22 +148,23 @@ The following rules are currently available:
 | bugs      | [rule-shadows-builtin](https://github.com/StyraInc/regal/blob/main/docs/rules/bugs/rule-shadows-builtin.md)              | Rule name shadows built-in                                |
 | bugs      | [top-level-iteration](https://github.com/StyraInc/regal/blob/main/docs/rules/bugs/top-level-iteration.md)                | Iteration in top-level assignment                         |
 | bugs      | [unused-return-value](https://github.com/StyraInc/regal/blob/main/docs/rules/bugs/unused-return-value.md)                | Non-boolean return value unused                           |
+| custom    | [naming-convention](https://github.com/StyraInc/regal/blob/main/docs/rules/custom/naming-convention.md)                  | Naming convention violation                               |
 | idiomatic | [custom-has-key-construct](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/custom-has-key-construct.md) | Custom function may be replaced by `in` and `object.keys` |
 | idiomatic | [custom-in-construct](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/custom-in-construct.md)           | Custom function may be replaced by `in` keyword           |
 | idiomatic | [non-raw-regex-pattern](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/non-raw-regex-pattern.md)       | Use raw strings for regex patterns                        |
 | idiomatic | [use-in-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/idiomatic/use-in-operator.md)                   | Use in to check for membership                            |
-| imports   | [avoid-importing-input](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/avoid-importing-input.md)         | Avoid importing input                                     |
+| imports   | [redundant-data-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-data-import.md)         | Redundant import of data                                  |
 | imports   | [implicit-future-keywords](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/implicit-future-keywords.md)   | Use explicit future keyword imports                       |
 | imports   | [import-shadows-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/import-shadows-import.md)         | Import shadows another import                             |
 | imports   | [redundant-alias](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-alias.md)                     | Redundant alias                                           |
-| imports   | [redundant-data-import](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/redundant-data-import.md)         | Redundant import of data                                  |
-| style     | [avoid-get-and-list-prefix](https://github.com/StyraInc/regal/blob/main/docs/rules/style/avoid-get-and-list-prefix.md)   | Avoid get_ and list_ prefix for rules and functions       |
+| imports   | [avoid-importing-input](https://github.com/StyraInc/regal/blob/main/docs/rules/imports/avoid-importing-input.md)         | Avoid importing input                                     |
+| style     | [prefer-snake-case](https://github.com/StyraInc/regal/blob/main/docs/rules/style/prefer-snake-case.md)                   | Prefer snake_case for names                               |
 | style     | [todo-comment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/todo-comment.md)                             | Avoid TODO comments                                       |
 | style     | [external-reference](https://github.com/StyraInc/regal/blob/main/docs/rules/style/external-reference.md)                 | Reference to input, data or rule ref in function body     |
 | style     | [function-arg-return](https://github.com/StyraInc/regal/blob/main/docs/rules/style/function-arg-return.md)               | Function argument used for return value                   |
 | style     | [line-length](https://github.com/StyraInc/regal/blob/main/docs/rules/style/line-length.md)                               | Line too long                                             |
 | style     | [no-whitespace-comment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/no-whitespace-comment.md)           | Comment should start with whitespace                      |
-| style     | [prefer-snake-case](https://github.com/StyraInc/regal/blob/main/docs/rules/style/prefer-snake-case.md)                   | Prefer snake_case for names                               |
+| style     | [avoid-get-and-list-prefix](https://github.com/StyraInc/regal/blob/main/docs/rules/style/avoid-get-and-list-prefix.md)   | Avoid get_ and list_ prefix for rules and functions       |
 | style     | [detached-metadata](https://github.com/StyraInc/regal/blob/main/docs/rules/style/detached-metadata.md)                   | Detached metadata annotation                              |
 | style     | [unconditional-assignment](https://github.com/StyraInc/regal/blob/main/docs/rules/style/unconditional-assignment.md)     | Unconditional assignment in rule body                     |
 | style     | [use-assignment-operator](https://github.com/StyraInc/regal/blob/main/docs/rules/style/use-assignment-operator.md)       | Prefer := over = for assignment                           |
@@ -175,11 +177,23 @@ The following rules are currently available:
 
 <!-- RULES_TABLE_END -->
 
-By default, all rules are currently **enabled**.
+By default, all rules except for those in the `custom` category are currently **enabled**.
 
 If you'd like to see more rules, please [open an issue](https://github.com/StyraInc/regal/issues) for your feature
 request, or better yet, submit a PR! See the [custom rules](/docs/custom-rules.md) page for more information on how to
 develop your own rules, for yourself or for inclusion in Regal.
+
+### Custom Rules
+
+The `custom` category is a special one, as the rules in this category allow you to enforce rules that are specific to
+your project, team or organization. This typically includes things like naming conventions, where you might want to
+ensure that, for example, all package names adhere to an organizational standard, like having a prefix matching the
+organization name.
+
+Since these rules require configuration provided by the user, they are disabled by default. In order to enable them,
+see the configuration options available for each rule for how to configure them according to your requirements.
+
+For more advanced requirements, see the guide on writing [custom rules](/docs/custom-rules.md) in Rego.
 
 ## Configuration
 
@@ -221,6 +235,15 @@ rules:
       ignore:
         files:
           - "*_test.rego"
+  custom:
+    # custom rule configuration
+    naming-convention:
+      level: error
+      conventions:
+        # ensure all package names start with "acmecorp" or "system"
+        - pattern: '^acmecorp\.[a-z_\.]+$|^system\.[a-z_\.]+$'
+          targets:
+            - package
 ```
 
 Regal will automatically search for a configuration file (`.regal/config.yaml`) in the current directory, and if not

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -23,6 +23,9 @@ rules:
       level: error
     use-in-operator:
       level: error
+  custom:
+    naming-convention:
+      level: ignore
   imports:
     avoid-importing-input:
       level: error

--- a/bundle/regal/rules/custom/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming_convention.rego
@@ -1,0 +1,104 @@
+# METADATA
+# description: Naming convention violation
+package regal.rules.custom["naming-convention"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+import data.regal.result
+
+cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
+
+# target: package
+report contains violation if {
+	some convention in cfg.conventions
+	some target in convention.targets
+
+	target == "package"
+
+	not regex.match(convention.pattern, ast.package_name)
+
+	violation := with_description(
+		result.fail(rego.metadata.chain(), result.location(input["package"])),
+		sprintf(
+			"Naming convention violation: package name %q does not match pattern %q",
+			[ast.package_name, convention.pattern],
+		),
+	)
+}
+
+# target: rule
+report contains violation if {
+	cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
+
+	some convention in cfg.conventions
+	some target in convention.targets
+
+	target == "rule"
+
+	some rule in input.rules
+
+	not rule.head.args
+	not regex.match(convention.pattern, rule.head.name)
+
+	violation := with_description(
+		result.fail(rego.metadata.chain(), result.location(rule.head)),
+		sprintf(
+			"Naming convention violation: rule name %q does not match pattern %q",
+			[rule.head.name, convention.pattern],
+		),
+	)
+}
+
+# target: function
+report contains violation if {
+	cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
+
+	some convention in cfg.conventions
+	some target in convention.targets
+
+	target == "function"
+
+	some rule in input.rules
+
+	rule.head.args
+	not regex.match(convention.pattern, rule.head.name)
+
+	violation := with_description(
+		result.fail(rego.metadata.chain(), result.location(rule.head)),
+		sprintf(
+			"Naming convention violation: function name %q does not match pattern %q",
+			[rule.head.name, convention.pattern],
+		),
+	)
+}
+
+# target: var
+report contains violation if {
+	cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
+
+	some convention in cfg.conventions
+	some target in convention.targets
+
+	target in {"var", "variable"}
+
+	some var in ast.find_vars(input.rules)
+
+	not regex.match(convention.pattern, var.value)
+
+	violation := with_description(
+		result.fail(rego.metadata.chain(), result.location(var)),
+		sprintf(
+			"Naming convention violation: variable name %q does not match pattern %q",
+			[var.value, convention.pattern],
+		),
+	)
+}
+
+with_description(violation, description) := json.patch(
+	violation,
+	[{"op": "replace", "path": "/description", "value": description}],
+)

--- a/bundle/regal/rules/custom/naming_convention_test.rego
+++ b/bundle/regal/rules/custom/naming_convention_test.rego
@@ -1,0 +1,189 @@
+package regal.rules.custom["naming-convention_test"]
+
+import future.keywords.if
+
+import data.regal.ast
+import data.regal.config
+import data.regal.rules.custom["naming-convention"] as rule
+
+test_fail_package_name_does_not_match_pattern if {
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["package"], "pattern": `^foo\.bar\..+$`}],
+	}
+	r := rule.report with input as regal.parse_module("policy.rego", "package foo.bar") with config.for_rule as cfg
+	r == {{
+		"category": "custom",
+		# regal ignore:line-length
+		"description": "Naming convention violation: package name \"foo.bar\" does not match pattern \"^foo\\\\.bar\\\\..+$\"",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+		}],
+		"title": "naming-convention",
+	}}
+}
+
+test_success_package_name_matches_pattern if {
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["package"], "pattern": `^foo\.bar$`}],
+	}
+	r := rule.report with input as regal.parse_module("policy.rego", "package foo.bar") with config.for_rule as cfg
+	r == set()
+}
+
+test_fail_rule_name_does_not_match_pattern if {
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["rule"], "pattern": "^[a-z]+$"}],
+	}
+	r := rule.report with input as ast.policy(`FOO := true`) with config.for_rule as cfg
+	r == {{
+		"category": "custom",
+		"description": "Naming convention violation: rule name \"FOO\" does not match pattern \"^[a-z]+$\"",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "FOO := true"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+		}],
+		"title": "naming-convention",
+	}}
+}
+
+test_success_rule_name_matches_pattern if {
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["rule"], "pattern": "^[a-z]+$"}],
+	}
+	r := rule.report with input as ast.policy(`foo := true`) with config.for_rule as cfg
+	r == set()
+}
+
+test_fail_function_name_does_not_match_pattern if {
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["function"], "pattern": "^[a-z]+$"}],
+	}
+	r := rule.report with input as ast.policy(`fooBar(_) := true`) with config.for_rule as cfg
+	r == {{
+		"category": "custom",
+		"description": "Naming convention violation: function name \"fooBar\" does not match pattern \"^[a-z]+$\"",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "fooBar(_) := true"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+		}],
+		"title": "naming-convention",
+	}}
+}
+
+test_success_function_name_matches_pattern if {
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["function"], "pattern": "^[a-z_]+$"}],
+	}
+	r := rule.report with input as ast.policy(`foo_bar(_) := true`) with config.for_rule as cfg
+	r == set()
+}
+
+test_fail_var_name_does_not_match_pattern if {
+	policy := ast.policy(`
+	allow {
+		fooBar := true
+		fooBar == true
+	}
+	`)
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["variable"], "pattern": "^[a-z_]+$"}],
+	}
+	r := rule.report with input as policy with config.for_rule as cfg
+	r == {{
+		"category": "custom",
+		"description": "Naming convention violation: variable name \"fooBar\" does not match pattern \"^[a-z_]+$\"",
+		"level": "error",
+		"location": {"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tfooBar := true"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+		}],
+		"title": "naming-convention",
+	}}
+}
+
+test_success_var_name_matches_pattern if {
+	policy := ast.policy(`
+	allow {
+		some foo_bar
+		input[foo_bar]
+		foo_bar == "works"
+	}
+	`)
+	cfg := {
+		"level": "error",
+		"conventions": [{"targets": ["variable"], "pattern": "^[a-z_]+$"}],
+	}
+	r := rule.report with input as policy with config.for_rule as cfg
+	r == set()
+}
+
+test_fail_multiple_conventions if {
+	policy := regal.parse_module("policy.rego", `package foo.bar
+
+	foo := true
+
+	bar {
+		fooBar := true
+		fooBar == true
+	}
+	`)
+	cfg := {
+		"level": "error",
+		"conventions": [
+			{"targets": ["package"], "pattern": `^acmecorp\.[a-z_\.]+$`},
+			{"targets": ["rule", "variable"], "pattern": "^bar$|^foo_bar$"},
+		],
+	}
+	r := rule.report with input as policy with config.for_rule as cfg
+	r == {
+		{
+			"category": "custom",
+			# regal ignore:line-length
+			"description": "Naming convention violation: package name \"foo.bar\" does not match pattern \"^acmecorp\\\\.[a-z_\\\\.]+$\"",
+			"level": "error",
+			"location": {"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
+			"related_resources": [{
+				"description": "documentation",
+				"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+			}],
+			"title": "naming-convention",
+		},
+		{
+			"category": "custom",
+			"description": "Naming convention violation: rule name \"foo\" does not match pattern \"^bar$|^foo_bar$\"",
+			"level": "error",
+			"location": {"col": 2, "file": "policy.rego", "row": 3, "text": "\tfoo := true"},
+			"related_resources": [{
+				"description": "documentation",
+				"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+			}],
+			"title": "naming-convention",
+		},
+		{
+			"category": "custom",
+			"description": "Naming convention violation: variable name \"fooBar\" does not match pattern \"^bar$|^foo_bar$\"",
+			"level": "error",
+			"location": {"col": 3, "file": "policy.rego", "row": 6, "text": "\t\tfooBar := true"},
+			"related_resources": [{
+				"description": "documentation",
+				"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+			}],
+			"title": "naming-convention",
+		},
+	}
+}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -238,7 +238,11 @@ func lint(args []string, params lintCommandParams) (report.Report, error) {
 
 		configData := make(map[string]any)
 		if err := yaml.NewDecoder(userConfig).Decode(&configData); err != nil {
-			return report.Report{}, fmt.Errorf("failed to decode user config from %s: %w", regalDir.Name(), err)
+			if regalDir != nil {
+				return report.Report{}, fmt.Errorf("failed to decode user config from %s: %w", regalDir.Name(), err)
+			}
+
+			return report.Report{}, fmt.Errorf("failed to decode user config: %w", err)
 		}
 
 		regal = regal.WithUserConfig(configData)

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -1,10 +1,18 @@
 # Custom Rules
 
-Regal is built to be easily extended. Creating custom rules is a great way to enforce naming conventions, best practices
-or more opinionated rules across teams and organizations. If you'd like to provide your own linter rules for a project,
-you may do so by placing them in a `rules` directory inside the `.regal` directory preferably placed in the root of your
-project (which is also where custom configuration resides). The directory structure of a policy repository with custom
-linter rules might then look something like this:
+Regal is built to be easily extended. Using custom rules is a great way to enforce naming conventions, best practices
+or more opinionated rules across teams and organizations.
+
+There are two types of custom rules to be aware of — those that are included with Regal in the `custom` category, and
+those that you write yourself. The rules in the `custom` category provide a way to enforce common organizational
+requirements, like naming conventions, by means of _configuration_ rather than code. If your requirements aren't
+fulfilled by the rules in this category, your other option is to write your own custom rules using Rego.
+
+## Your Own Custom Rules
+
+If you'd like to provide your own linter rules for a project, you may do so by placing them in a `rules` directory
+inside the `.regal` directory preferably placed in the root of your project (which is also where custom configuration
+resides). The directory structure of a policy repository with custom linter rules might then look something like this:
 
 ```text
 .
@@ -152,7 +160,7 @@ Starting from top to bottom, these are the components comprising our custom rule
    starts with `acme.corp`, and another rule (`system_log_package`) to know if it starts with `system.log`. If neither
    of the conditions are true, the rule fails and violation is created.
 1. The violation is created by calling `result.fail`, which takes the metadata from the package (using
-   `rego.metadata.chain` which conveniently also includes the path of the package) and returns a result, which 
+   `rego.metadata.chain` which conveniently also includes the path of the package) and returns a result, which
    will later be included in the final report provided by Regal.
 1. The `result.location` helps extract the location from the element failing the test. Make sure to use it!
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,8 +16,6 @@ for testing it. The code here will be a pretty simple template, but contains all
 rule. A good idea for learning more about what's needed is to take a look at some previous PRs adding new rules to
 Regal.
 
-```text
-
 ## Building
 
 1. Run the `build.sh` script to populate the `data` directory with any data necessary for linting (such as the built-in

--- a/docs/rules/custom/naming-convention.md
+++ b/docs/rules/custom/naming-convention.md
@@ -1,0 +1,57 @@
+# naming-convention
+
+**Summary**: Naming convention violation
+
+**Category**: Custom
+
+## Description
+
+This custom rule allows teams and organizations to define their own naming conventions for their Rego projects, without
+having to write custom linter policies. Naming conventions are simply defined in the Regal configuration file using
+regex patterns.
+
+Regal can enforce naming conventions for:
+
+- Package names
+- Rule names
+- Function names
+- Variable names
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  custom:
+    naming-convention:
+      # note that all rules in the "custom" category are disabled by default
+      # (i.e. level "ignore") as some configuration needs to be provided by
+      # the user (i.e. you!) in order for them to be useful.
+      #
+      # one of "error", "warning", "ignore"
+      level: error
+      conventions:
+          # allow only "private" rules and functions, i.e. those starting with
+          # underscore, or rules named "deny" or "allow"
+        - pattern: '^_[a-z]+$|^deny$|^allow$'
+          # one of "package", "rule", "function", "variable"
+          targets:
+            - rule
+            - function
+        # any number of naming rules may be added
+        # package names must start with "acmecorp" or "system"
+        - pattern: '^acmecorp|^system'
+          targets:
+            - package
+```
+
+**Note:** In order to avoid characters accidentally getting escaped, always use single quotes to encode your regex
+patterns. Additionally, you'll most often want to include anchors for the start and end of the string (`^` and `$`) in
+your patterns, or else your pattern might accidentally match only parts of the name rather than the whole name.
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/configs/custom_naming_convention.yaml
+++ b/e2e/testdata/configs/custom_naming_convention.yaml
@@ -1,0 +1,11 @@
+rules:
+  custom:
+    naming-convention:
+      level: error
+      conventions:
+        - pattern: '^_[a-z_]+$|^allow$'
+          targets:
+            - rule
+        - pattern: '^acmecorp\.[a-z_\.]+$'
+          targets:
+            - package

--- a/e2e/testdata/custom_naming_convention/policy.rego
+++ b/e2e/testdata/custom_naming_convention/policy.rego
@@ -1,0 +1,11 @@
+# package name must start with "acmecorp"
+package this.fails
+
+# rules must either start with "_" or be named "allow"
+naming_convention_fail {
+	input.foo == "bar"
+}
+
+_this_is_ok := true
+
+allow := true


### PR DESCRIPTION
This should hopefully help people satisfy the most common organizational requirements without having to write their own rules. First off is the naming-convention rule, with more to follow later.

Fixes #19