### PR TITLE
Ensure rule "name" logic works without rule.head.name

### DIFF
--- a/bundle/regal/rules/bugs/rule_named_if.rego
+++ b/bundle/regal/rules/bugs/rule_named_if.rego
@@ -6,11 +6,12 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
 	some rule in input.rules
-	rule.head.name == "if"
+	ast.name(rule) == "if"
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/bugs/rule_shadows_builtin.rego
+++ b/bundle/regal/rules/bugs/rule_shadows_builtin.rego
@@ -11,7 +11,7 @@ import data.regal.result
 
 report contains violation if {
 	some rule in input.rules
-	rule.head.name in ast.builtin_names
+	ast.name(rule) in ast.builtin_names
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/bugs/top_level_iteration.rego
+++ b/bundle/regal/rules/bugs/top_level_iteration.rego
@@ -6,6 +6,7 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
@@ -21,7 +22,7 @@ report contains violation if {
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }
 
-_rule_names := {rule.head.name | some rule in input.rules}
+_rule_names := {ast.name(rule) | some rule in input.rules}
 
 # regal ignore:external-reference
 illegal_value_ref(value) if not value in _rule_names

--- a/bundle/regal/rules/custom/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming_convention.rego
@@ -40,13 +40,13 @@ report contains violation if {
 	some rule in input.rules
 
 	not rule.head.args
-	not regex.match(convention.pattern, rule.head.name)
+	not regex.match(convention.pattern, ast.name(rule))
 
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
 		sprintf(
 			"Naming convention violation: rule name %q does not match pattern %q",
-			[rule.head.name, convention.pattern],
+			[ast.name(rule), convention.pattern],
 		),
 	)
 }
@@ -61,13 +61,13 @@ report contains violation if {
 	some rule in input.rules
 
 	rule.head.args
-	not regex.match(convention.pattern, rule.head.name)
+	not regex.match(convention.pattern, ast.name(rule))
 
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
 		sprintf(
 			"Naming convention violation: function name %q does not match pattern %q",
-			[rule.head.name, convention.pattern],
+			[ast.name(rule), convention.pattern],
 		),
 	)
 }

--- a/bundle/regal/rules/style/avoid_get_and_list_prefix.rego
+++ b/bundle/regal/rules/style/avoid_get_and_list_prefix.rego
@@ -6,11 +6,12 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
 	some rule in input.rules
-	strings.any_prefix_match(rule.head.name, {"get_", "list_"})
+	strings.any_prefix_match(ast.name(rule), {"get_", "list_"})
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/style/prefer_snake_case.rego
+++ b/bundle/regal/rules/style/prefer_snake_case.rego
@@ -12,7 +12,11 @@ import data.regal.util
 
 report contains violation if {
 	some rule in input.rules
-	not util.is_snake_case(rule.head.name)
+	some i, ref in rule.head.ref
+
+	_is_name(ref, i)
+
+	not util.is_snake_case(ref.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }
@@ -22,4 +26,14 @@ report contains violation if {
 	not util.is_snake_case(var.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(var))
+}
+
+_is_name(ref, pos) if {
+	pos == 0
+	ref.type == "var"
+}
+
+_is_name(ref, pos) if {
+	pos > 0
+	ref.type == "string"
 }

--- a/bundle/regal/rules/style/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use_assignment_operator_test.rego
@@ -125,3 +125,13 @@ test_success_partial_rule if {
 	r := rule.report with input as ast.policy(`partial["works"] { 1 == 1 }`)
 	r == set()
 }
+
+test_success_using_if if {
+	r := rule.report with input as ast.with_future_keywords(`foo if 1 == 1`)
+	r == set()
+}
+
+test_success_ref_head_rule_if if {
+	r := rule.report with input as ast.with_future_keywords(`a.b.c if true`)
+	r == set()
+}

--- a/bundle/regal/rules/testing/identically_named_tests.rego
+++ b/bundle/regal/rules/testing/identically_named_tests.rego
@@ -10,7 +10,7 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	test_names := [rule.head.name | some rule in ast.tests]
+	test_names := [ast.name(rule) | some rule in ast.tests]
 
 	some i, name in test_names
 

--- a/bundle/regal/rules/testing/todo_test.rego
+++ b/bundle/regal/rules/testing/todo_test.rego
@@ -6,12 +6,13 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
 	some rule in input.rules
 
-	startswith(rule.head.name, "todo_test_")
+	startswith(ast.name(rule), "todo_test_")
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/internal/embeds/templates/builtin/builtin.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin.rego.tpl
@@ -6,6 +6,7 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
@@ -14,7 +15,7 @@ report contains violation if {
 
 	# Deny any rule named foo, bar, or baz. This is just an example!
 	# Add your own rule logic here.
-	rule.head.name in {"foo", "bar", "baz"}
+	ast.name(rule) in {"foo", "bar", "baz"}
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule))
 }

--- a/internal/embeds/templates/custom/custom.rego.tpl
+++ b/internal/embeds/templates/custom/custom.rego.tpl
@@ -8,6 +8,7 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
@@ -16,7 +17,7 @@ report contains violation if {
 
 	# Deny any rule named foo, bar, or baz. This is just an example!
 	# Add your own rule logic here.
-	rule.head.name in {"foo", "bar", "baz"}
+	ast.name(rule) in {"foo", "bar", "baz"}
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule))
 }


### PR DESCRIPTION
The name attribute is not present in ref-head rules, so make sure things keep working when those are around.

Fixes #276

Note though that the rules don't yet necessarily take all ref names into account. Will look at that separately. Just fix the bug for now.