### PR TITLE
Rule: use-some-for-output-vars

### DIFF
--- a/bundle/regal/config/exclusion.rego
+++ b/bundle/regal/config/exclusion.rego
@@ -37,7 +37,12 @@ pattern_compiler(pattern) := ps1 if {
 	p := internal_slashes(pattern)
 	p1 := leading_slash(p)
 	ps := leading_doublestar_pattern(p1)
-	ps1 := {pat | some _p; ps[_p]; nps := trailing_slash(_p); nps[pat]}
+	ps1 := {pat |
+		some _p
+		ps[_p]
+		nps := trailing_slash(_p)
+		nps[pat]
+	}
 }
 
 # Internal slashes means that the path is relative to root,

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -23,6 +23,8 @@ rules:
       level: error
     use-in-operator:
       level: error
+    use-some-for-output-vars:
+      level: error
   custom:
     naming-convention:
       level: ignore

--- a/bundle/regal/rules/idiomatic/use_some_for_output_vars.rego
+++ b/bundle/regal/rules/idiomatic/use_some_for_output_vars.rego
@@ -1,0 +1,32 @@
+# METADATA
+# description: Use `some` to declare output variables
+package regal.rules.idiomatic["use-some-for-output-vars"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.result
+
+report contains violation if {
+	some rule in input.rules
+
+	# regal ignore:unused-return-value,function-arg-return
+	walk(rule, [_, value])
+
+	value.type == "ref"
+	ref := value.value
+
+	some i, elem in ref
+
+	# first item can't be a loop or key ref
+	i != 0
+	elem.type == "var"
+	not startswith(elem.value, "$")
+
+	scope := ast.find_names_in_scope(rule, elem.location)
+	not elem.value in scope
+
+	violation := result.fail(rego.metadata.chain(), result.location(elem))
+}

--- a/bundle/regal/rules/idiomatic/use_some_for_output_vars_test.rego
+++ b/bundle/regal/rules/idiomatic/use_some_for_output_vars_test.rego
@@ -1,0 +1,119 @@
+package regal.rules.idiomatic["use-some-for-output-vars_test"]
+
+import future.keywords.if
+
+import data.regal.ast
+import data.regal.config
+import data.regal.rules.idiomatic["use-some-for-output-vars"] as rule
+
+test_fail_output_var_not_declared if {
+	r := rule.report with input as ast.policy(`allow {
+		"admin" == input.user.roles[i]
+	}`)
+	r == {{
+		"category": "idiomatic",
+		"description": "Use `some` to declare output variables",
+		"level": "error",
+		"location": {"col": 31, "file": "policy.rego", "row": 4, "text": "\t\t\"admin\" == input.user.roles[i]"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+		}],
+		"title": "use-some-for-output-vars",
+	}}
+}
+
+test_fail_multiple_output_vars_not_declared if {
+	r := rule.report with input as ast.policy(`allow {
+		foo := input.foo[i].bar[j]
+	}`)
+	r == {
+		{
+			"category": "idiomatic",
+			"description": "Use `some` to declare output variables",
+			"level": "error",
+			"location": {"col": 20, "file": "policy.rego", "row": 4, "text": "\t\tfoo := input.foo[i].bar[j]"},
+			"related_resources": [{
+				"description": "documentation",
+				"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+			}],
+			"title": "use-some-for-output-vars",
+		},
+		{
+			"category": "idiomatic",
+			"description": "Use `some` to declare output variables",
+			"level": "error",
+			"location": {"col": 27, "file": "policy.rego", "row": 4, "text": "\t\tfoo := input.foo[i].bar[j]"},
+			"related_resources": [{
+				"description": "documentation",
+				"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+			}],
+			"title": "use-some-for-output-vars",
+		},
+	}
+}
+
+test_fail_only_one_declared if {
+	r := rule.report with input as ast.policy(`allow {
+		some i
+		foo := input.foo[i].bar[j]
+	}`)
+
+	r == {{
+		"category": "idiomatic",
+		"description": "Use `some` to declare output variables",
+		"level": "error",
+		"location": {"col": 27, "file": "policy.rego", "row": 5, "text": "\t\tfoo := input.foo[i].bar[j]"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-some-for-output-vars", "idiomatic"),
+		}],
+		"title": "use-some-for-output-vars",
+	}}
+}
+
+test_success_uses_some if {
+	r := rule.report with input as ast.policy(`allow {
+		some i
+		"admin" == input.user.roles[i]
+	}`)
+	r == set()
+}
+
+test_success_some_iteration if {
+	rule.report with input as ast.with_future_keywords(`allow {
+		some i in input
+		foo[i]
+	}`) == set()
+
+	rule.report with input as ast.with_future_keywords(`allow {
+		some i, x in input
+		input.user.roles[i]
+	}`) == set()
+
+	rule.report with input as ast.with_future_keywords(`allow {
+		some x, i in input
+		input.user.roles[i]
+	}`) == set()
+
+	rule.report with input as ast.with_future_keywords(`allow {
+		some x, i in input
+		input.user.roles[x][i]
+	}`) == set()
+
+	rule.report with input as ast.with_future_keywords(`allow {
+		some i in input
+		input.user.roles[_]
+	}`) == set()
+}
+
+test_success_not_an_output_var if {
+	r := rule.report with input as ast.policy(`
+		i := 0
+
+		allow {
+			# i now an *input* var
+			"admin" == input.user.roles[i]
+		}`)
+	r == set()
+}

--- a/docs/rules/idiomatic/non-raw-regex-pattern.md
+++ b/docs/rules/idiomatic/non-raw-regex-pattern.md
@@ -58,3 +58,9 @@ rules:
 
 - Rego Style Guide [Use raw strings for regex patterns](https://github.com/StyraInc/rego-style-guide#use-raw-strings-for-regex-patterns)
 - OPA docs: [Regex Functions Reference](https://www.openpolicyagent.org/docs/latest/policy-reference/#regex)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/docs/rules/idiomatic/use-some-for-output-vars.md
+++ b/docs/rules/idiomatic/use-some-for-output-vars.md
@@ -1,0 +1,102 @@
+# use-some-for-output-vars
+
+**Summary**: Use `some` to declare output variables
+
+**Category**: Idiomatic
+
+**Avoid**
+```rego
+package policy
+
+allow {
+    userinfo := data.users[id]
+    # ...
+}
+```
+
+**Prefer**
+```rego
+allow {
+    some id
+    userinfo := data.users[id]
+    # ...
+}
+
+# alternatively, and arguably more idiomatic:
+allow {
+    some id, userinfo in data.users
+    # ...
+}
+```
+
+## Rationale
+
+An interesting, and likely unfamiliar aspect of Rego for developers coming from other languages, is the concept of
+[unification](https://en.wikipedia.org/wiki/Unification_(computer_science)). Unification happens not just explicitly via
+the unification operator (`=`), but is an integral part of Rego. In the context of this rule, unification means that a
+variable can either be an _input_ or an _output_. What does that mean?
+
+From the example above, consider that `data.users` is a map of user IDs to user objects:
+
+```json
+{
+  "jane": {"email": "jane@acmecorp.com", "firstname": "Jane", "lastname": "Doe"},
+  "joe": {"email": "joe@example.com", "firstname": "Joe", "lastname": "Bloggs"},
+  "john": {"email": "john@opa.org", "firstname": "John", "lastname": "Smith"}
+}
+```
+
+```rego
+usernames contains name if {
+    data.users[name]
+}
+```
+
+What is the meaning of `name` in the body of the `usernames` rule? In most programming languages, evaluation would
+fail unless `name` was defined elsewhere in the code. That is because `name` would be expected to be an **input** in the
+expression — the result of using, say "joe", as the input in `users["joe"]` would predictably be the value associated
+with that key. In Rego, however, `name` may also be an **output** — meaning that if the variable is not defined
+elsewhere, OPA will attempt to _unify_ it with any value that satisfies the expression. In this case, that means that
+`name` will be bound to each of the keys in the `users` object in turn, and the rule will succeed for each of them.
+
+This is a powerful feature of Rego, but it can also be a source of confusion. If we were to defined `name` somewhere
+else in the policy, perhaps by mistake:
+
+```rego
+name := "joe"
+
+# hundreds of lines of Rego later..
+
+usernames contains name if {
+    data.users[name]
+}
+```
+
+Our `usernames` rule would no longer iterate over all the users, as the condition would be satisfied by simply mapping
+the key "joe" to its value. By using `some` to locally declare `name`, we can avoid this problem:
+
+```rego
+name := "joe"
+
+# hundreds of lines of Rego later..
+
+usernames contains name if {
+    some name
+    data.users[name]
+}
+```
+
+Even though `name` is defined in the global scope, the `some` keyword will ensure it's now considered as an output
+variable in the local scope of the `usernames` rule.
+
+## Related Resources
+
+- Rego Style Guide [Don't use undeclared variables](https://github.com/StyraInc/rego-style-guide#dont-use-undeclared-variables)
+- OPA docs: [The `some` keyword](https://www.openpolicyagent.org/docs/latest/policy-language/#some-keyword)
+- Wikipedia [Unification](https://en.wikipedia.org/wiki/Unification_(computer_science))
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -107,3 +107,7 @@ print_or_trace_call {
 }
 
 non_raw_regex_pattern := regex.match("[0-9]", "1")
+
+use_some_for_output_vars {
+	input.foo[output_var]
+}


### PR DESCRIPTION
This commit adds AST functions to find vars in scope of a location, which means scanning "up" in the scope for e.g. rules or other vars to check if they are present. This allows us to see if a possible "output var" is defined using some, or if it is an "input" var that's assigned elsewhere in the policy.

Fixes #250 