### PR TITLE
Rule: prefer-some-in-iteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,15 @@ The following rules are currently available:
 | imports   | [avoid-importing-input](https://docs.styra.com/regal/rules/imports/avoid-importing-input)         | Avoid importing input                                     |
 | imports   | [redundant-data-import](https://docs.styra.com/regal/rules/imports/redundant-data-import)         | Redundant import of data                                  |
 | style     | [prefer-snake-case](https://docs.styra.com/regal/rules/style/prefer-snake-case)                   | Prefer snake_case for names                               |
-| style     | [todo-comment](https://docs.styra.com/regal/rules/style/todo-comment)                             | Avoid TODO comments                                       |
+| style     | [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)     | Unconditional assignment in rule body                     |
 | style     | [external-reference](https://docs.styra.com/regal/rules/style/external-reference)                 | Reference to input, data or rule ref in function body     |
 | style     | [function-arg-return](https://docs.styra.com/regal/rules/style/function-arg-return)               | Function argument used for return value                   |
 | style     | [line-length](https://docs.styra.com/regal/rules/style/line-length)                               | Line too long                                             |
 | style     | [no-whitespace-comment](https://docs.styra.com/regal/rules/style/no-whitespace-comment)           | Comment should start with whitespace                      |
 | style     | [avoid-get-and-list-prefix](https://docs.styra.com/regal/rules/style/avoid-get-and-list-prefix)   | Avoid get_ and list_ prefix for rules and functions       |
+| style     | [prefer-some-in-iteration](https://docs.styra.com/regal/rules/style/prefer-some-in-iteration)     | Prefer `some .. in` for iteration                         |
+| style     | [todo-comment](https://docs.styra.com/regal/rules/style/todo-comment)                             | Avoid TODO comments                                       |
 | style     | [detached-metadata](https://docs.styra.com/regal/rules/style/detached-metadata)                   | Detached metadata annotation                              |
-| style     | [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)     | Unconditional assignment in rule body                     |
 | style     | [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)       | Prefer := over = for assignment                           |
 | style     | [opa-fmt](https://docs.styra.com/regal/rules/style/opa-fmt)                                       | File should be formatted with `opa fmt`                   |
 | testing   | [identically-named-tests](https://docs.styra.com/regal/rules/testing/identically-named-tests)     | Multiple tests with same name                             |

--- a/bundle/regal/config/exclusion.rego
+++ b/bundle/regal/config/exclusion.rego
@@ -38,8 +38,7 @@ pattern_compiler(pattern) := ps1 if {
 	p1 := leading_slash(p)
 	ps := leading_doublestar_pattern(p1)
 	ps1 := {pat |
-		some _p
-		ps[_p]
+		some _p, _ in ps
 		nps := trailing_slash(_p)
 		nps[pat]
 	}

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -57,6 +57,9 @@ rules:
       level: error
     prefer-snake-case:
       level: error
+    prefer-some-in-iteration:
+      level: error
+      ignore-nesting-level: 2
     todo-comment:
       level: error
     unconditional-assignment:

--- a/bundle/regal/rules/bugs/not_equals_in_loop.rego
+++ b/bundle/regal/rules/bugs/not_equals_in_loop.rego
@@ -19,9 +19,9 @@ report contains violation if {
 	some neq_term in array.slice(expr.terms, 1, count(expr.terms))
 	neq_term.type == "ref"
 
-	some i
-	neq_term.value[i].type == "var"
-	startswith(neq_term.value[i].value, "$")
+	some value in neq_term.value
+	value.type == "var"
+	startswith(value.value, "$")
 
 	violation := result.fail(rego.metadata.chain(), result.location(expr.terms[0]))
 }

--- a/bundle/regal/rules/bugs/top_level_iteration.rego
+++ b/bundle/regal/rules/bugs/top_level_iteration.rego
@@ -21,7 +21,7 @@ report contains violation if {
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }
 
-_rule_names := {name | name := input.rules[_].head.name}
+_rule_names := {rule.head.name | some rule in input.rules}
 
 # regal ignore:external-reference
 illegal_value_ref(value) if not value in _rule_names

--- a/bundle/regal/rules/custom/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming_convention.rego
@@ -32,8 +32,6 @@ report contains violation if {
 
 # target: rule
 report contains violation if {
-	cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
-
 	some convention in cfg.conventions
 	some target in convention.targets
 
@@ -55,8 +53,6 @@ report contains violation if {
 
 # target: function
 report contains violation if {
-	cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
-
 	some convention in cfg.conventions
 	some target in convention.targets
 
@@ -78,8 +74,6 @@ report contains violation if {
 
 # target: var
 report contains violation if {
-	cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
-
 	some convention in cfg.conventions
 	some target in convention.targets
 

--- a/bundle/regal/rules/style/prefer_snake_case_test.rego
+++ b/bundle/regal/rules/style/prefer_snake_case_test.rego
@@ -31,10 +31,10 @@ test_success_snake_cased_rule_name if {
 }
 
 test_fail_camel_cased_some_declaration if {
-	r := rule.report with input as ast.policy(`p {some fooBar; input[fooBar]}`)
+	r := rule.report with input as ast.policy(`p {some fooBar; input[_]}`)
 	r == {object.union(
 		snake_case_violation,
-		{"location": {"col": 9, "file": "policy.rego", "row": 3, "text": `p {some fooBar; input[fooBar]}`}},
+		{"location": {"col": 9, "file": "policy.rego", "row": 3, "text": `p {some fooBar; input[_]}`}},
 	)}
 }
 
@@ -45,13 +45,13 @@ test_success_snake_cased_some_declaration if {
 
 test_fail_camel_cased_multiple_some_declaration if {
 	r := rule.report with input as ast.with_future_keywords(`p {
-		some x, foo_bar, fooBar; x = 1; foo_bar = 2; input[fooBar]
+		some x, foo_bar, fooBar; x = 1; foo_bar = 2; input[_]
 	}`)
 	r == {object.union(
 		snake_case_violation,
 		{"location": {
 			"col": 20, "file": "policy.rego", "row": 9,
-			"text": "\t\tsome x, foo_bar, fooBar; x = 1; foo_bar = 2; input[fooBar]",
+			"text": "\t\tsome x, foo_bar, fooBar; x = 1; foo_bar = 2; input[_]",
 		}},
 	)}
 }

--- a/bundle/regal/rules/style/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer_some_in_iteration.rego
@@ -1,0 +1,47 @@
+# METADATA
+# description: Prefer `some .. in` for iteration
+package regal.rules.style["prefer-some-in-iteration"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+import data.regal.result
+
+cfg := config.for_rule({"custom": {"category": "style"}, "title": "prefer-some-in-iteration"})
+
+report contains violation if {
+	some rule in input.rules
+
+	node := filter_top_level_ref(rule)
+
+	# regal ignore:function-arg-return,unused-return-value
+	walk(node, [_, value])
+
+	value.type == "ref"
+
+	vars_in_ref := ast.find_ref_vars(value)
+
+	count(vars_in_ref) > 0
+
+	num_output_vars := count([var |
+		some var in vars_in_ref
+
+		# we don't need the location of each var, but using the first
+		# ref will do, and will hopefully help with caching the result
+		ast.is_output_var(rule, var, value.location)
+	])
+
+	num_output_vars != 0
+	num_output_vars < cfg["ignore-nesting-level"]
+
+	violation := result.fail(rego.metadata.chain(), result.location(value))
+}
+
+# don't walk top level iteration refs:
+# https://docs.styra.com/regal/rules/bugs/top-level-iteration
+filter_top_level_ref(rule) := rule.body if {
+	rule.head.value.type == "ref"
+} else := rule

--- a/bundle/regal/rules/style/prefer_some_in_iteration_test.rego
+++ b/bundle/regal/rules/style/prefer_some_in_iteration_test.rego
@@ -1,0 +1,136 @@
+package regal.rules.style["prefer-some-in-iteration_test"]
+
+import future.keywords.if
+
+import data.regal.ast
+import data.regal.config
+import data.regal.rules.style["prefer-some-in-iteration"] as rule
+
+test_fail_simple_iteration if {
+	policy := ast.policy(`allow {
+		input.foo[_] == "bar"
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == with_location({"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tinput.foo[_] == \"bar\""})
+}
+
+test_fail_simple_iteration_output_var if {
+	policy := ast.policy(`allow {
+		input.foo[x] == 1
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == with_location({"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tinput.foo[x] == 1"})
+}
+
+test_fail_simple_iteration_output_var_some_decl if {
+	policy := ast.policy(`allow {
+		some x
+		input.foo[x] == 1
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tinput.foo[x] == 1"})
+}
+
+test_success_some_in_var_input if {
+	policy := ast.with_future_keywords(`allow {
+		some x in input
+		input.foo[x] == 1
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == set()
+}
+
+test_success_allow_nesting_zero if {
+	policy := ast.policy(`allow {
+		input.foo[_] == 1
+		input.foo[_].bar[_] == 2
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(0) with input as policy
+	r == set()
+}
+
+test_success_allow_nesting_one if {
+	policy := ast.policy(`allow {
+		input.foo[_] == 2
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(1) with input as policy
+	r == set()
+}
+
+test_success_allow_nesting_two if {
+	policy := ast.policy(`allow {
+		input.foo[_].bar[_] == 2
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == set()
+}
+
+test_fail_allow_nesting_two if {
+	policy := ast.policy(`allow {
+		input.foo[_] == 2
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == with_location({"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tinput.foo[_] == 2"})
+}
+
+test_success_not_output_vars if {
+	policy := ast.policy(`
+	x := 5
+
+	allow {
+		y := 10
+		input.foo[x].bar[y] == 2
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == set()
+}
+
+test_success_output_var_to_input_var if {
+	policy := ast.policy(`allow {
+		# x is an output var here
+		# iteration allowed as nesting level == 2
+		input.foo[x].bar[_]
+		# x is an input var here
+		# iteration not allowed, but this is not iteration
+		input.bar[x]
+	}`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == set()
+}
+
+test_success_complex_comprehension_term if {
+	policy := ast.policy(`
+
+	foo := [{"foo": bar} | input[bar]]
+	`)
+
+	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
+	r == set()
+}
+
+allow_nesting(i) := {
+	"level": "error",
+	"ignore-nesting-level": i,
+}
+
+with_location(location) := {{
+	"category": "style",
+	"description": "Prefer `some .. in` for iteration",
+	"level": "error",
+	"location": location,
+	"related_resources": [{
+		"description": "documentation",
+		"ref": config.docs.resolve_url("$baseUrl/$category/prefer-some-in-iteration", "style"),
+	}],
+	"title": "prefer-some-in-iteration",
+}}

--- a/docs/rego-style-guide.md
+++ b/docs/rego-style-guide.md
@@ -52,7 +52,7 @@ determine whether the author has done, and both have valid use cases.
 ## Variables and Data Types
 
 - [x] Use `in` to check for membership
-- [ ] Prefer some .. in for iteration
+- [x] Prefer some .. in for iteration
 - [ ] Use every to express FOR ALL
 - [ ] Don't use unification operator for assignment or comparison
 - [x] Don't use undeclared variables

--- a/docs/rules/style/prefer-some-in-iteration.md
+++ b/docs/rules/style/prefer-some-in-iteration.md
@@ -1,0 +1,117 @@
+# prefer-some-in-iteration
+
+**Summary**: Prefer `some .. in` for iteration
+
+**Category**: Style
+
+**Avoid**
+```rego
+package policy
+
+engineering_roles = {"engineer", "dba", "developer"}
+
+engineers[employee] {
+    employee := data.employees[_]
+    employee.role in engineering_roles
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+import future.keywords.in
+
+engineering_roles = {"engineer", "dba", "developer"}
+
+engineers[employee] {
+    some employee in data.employees
+    employee.role in engineering_roles
+}
+```
+
+## Rationale
+
+Using the `some .. in` construct for iteration removes ambiguity around iteration vs. membership checks, and is
+generally more pleasant to read. Consider the following example:
+
+```rego
+some_condition if {
+    other_rule[user]
+    # ...
+}
+```
+
+Are we iterating users over a partial "other_rule" here, or checking if the set contains a user defined elsewhere?
+Or is other_rule a map generating rule, and we're checking for the existence of a key? We won't know without looking
+elsewhere in the code. Using `some .. in` removes this ambiguity, and makes the intent clear without having to jump
+around in the policy.
+
+## Exceptions
+
+Deeply nested iteration is often easier to read using the more compact form.
+
+```rego
+package policy
+
+import future.keywords.if
+import future.keywords.in
+
+# These rules are equivalent, but the more compact form is arguably easier to read
+
+any_user_is_admin if {
+    some user in input.users
+    some attribute in user.attributes
+    some role in attribute.roles
+    role == "admin"
+}
+
+any_user_is_admin if {
+    input.users[_].attributes[_].roles[_] == "admin"
+}
+
+# Using "if", we may even omit the brackets for single line rules
+any_user_is_admin if input.users[_].attributes[_].roles[_] == "admin"
+```
+
+The `ignore-nesting-level` configuration option allows setting the threshold for nesting. Any level of nesting
+**equal or greater than** the threshold won't be considered a violation. The default setting of `2` allows all _nested_
+iteration, but not e.g. `my_array[x]`.
+
+**Note:** not all nesting is *iteration*! The following example is considered to have a nesting level of `1`, as only
+one of the variables (including wildcards: `_`) is an output variable bound in iteration:
+
+```rego
+package policy
+
+example_users[user] {
+    domain := "example.com"
+    user := input.sites[domain].users[_]
+}
+```
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  style:
+    prefer-some-in-iteration:
+      # one of "error", "warning", "ignore"
+      level: error
+      # except iteration if nested at or above the level i.e. setting of
+      # '2' will allow `input[_].users[_]` but not `input[_]`
+      ignore-nesting-level: 2
+```
+
+## Related Resources
+
+- Rego Style Guide: [Prefer some .. in for iteration](https://github.com/StyraInc/rego-style-guide#prefer-some--in-for-iteration)
+- Regal Docs: [Use `some` to declare output variables](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -88,7 +88,7 @@ or := 1
 	}
 
 	if len(result.Violations) != 1 {
-		t.Fatalf("expected 1 violation, got %d", len(result.Violations))
+		t.Fatalf("expected 1 violation, got %d - violations: %v", len(result.Violations), result.Violations)
 	}
 
 	if result.Violations[0].Title != "top-level-iteration" {


### PR DESCRIPTION
Building on top of previous work to find vars and to determine the "scope" of a variable, this commit adds a new rule in the style category to prefer `some x in y` over `x := y[_]`.

There are also a few fixups here related to the new rule, and some that were forgotten about in the previous rule added.

Note that there are some situations where a variable may thought of as being in scope while not actually being in scope — such as when iteration happens after a comprehension, as we have no way of keeping the nesting level "state" currently. This should not lead to false positives but could lead to a few cases being missed, which I think is OK for the time being. Will need to investigate better methods for determining scope, and likely outside of Rego.

Fixes #243