### PR TITLE
Refactor: improve config.for_rule ergonomics

### DIFF
--- a/bundle/regal/config/config_test.rego
+++ b/bundle/regal/config/config_test.rego
@@ -2,11 +2,6 @@ package regal.config_test
 
 import data.regal.config
 
-rule := {
-	"title": "test-case",
-	"custom": {"category": "test"},
-}
-
 rules_config := {"rules": {"test": {"test-case": {
 	"level": "ignore",
 	"important_setting": 42,
@@ -24,13 +19,13 @@ params := {
 # disable all
 
 test_disable_all_no_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"disable_all": true})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_all": true})
 
 	c == {"level": "ignore"}
 }
 
 test_disable_all_with_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"disable_all": true})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_all": true})
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
@@ -38,7 +33,7 @@ test_disable_all_with_config {
 
 test_disable_all_with_category_override {
 	p := object.union(params, {"disable_all": true, "enable_category": ["test"]})
-	c := config.for_rule(rule) with data.eval.params as p
+	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
@@ -46,7 +41,7 @@ test_disable_all_with_category_override {
 
 test_disable_all_with_rule_override {
 	p := object.union(params, {"disable_all": true, "enable": ["test-case"]})
-	c := config.for_rule(rule) with data.eval.params as p
+	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
@@ -55,13 +50,13 @@ test_disable_all_with_rule_override {
 # disable category
 
 test_disable_category_no_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"disable_category": ["test"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_category": ["test"]})
 
 	c == {"level": "ignore"}
 }
 
 test_disable_category_with_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"disable_category": ["test"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_category": ["test"]})
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
@@ -69,7 +64,7 @@ test_disable_category_with_config {
 
 test_disable_category_with_rule_override {
 	p := object.union(params, {"disable_category": ["test"], "enable": ["test-case"]})
-	c := config.for_rule(rule) with data.eval.params as p
+	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
@@ -78,13 +73,13 @@ test_disable_category_with_rule_override {
 # disable rule
 
 test_disable_single_rule {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"disable": ["test-case"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable": ["test-case"]})
 
 	c == {"level": "ignore"}
 }
 
 test_disable_single_rule_with_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"disable": ["test-case"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable": ["test-case"]})
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
@@ -93,13 +88,13 @@ test_disable_single_rule_with_config {
 # enable all
 
 test_enable_all_no_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"enable_all": true})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_all": true})
 
 	c == {"level": "error"}
 }
 
 test_enable_all_with_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"enable_all": true})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_all": true})
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
@@ -107,7 +102,7 @@ test_enable_all_with_config {
 
 test_enable_all_with_category_override {
 	p := object.union(params, {"enable_all": true, "disable_category": ["test"]})
-	c := config.for_rule(rule) with data.eval.params as p
+	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
@@ -115,7 +110,7 @@ test_enable_all_with_category_override {
 
 test_enable_all_with_rule_override {
 	p := object.union(params, {"enable_all": true, "disable": ["test-case"]})
-	c := config.for_rule(rule) with data.eval.params as p
+	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
@@ -124,13 +119,13 @@ test_enable_all_with_rule_override {
 # disable category
 
 test_enable_category_no_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"enable_category": ["test"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_category": ["test"]})
 
 	c == {"level": "error"}
 }
 
 test_enable_category_with_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"enable_category": ["test"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_category": ["test"]})
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
@@ -138,7 +133,7 @@ test_enable_category_with_config {
 
 test_enable_category_with_rule_override {
 	p := object.union(params, {"enable_category": ["test"], "disable": ["test-case"]})
-	c := config.for_rule(rule) with data.eval.params as p
+	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
@@ -147,13 +142,13 @@ test_enable_category_with_rule_override {
 # enable rule
 
 test_enable_single_rule {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"enable": ["test-case"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable": ["test-case"]})
 
 	c == {"level": "error"}
 }
 
 test_enable_single_rule_with_config {
-	c := config.for_rule(rule) with data.eval.params as object.union(params, {"enable": ["test-case"]})
+	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable": ["test-case"]})
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}

--- a/bundle/regal/config/exclusion.rego
+++ b/bundle/regal/config/exclusion.rego
@@ -3,10 +3,10 @@ package regal.config
 import future.keywords.if
 import future.keywords.in
 
-excluded_file(metadata, file) if {
+excluded_file(category, title, file) if {
 	force_exclude_file(file)
 } else if {
-	rule_config := for_rule(metadata)
+	rule_config := for_rule(category, title)
 	ex := rule_config.ignore.files
 	is_array(ex)
 	some pattern in ex

--- a/bundle/regal/config/exclusion_test.rego
+++ b/bundle/regal/config/exclusion_test.rego
@@ -64,7 +64,7 @@ rules_config_ignore_delta := {"rules": {"test": {"test-case": {"ignore": {"files
 config_ignore := {"ignore": {"files": ["p.rego"]}}
 
 test_excluded_file_default {
-	e := config.excluded_file(rule, "p.rego") with data.eval.params as params
+	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
 		with config.merged_config as rules_config_error
 
 	e == false
@@ -72,23 +72,26 @@ test_excluded_file_default {
 
 test_excluded_file_with_ignore {
 	c := object.union(rules_config_error, rules_config_ignore_delta)
-	e := config.excluded_file(rule, "p.rego") with data.eval.params as params
+	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
 		with config.merged_config as c
 	e == true
 }
 
 test_excluded_file_config {
-	e := config.excluded_file(rule, "p.rego") with config.merged_config as config_ignore
+	e := config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
 	e == true
 }
 
 test_excluded_file_cli_flag {
-	e := config.excluded_file(rule, "p.rego") with data.eval.params as object.union(params, {"ignore_files": ["p.rego"]})
+	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as object.union(
+		params,
+		{"ignore_files": ["p.rego"]},
+	)
 	e == true
 }
 
 test_excluded_file_cli_overrides_config {
-	e := config.excluded_file(rule, "p.rego") with config.merged_config as config_ignore
+	e := config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
 		with data.eval.params as object.union(params, {"ignore_files": [""]})
 	e == false
 }

--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -26,18 +26,13 @@ report contains violation if {
 	}
 }
 
-to_meta(category, title) := {
-	"custom": {"category": category},
-	"title": title,
-}
-
 # Check bundled rules
 report contains violation if {
 	some category, title
 	config.merged_config.rules[category][title]
 
-	config.for_rule(to_meta(category, title)).level != "ignore"
-	not config.excluded_file(to_meta(category, title), input.regal.file.name)
+	config.for_rule(category, title).level != "ignore"
+	not config.excluded_file(category, title, input.regal.file.name)
 
 	violation := data.regal.rules[category][title].report[_]
 
@@ -50,8 +45,8 @@ report contains violation if {
 
 	violation := data.custom.regal.rules[category][title].report[_]
 
-	config.for_rule(to_meta(category, title)).level != "ignore"
-	not config.excluded_file(to_meta(category, title), input.regal.file.name)
+	config.for_rule(category, title).level != "ignore"
+	not config.excluded_file(category, title, input.regal.file.name)
 
 	not ignored(violation, ignore_directives)
 }

--- a/bundle/regal/result.rego
+++ b/bundle/regal/result.rego
@@ -59,7 +59,7 @@ _fail_annotated(metadata, details) := violation if {
 	category := with_location.custom.category
 	with_category := object.union(with_location, {
 		"category": category,
-		"level": config.rule_level(config.for_rule(with_location)),
+		"level": config.rule_level(config.for_rule(category, metadata.title)),
 	})
 
 	without_custom_and_scope := object.remove(with_category, ["custom", "scope", "schemas"])
@@ -77,7 +77,7 @@ _fail_annotated_custom(metadata, details) := violation if {
 	category := with_location.custom.category
 	with_category := object.union(with_location, {
 		"category": category,
-		"level": config.rule_level(config.for_rule(with_location)),
+		"level": config.rule_level(config.for_rule(category, metadata.title)),
 	})
 
 	violation := object.remove(with_category, ["custom", "scope", "schemas"])

--- a/bundle/regal/rules/custom/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming_convention.rego
@@ -10,7 +10,7 @@ import data.regal.ast
 import data.regal.config
 import data.regal.result
 
-cfg := config.for_rule({"custom": {"category": "custom"}, "title": "naming-convention"})
+cfg := config.for_rule("custom", "naming-convention")
 
 # target: package
 report contains violation if {

--- a/bundle/regal/rules/style/function_arg_return.rego
+++ b/bundle/regal/rules/style/function_arg_return.rego
@@ -11,7 +11,7 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule({"custom": {"category": "style"}, "title": "function-arg-return"})
+	cfg := config.for_rule("style", "function-arg-return")
 
 	except_functions := array.concat(
 		object.get(cfg, "except-functions", []),

--- a/bundle/regal/rules/style/line_length.rego
+++ b/bundle/regal/rules/style/line_length.rego
@@ -10,7 +10,7 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule({"custom": {"category": "style"}, "title": "line-length"})
+	cfg := config.for_rule("style", "line-length")
 
 	some i, line in input.regal.file.lines
 

--- a/bundle/regal/rules/style/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer_some_in_iteration.rego
@@ -10,7 +10,7 @@ import data.regal.ast
 import data.regal.config
 import data.regal.result
 
-cfg := config.for_rule({"custom": {"category": "style"}, "title": "prefer-some-in-iteration"})
+cfg := config.for_rule("style", "prefer-some-in-iteration")
 
 report contains violation if {
 	some rule in input.rules


### PR DESCRIPTION
This function expected an object derived from a rule annotation, and while we no longer use that this function remained the same. Instead we now expect just the category and title of the rule.