### PR TITLE
Filter out files _before_ parsing

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -131,8 +131,9 @@ func TestLintNonExistentDir(t *testing.T) {
 		t.Errorf("expected stderr %q, got %q", exp, act)
 	}
 
-	if exp, act := "errors encountered when reading files to lint: failed to load policy from provided args: "+
-		"1 error occurred during loading: stat "+td+"/what/ever: no such file or directory\n", stdout.String(); exp != act {
+	if exp, act := "error(s) encountered while linting: errors encountered when reading files to lint: "+
+		"failed to filter paths: 1 error occurred during loading: stat "+td+"/what/ever: no such file or directory\n",
+		stdout.String(); exp != act {
 		t.Errorf("expected stdout %q, got %q", exp, act)
 	}
 }

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -72,6 +72,13 @@ func JSONRoundTrip(from any, to any) error {
 	return json.Unmarshal(bs, to) //nolint:wrapcheck
 }
 
+// MustJSONRoundTrip convert any value to JSON and back again, exit on failure.
+func MustJSONRoundTrip(from any, to any) {
+	if err := JSONRoundTrip(from, to); err != nil {
+		log.Fatal(err)
+	}
+}
+
 // MustYAMLToMap creates a map from reader, expecting YAML content, or fail.
 func MustYAMLToMap(from io.Reader) (m map[string]any) {
 	if err := yaml.NewDecoder(from).Decode(&m); err != nil {

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -1,0 +1,110 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/gobwas/glob"
+
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/open-policy-agent/opa/loader"
+)
+
+func FilterIgnoredPaths(paths, ignore []string, checkFileExists bool) ([]string, error) {
+	policyPaths := paths
+
+	if checkFileExists {
+		filteredPaths, err := loader.FilteredPaths(paths, func(_ string, info os.FileInfo, depth int) bool {
+			return !info.IsDir() && !strings.HasSuffix(info.Name(), bundle.RegoExt)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to filter paths: %w", err)
+		}
+
+		policyPaths = filteredPaths
+	}
+
+	if len(ignore) == 0 {
+		return policyPaths, nil
+	}
+
+	return filterPaths(policyPaths, ignore)
+}
+
+func filterPaths(policyPaths []string, ignore []string) ([]string, error) {
+	filtered := make([]string, 0, len(policyPaths))
+
+outer:
+	for _, f := range policyPaths {
+		for _, pattern := range ignore {
+			if pattern == "" {
+				continue
+			}
+
+			excluded, err := excludeFile(pattern, f)
+			if err != nil {
+				return nil, fmt.Errorf("failed to check for exclusion using pattern %s: %w", pattern, err)
+			}
+
+			if excluded {
+				continue outer
+			}
+		}
+
+		filtered = append(filtered, f)
+	}
+
+	return filtered, nil
+}
+
+// excludeFile imitates the pattern matching of .gitignore files
+// See `exclusion.rego` for details on the implementation.
+func excludeFile(pattern string, filename string) (bool, error) {
+	n := len(pattern)
+
+	// Internal slashes means path is relative to root, otherwise it can
+	// appear anywhere in the directory (--> **/)
+	if !strings.Contains(pattern[:n-1], "/") {
+		pattern = "**/" + pattern
+	}
+
+	// Leading slash?
+	pattern = strings.TrimPrefix(pattern, "/")
+
+	// Leading double-star?
+	var ps []string
+	if strings.HasPrefix(pattern, "**/") {
+		ps = []string{pattern, strings.TrimPrefix(pattern, "**/")}
+	} else {
+		ps = []string{pattern}
+	}
+
+	var ps1 []string
+
+	// trailing slash?
+	for _, p := range ps {
+		switch {
+		case strings.HasSuffix(p, "/"):
+			ps1 = append(ps1, p+"**")
+		case !strings.HasSuffix(p, "/") && !strings.HasSuffix(p, "**"):
+			ps1 = append(ps1, p, p+"/**")
+		default:
+			ps1 = append(ps1, p)
+		}
+	}
+
+	// Loop through patterns and return true on first match
+	for _, p := range ps1 {
+		g, err := glob.Compile(p, '/')
+		if err != nil {
+			return false, fmt.Errorf("failed to compile pattern %s: %w", p, err)
+		}
+
+		if g.Match(filename) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
Also:
* Allow files to be provided either from file paths, *or* programmatically as modules.
* Marshal config directly to Config struct, and prefer to use the struct rather than passing around the config as a map.

Fixes #265