### PR TITLE
Add .gitattributes for proper language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.rego.tpl linguist-language=rego


### PR DESCRIPTION
Fixing the issue where *.rego.tpl was identified as "Smarty".