### PR TITLE
Add GitHub output format

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,5 +21,5 @@ jobs:
       - run: go test ./...
       - run: go build
       - run: chmod +x regal
-      - run: ./regal lint bundle
+      - run: ./regal lint --format github bundle
       - run: go test -tags e2e ./e2e

--- a/README.md
+++ b/README.md
@@ -306,6 +306,19 @@ Note that at this point in time, Regal only considers the line following the ign
 entire blocks of code (like rules, functions or even packages). See [configuration](#configuration) if you want to
 ignore certain rules altogether.
 
+## Output Formats
+
+The `regal lint` command allows specifying the output format by using the `--format` flag. The available output formats
+are:
+
+- `pretty` (default) - Human-readable table-like output where each violation is printed with a detailed explanation
+- `compact` - Human-readable output where each violation is printed on a single line
+- `json` - JSON output, suitable for programmatic consumption
+- `github` - GitHub [workflow command](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)
+  output, ideal for use in GitHub Actions. Annotates PRs and creates a
+  [job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary)
+  from the linter report
+
 ## Resources
 
 ### Documentation

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -7,4 +7,6 @@ const (
 	formatPretty = "pretty"
 	// formatCompact is the compact format value for the --format flag in various commands.
 	formatCompact = "compact"
+	// formatGitHub is the GitHub format value for the --format flag in various commands.
+	formatGitHub = "github"
 )

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -119,7 +119,7 @@ func init() {
 	lintCommand.Flags().StringVarP(&params.configFile, "config-file", "c", "",
 		"set path of configuration file")
 	lintCommand.Flags().StringVarP(&params.format, "format", "f", formatPretty,
-		"set output format (pretty, compact, json)")
+		"set output format (pretty, compact, json, github)")
 	lintCommand.Flags().StringVarP(&params.outputFile, "output-file", "o", "",
 		"set file to use for linting output, defaults to stdout")
 	lintCommand.Flags().StringVarP(&params.failLevel, "fail-level", "l", "error",
@@ -270,6 +270,8 @@ func getReporter(format string, outputWriter io.Writer) (reporter.Reporter, erro
 		return reporter.NewCompactReporter(outputWriter), nil
 	case formatJSON:
 		return reporter.NewJSONReporter(outputWriter), nil
+	case formatGitHub:
+		return reporter.NewGitHubReporter(outputWriter), nil
 	default:
 		return nil, fmt.Errorf("unknown format %s", format)
 	}


### PR DESCRIPTION
This will have violations printed in PRs as annotations in the source code at the location of the violation.

In addition to this, the GitHub output format also prints the summary as a "Job Summary", which is a rather nice touch!

Fixes #260 

**Annotations**
![annotation](https://github.com/StyraInc/regal/assets/510711/23bf7c5b-e96d-4c95-9629-5cc185ad702e)

**Job Summary**
![report](https://github.com/StyraInc/regal/assets/510711/9497f9f5-3889-48d8-8938-d727f9f20c33)
