### PR TITLE
Enable pre-commit hook for all hook types

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,4 @@
 - id: regal-lint
-  stages:
-    - pre-commit
   language: golang
   name: policy file linting
   description: policy file linting with Regal from Styra built from source
@@ -8,8 +6,6 @@
   files: (\.rego)$
 
 - id: regal-lint-use-path
-  stages:
-    - pre-commit
   language: system
   name: policy file linting
   description: policy file linting with Regal from Styra using system $PATH
@@ -17,8 +13,6 @@
   files: (\.rego)$
 
 - id: regal-download
-  stages:
-    - pre-commit
   language: script
   name: policy file linting
   description: policy file linting with Regal downloaded from Github

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -7,7 +7,7 @@ To use Regal with pre-commit, add this to your `.pre-commit-config.yaml`
 
 ```yaml
 - repo: https://github.com/StyraInc/regal
-  rev: v0.5.0 # Use the ref you want to point at
+  rev: v0.7.0 # Use the ref you want to point at
   hooks:
     - id: regal-lint
   # -   id: ...


### PR DESCRIPTION
The current pre-commit hook configuration only allows the hook to run on a `pre-commit` hook. The default configuration enables the hook for all hook types supported by pre-commit as per the [docs](https://pre-commit.com/#confining-hooks-to-run-at-certain-stages), e.g. on a `push` hook which is very useful for CI.

Also a minor fix for the docs to use a ref that works.