### PR TITLE
Rule: metasyntactic-variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,24 +154,25 @@ The following rules are currently available:
 | idiomatic | [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)       | Use raw strings for regex patterns                        |
 | idiomatic | [use-in-operator](https://docs.styra.com/regal/rules/idiomatic/use-in-operator)                   | Use in to check for membership                            |
 | idiomatic | [use-some-for-output-vars](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars) | Use `some` to declare output variables                    |
-| imports   | [redundant-alias](https://docs.styra.com/regal/rules/imports/redundant-alias)                     | Redundant alias                                           |
+| imports   | [avoid-importing-input](https://docs.styra.com/regal/rules/imports/avoid-importing-input)         | Avoid importing input                                     |
 | imports   | [implicit-future-keywords](https://docs.styra.com/regal/rules/imports/implicit-future-keywords)   | Use explicit future keyword imports                       |
 | imports   | [import-shadows-import](https://docs.styra.com/regal/rules/imports/import-shadows-import)         | Import shadows another import                             |
-| imports   | [avoid-importing-input](https://docs.styra.com/regal/rules/imports/avoid-importing-input)         | Avoid importing input                                     |
+| imports   | [redundant-alias](https://docs.styra.com/regal/rules/imports/redundant-alias)                     | Redundant alias                                           |
 | imports   | [redundant-data-import](https://docs.styra.com/regal/rules/imports/redundant-data-import)         | Redundant import of data                                  |
-| style     | [prefer-snake-case](https://docs.styra.com/regal/rules/style/prefer-snake-case)                   | Prefer snake_case for names                               |
+| style     | [avoid-get-and-list-prefix](https://docs.styra.com/regal/rules/style/avoid-get-and-list-prefix)   | Avoid get_ and list_ prefix for rules and functions       |
 | style     | [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)     | Unconditional assignment in rule body                     |
 | style     | [external-reference](https://docs.styra.com/regal/rules/style/external-reference)                 | Reference to input, data or rule ref in function body     |
 | style     | [function-arg-return](https://docs.styra.com/regal/rules/style/function-arg-return)               | Function argument used for return value                   |
 | style     | [line-length](https://docs.styra.com/regal/rules/style/line-length)                               | Line too long                                             |
 | style     | [no-whitespace-comment](https://docs.styra.com/regal/rules/style/no-whitespace-comment)           | Comment should start with whitespace                      |
-| style     | [avoid-get-and-list-prefix](https://docs.styra.com/regal/rules/style/avoid-get-and-list-prefix)   | Avoid get_ and list_ prefix for rules and functions       |
+| style     | [prefer-snake-case](https://docs.styra.com/regal/rules/style/prefer-snake-case)                   | Prefer snake_case for names                               |
 | style     | [prefer-some-in-iteration](https://docs.styra.com/regal/rules/style/prefer-some-in-iteration)     | Prefer `some .. in` for iteration                         |
 | style     | [todo-comment](https://docs.styra.com/regal/rules/style/todo-comment)                             | Avoid TODO comments                                       |
 | style     | [detached-metadata](https://docs.styra.com/regal/rules/style/detached-metadata)                   | Detached metadata annotation                              |
 | style     | [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)       | Prefer := over = for assignment                           |
 | style     | [opa-fmt](https://docs.styra.com/regal/rules/style/opa-fmt)                                       | File should be formatted with `opa fmt`                   |
 | testing   | [identically-named-tests](https://docs.styra.com/regal/rules/testing/identically-named-tests)     | Multiple tests with same name                             |
+| testing   | [metasyntactic-variable](https://docs.styra.com/regal/rules/testing/metasyntactic-variable)       | Metasyntactic variable name                               |
 | testing   | [print-or-trace-call](https://docs.styra.com/regal/rules/testing/print-or-trace-call)             | Call to print or trace function                           |
 | testing   | [test-outside-test-package](https://docs.styra.com/regal/rules/testing/test-outside-test-package) | Test outside of test package                              |
 | testing   | [todo-test](https://docs.styra.com/regal/rules/testing/todo-test)                                 | TODO test encountered                                     |
@@ -346,15 +347,18 @@ If you want to embed Regal in another project or product, please reach out!
 
 ## Roadmap
 
-- [ ] More rules!
-- [x] Add `custom` (or `organizational`, `opinionated`, or..) category for built-in "custom", or
+The roadmap for Regal currently looks like this:
+
+- [ ] 50 rules!
+- [x] Add `custom` (or `organizational`, `opinionated`, or...) category for built-in "custom", or
       [organizational rules](https://github.com/StyraInc/regal/issues/48), to enforce things like naming conventions.
       The most common customizations should not require writing custom rules, but be made available in configuration.
 - [x] Simplify custom rules authoring by providing
       [command for scaffolding](https://github.com/StyraInc/regal/issues/206)
-- [ ] Make more rules consider nested AST nodes
+- [ ] Make more rules consider [nested](https://github.com/StyraInc/regal/issues/82) AST nodes
 - [ ] GitHub Action
-- [ ] VS Code extension
+
+The roadmap is updated when all the current items have been completed.
 
 ## Community
 

--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -28,6 +28,18 @@ name(rule) := rule.head.name if {
 	rule.head.name
 } else := rule.head.ref[0].value
 
+named_refs(refs) := [ref |
+	some i, ref in refs
+	_is_name(ref, i)
+]
+
+_is_name(ref, 0) if ref.type == "var"
+
+_is_name(ref, pos) if {
+	pos > 0
+	ref.type == "string"
+}
+
 tests := [rule |
 	some rule in input.rules
 	not rule.head.args

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -71,6 +71,8 @@ rules:
       level: error
     identically-named-tests:
       level: error
+    metasyntactic-variable:
+      level: error
     print-or-trace-call:
       level: error
     test-outside-test-package:

--- a/bundle/regal/rules/style/prefer_snake_case_test.rego
+++ b/bundle/regal/rules/style/prefer_snake_case_test.rego
@@ -1,28 +1,15 @@
 package regal.rules.style["prefer-snake-case_test"]
 
 import future.keywords.if
+import future.keywords.in
 
 import data.regal.ast
 import data.regal.config
 import data.regal.rules.style["prefer-snake-case"] as rule
 
-snake_case_violation := {
-	"category": "style",
-	"description": "Prefer snake_case for names",
-	"related_resources": [{
-		"description": "documentation",
-		"ref": config.docs.resolve_url("$baseUrl/$category/prefer-snake-case", "style"),
-	}],
-	"title": "prefer-snake-case",
-	"level": "error",
-}
-
 test_fail_camel_cased_rule_name if {
 	r := rule.report with input as ast.policy(`camelCase := 5`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {"col": 1, "file": "policy.rego", "row": 3, "text": `camelCase := 5`}},
-	)}
+	r == expected_with_locations([{"col": 1, "file": "policy.rego", "row": 3, "text": `camelCase := 5`}])
 }
 
 test_success_snake_cased_rule_name if {
@@ -32,10 +19,7 @@ test_success_snake_cased_rule_name if {
 
 test_fail_camel_cased_some_declaration if {
 	r := rule.report with input as ast.policy(`p {some fooBar; input[_]}`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {"col": 9, "file": "policy.rego", "row": 3, "text": `p {some fooBar; input[_]}`}},
-	)}
+	r == expected_with_locations([{"col": 9, "file": "policy.rego", "row": 3, "text": `p {some fooBar; input[_]}`}])
 }
 
 test_success_snake_cased_some_declaration if {
@@ -47,13 +31,12 @@ test_fail_camel_cased_multiple_some_declaration if {
 	r := rule.report with input as ast.with_future_keywords(`p {
 		some x, foo_bar, fooBar; x = 1; foo_bar = 2; input[_]
 	}`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {
-			"col": 20, "file": "policy.rego", "row": 9,
-			"text": "\t\tsome x, foo_bar, fooBar; x = 1; foo_bar = 2; input[_]",
-		}},
-	)}
+	r == expected_with_locations([{
+		"col": 20,
+		"file": "policy.rego",
+		"row": 9,
+		"text": "\t\tsome x, foo_bar, fooBar; x = 1; foo_bar = 2; input[_]",
+	}])
 }
 
 test_success_snake_cased_multiple_some_declaration if {
@@ -63,21 +46,17 @@ test_success_snake_cased_multiple_some_declaration if {
 
 test_fail_camel_cased_var_assignment if {
 	r := rule.report with input as ast.policy(`allow { camelCase := 5 }`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {"col": 9, "file": "policy.rego", "row": 3, "text": `allow { camelCase := 5 }`}},
-	)}
+	r == expected_with_locations([{"col": 9, "file": "policy.rego", "row": 3, "text": `allow { camelCase := 5 }`}])
 }
 
 test_fail_camel_cased_multiple_var_assignment if {
 	r := rule.report with input as ast.policy(`allow { snake_case := "foo"; camelCase := 5 }`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {
-			"col": 30, "file": "policy.rego", "row": 3,
-			"text": `allow { snake_case := "foo"; camelCase := 5 }`,
-		}},
-	)}
+	r == expected_with_locations([{
+		"col": 30,
+		"file": "policy.rego",
+		"row": 3,
+		"text": `allow { snake_case := "foo"; camelCase := 5 }`,
+	}])
 }
 
 test_success_snake_cased_var_assignment if {
@@ -87,26 +66,27 @@ test_success_snake_cased_var_assignment if {
 
 test_fail_camel_cased_some_in_value if {
 	r := rule.report with input as ast.with_future_keywords(`allow { some cC in input }`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {"col": 14, "file": "policy.rego", "row": 8, "text": `allow { some cC in input }`}},
-	)}
+	r == expected_with_locations([{"col": 14, "file": "policy.rego", "row": 8, "text": `allow { some cC in input }`}])
 }
 
 test_fail_camel_cased_some_in_key_value if {
 	r := rule.report with input as ast.with_future_keywords(`allow { some cC, sc in input }`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {"col": 14, "file": "policy.rego", "row": 8, "text": `allow { some cC, sc in input }`}},
-	)}
+	r == expected_with_locations([{
+		"col": 14,
+		"file": "policy.rego",
+		"row": 8,
+		"text": `allow { some cC, sc in input }`,
+	}])
 }
 
 test_fail_camel_cased_some_in_key_value_2 if {
 	r := rule.report with input as ast.with_future_keywords(`allow { some sc, cC in input }`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {"col": 18, "file": "policy.rego", "row": 8, "text": `allow { some sc, cC in input }`}},
-	)}
+	r == expected_with_locations([{
+		"col": 18,
+		"file": "policy.rego",
+		"row": 8,
+		"text": `allow { some sc, cC in input }`,
+	}])
 }
 
 test_success_snake_cased_some_in if {
@@ -116,24 +96,39 @@ test_success_snake_cased_some_in if {
 
 test_fail_camel_cased_every_value if {
 	r := rule.report with input as ast.with_future_keywords(`allow { every cC in input { cC == 1 } }`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {"col": 15, "file": "policy.rego", "row": 8, "text": `allow { every cC in input { cC == 1 } }`}},
-	)}
+	r == expected_with_locations([{
+		"col": 15,
+		"file": "policy.rego",
+		"row": 8,
+		"text": `allow { every cC in input { cC == 1 } }`,
+	}])
 }
 
 test_fail_camel_cased_every_key if {
 	r := rule.report with input as ast.with_future_keywords(`allow { every cC, sc in input { cC == 1; sc == 2 } }`)
-	r == {object.union(
-		snake_case_violation,
-		{"location": {
-			"col": 15, "file": "policy.rego", "row": 8,
-			"text": `allow { every cC, sc in input { cC == 1; sc == 2 } }`,
-		}},
-	)}
+	r == expected_with_locations([{
+		"col": 15, "file": "policy.rego", "row": 8,
+		"text": `allow { every cC, sc in input { cC == 1; sc == 2 } }`,
+	}])
 }
 
 test_success_snake_cased_every if {
 	r := rule.report with input as ast.with_future_keywords(`allow { every sc in input { sc == 1 } }`)
 	r == set()
+}
+
+expected_with_locations(locations) := {with_location |
+	expected := {
+		"category": "style",
+		"description": "Prefer snake_case for names",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-snake-case", "style"),
+		}],
+		"title": "prefer-snake-case",
+		"level": "error",
+	}
+
+	some location in locations
+	with_location := object.union(expected, {"location": location})
 }

--- a/bundle/regal/rules/testing/metasyntactic_variable.rego
+++ b/bundle/regal/rules/testing/metasyntactic_variable.rego
@@ -1,6 +1,6 @@
 # METADATA
-# description: Prefer snake_case for names
-package regal.rules.style["prefer-snake-case"]
+# description: Metasyntactic variable name
+package regal.rules.testing["metasyntactic-variable"]
 
 import future.keywords.contains
 import future.keywords.if
@@ -8,19 +8,40 @@ import future.keywords.in
 
 import data.regal.ast
 import data.regal.result
-import data.regal.util
+
+metasyntactic := {
+	"foobar",
+	"foo",
+	"bar",
+	"baz",
+	"qux",
+	"quux",
+	"corge",
+	"grault",
+	"garply",
+	"waldo",
+	"fred",
+	"plugh",
+	"xyzzy",
+	"thud",
+}
 
 report contains violation if {
 	some rule in input.rules
 	some ref in ast.named_refs(rule.head.ref)
-	not util.is_snake_case(ref.value)
+
+	lower(ref.value) in metasyntactic
 
 	violation := result.fail(rego.metadata.chain(), result.location(location_of(ref, rule)))
 }
 
 report contains violation if {
-	some var in ast.find_vars(input.rules)
-	not util.is_snake_case(var.value)
+	some rule in input.rules
+	some var in ast.find_vars(rule)
+
+	lower(var.value) in metasyntactic
+
+	ast.is_output_var(rule, var, var.location)
 
 	violation := result.fail(rego.metadata.chain(), result.location(var))
 }

--- a/bundle/regal/rules/testing/metasyntactic_variable_test.rego
+++ b/bundle/regal/rules/testing/metasyntactic_variable_test.rego
@@ -1,0 +1,53 @@
+package regal.rules.testing["metasyntactic-variable_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.testing["metasyntactic-variable"] as rule
+
+test_fail_rule_named_foo if {
+	module := ast.policy("foo := true")
+
+	r := rule.report with input as module
+	r == {expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "foo := true"})}
+}
+
+test_fail_metasyntactic_vars if {
+	module := ast.policy(`allow {
+		fooBar := true
+		input[baz]
+	}`)
+
+	r := rule.report with input as module
+	r == {
+		expected_with_location({"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tfooBar := true"}),
+		expected_with_location({"col": 9, "file": "policy.rego", "row": 5, "text": "\t\tinput[baz]"}),
+	}
+}
+
+test_fail_metasyntactic_vars_ref_head_strings if {
+	module := ast.policy(`foo.a.BAR.b.C.baz := true`)
+
+	r := rule.report with input as module
+	r == {
+		expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "foo.a.BAR.b.C.baz := true"}),
+		expected_with_location({"col": 7, "file": "policy.rego", "row": 3, "text": "foo.a.BAR.b.C.baz := true"}),
+		expected_with_location({"col": 15, "file": "policy.rego", "row": 3, "text": "foo.a.BAR.b.C.baz := true"}),
+	}
+}
+
+expected := {
+	"category": "testing",
+	"description": "Metasyntactic variable name",
+	"level": "error",
+	"related_resources": [{
+		"description": "documentation",
+		"ref": config.docs.resolve_url("$baseUrl/$category/metasyntactic-variable", "testing"),
+	}],
+	"title": "metasyntactic-variable",
+}
+
+expected_with_location(location) := object.union(expected, {"location": location})

--- a/docs/rules/testing/metasyntactic-variable.md
+++ b/docs/rules/testing/metasyntactic-variable.md
@@ -1,0 +1,90 @@
+# metasyntactic-variable
+
+**Summary**: Metasyntactic variable name
+
+**Category**: Testing
+
+**Avoid**
+```rego
+package policy
+
+# Using metasyntactic names
+foo := ["bar", "baz"]
+
+# ...
+```
+
+**Prefer**
+```rego
+package policy
+
+# Using names relevant to the context
+roles := ["developer", "admin"]
+
+# ...
+```
+
+## Rationale
+
+Using "foo", "bar", "baz" and other [metasyntactic variables](https://en.wikipedia.org/wiki/Metasyntactic_variable) is
+occasionally useful in examples, but should be avoided in production policy. 
+
+This linter rules forbids any metasyntactic variable names, as listed by Wikipedia:
+
+- foobar
+- foo
+- bar
+- baz
+- qux
+- quux
+- corge
+- grault
+- garply
+- waldo
+- fred
+- plugh
+- xyzzy
+- thud
+
+## Exceptions
+
+While there are no recommended exceptions to this rule, you could choose to allow metasyntactic variables in tests, or
+perhaps code meant to be used in examples. When using a
+[proper suffix](https://docs.styra.com/regal/rules/testing/file-missing-test-suffix) for tests, like `_test.rego`,
+simply configure an ignore pattern with the configuration of this rule:
+
+```yaml
+rules: 
+  testing:
+    metasyntactic-variable:
+      level: error
+      ignore:
+        files:
+          - "*_test.rego"
+```
+
+If you'd rather use your own list of forbidden variable names or patterns, see the
+[naming convention](https://docs.styra.com/regal/rules/custom/naming-convention) rule.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  testing:
+    metasyntactic-variable:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Regal Docs: [Naming convention rule](https://docs.styra.com/regal/rules/custom/naming-convention)
+- Wikipedia: [Metasyntactic variable](https://en.wikipedia.org/wiki/Metasyntactic_variable)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -111,3 +111,6 @@ non_raw_regex_pattern := regex.match("[0-9]", "1")
 use_some_for_output_vars {
 	input.foo[output_var]
 }
+
+# metasyntactic variable
+foo := "bar"

--- a/internal/embeds/templates/builtin/builtin_test.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin_test.rego.tpl
@@ -4,6 +4,7 @@ import future.keywords.if
 import future.keywords.in
 
 import data.regal.ast
+import data.regal.config
 
 import data.regal.rules.{{.Category}}{{.Name}} as rule
 
@@ -22,7 +23,7 @@ test_rule_named_foo_not_allowed {
 		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo := true"},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://github.com/StyraInc/regal/blob/main/docs/rules/{{.Category}}/{{.NameOriginal}}.md"
+			"ref": config.docs.resolve_url("$baseUrl/$category/{{.NameOriginal}}", "{{.Category}}")"
 		}],
 		"title": "{{.NameOriginal}}"
 	}}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -69,7 +69,7 @@ func TestLintWithUserConfig(t *testing.T) {
 
 	input := test.InputPolicy("p.rego", `package p
 
-foo := input.bar[_]
+boo := input.hoo[_]
 
 or := 1
 `)
@@ -101,7 +101,7 @@ func TestLintWithUserConfigTable(t *testing.T) {
 
 	policy := `package p
 
-foo := input.bar[_]
+boo := input.hoo[_]
 
  opa_fmt := "fail"
 


### PR DESCRIPTION
Add rule to check for "foo", "bar" and other metasyntactic variables.

Fixes #244

This PR also unifies the logic of this rule and prefer-snake-case, as well as their tests.