### PR TITLE
Remove build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-
-build/fetch_data.sh "$SCRIPT_DIR/bundle/regal/opa/builtins/data.json"

--- a/build/fetch_builtin_data.sh
+++ b/build/fetch_builtin_data.sh
@@ -4,4 +4,4 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
 
 result=$(opa eval --format pretty --data "$SCRIPT_DIR/builtin_metadata.rego" 'data.build.metadata.builtin_metadata')
 
-echo "${result}" > "$1"
+echo "${result}" > "$SCRIPT_DIR/../bundle/regal/opa/builtins/data.json"

--- a/bundle/regal/opa/builtins/data.json
+++ b/bundle/regal/opa/builtins/data.json
@@ -519,6 +519,20 @@
       "type": "string"
     }
   },
+  "crypto.parse_private_keys": {
+    "args": [
+      {
+        "description": "PEM encoded data containing one or more private keys as concatenated blocks. Optionally Base64 encoded.",
+        "name": "keys",
+        "type": "string"
+      }
+    ],
+    "result": {
+      "description": "parsed private keys represented as objects",
+      "name": "output",
+      "type": "array[object[string: any]]"
+    }
+  },
   "crypto.sha1": {
     "args": [
       {
@@ -2609,7 +2623,7 @@
   "time.format": {
     "args": [
       {
-        "description": "a number representing the nanoseconds since the epoch (UTC); or a two-element array of the nanoseconds, and a timezone string; or a three-element array of ns, timezone string and a layout string (see golang supported time formats)",
+        "description": "a number representing the nanoseconds since the epoch (UTC); or a two-element array of the nanoseconds, and a timezone string; or a three-element array of ns, timezone string and a layout string or golang defined formatting constant (see golang supported time formats)",
         "name": "x",
         "type": "any\u003cnumber, array\u003cnumber, string\u003e, array\u003cnumber, string, string\u003e\u003e"
       }


### PR DESCRIPTION
This was just calling another script, so rather redundant.

Rename `fetch_data.sh` -> `fetch_builtin_data.sh` as that better describes what the script does.

Actually run the script to update the built-in data available in Regal policy.