### PR TITLE
test: allow running "regal" on its own bundle 

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -318,6 +318,32 @@ func TestLintRuleNamingConventionFromCustomCategory(t *testing.T) {
 	}
 }
 
+func TestTestRegalBundledBundle(t *testing.T) {
+	t.Parallel()
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	cwd := must(os.Getwd)
+
+	err := regal(&stdout, &stderr)("test", "--format", "json", cwd+"/../bundle")
+
+	if exp, act := 0, ExitStatus(err); exp != act {
+		t.Errorf("expected exit status %d, got %d", exp, act)
+	}
+
+	if exp, act := "", stderr.String(); exp != act {
+		t.Errorf("expected stderr %q, got %q", exp, act)
+	}
+
+	var res []tester.Result
+
+	err = json.Unmarshal(stdout.Bytes(), &res)
+	if err != nil {
+		t.Fatalf("expected JSON response, got %v", stdout.String())
+	}
+}
+
 func TestTestRegalBundledRules(t *testing.T) {
 	t.Parallel()
 

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -9,18 +9,19 @@ import (
 
 func Capabilities() *ast.Capabilities {
 	caps := ast.CapabilitiesForThisVersion()
-	caps.Builtins = append(caps.Builtins, &ast.Builtin{
-		Name: builtins.RegalParseModuleMeta.Name,
-		Decl: builtins.RegalParseModuleMeta.Decl,
-	})
-	caps.Builtins = append(caps.Builtins, &ast.Builtin{
-		Name: builtins.RegalJSONPrettyMeta.Name,
-		Decl: builtins.RegalJSONPrettyMeta.Decl,
-	})
-	caps.Builtins = append(caps.Builtins, &ast.Builtin{
-		Name: builtins.RegalLastMeta.Name,
-		Decl: builtins.RegalLastMeta.Decl,
-	})
+	caps.Builtins = append(caps.Builtins,
+		&ast.Builtin{
+			Name: builtins.RegalParseModuleMeta.Name,
+			Decl: builtins.RegalParseModuleMeta.Decl,
+		},
+		&ast.Builtin{
+			Name: builtins.RegalJSONPrettyMeta.Name,
+			Decl: builtins.RegalJSONPrettyMeta.Decl,
+		},
+		&ast.Builtin{
+			Name: builtins.RegalLastMeta.Name,
+			Decl: builtins.RegalLastMeta.Decl,
+		})
 
 	return caps
 }

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -2,37 +2,31 @@
 package test
 
 import (
-	"path/filepath"
 	"sync"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
 
+	"github.com/styrainc/regal/internal/embeds"
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/internal/parse"
 	"github.com/styrainc/regal/pkg/rules"
 )
-
-const regalBundleDir = "../../bundle"
 
 var once sync.Once
 
 var regalBundle *bundle.Bundle
 
 // GetRegalBundle allows reusing the same Regal rule bundle in tests
-// without having to reload it from disk each time (i.e. a singleton)
+// without having to reload and compile it each time (i.e. a singleton)
 // Note that tests making use of this must *not* make any modifications
 // to the contents of the bundle.
 func GetRegalBundle(t *testing.T) bundle.Bundle {
 	t.Helper()
 
 	once.Do(func() {
-		absRegalBundleDir, err := filepath.Abs(regalBundleDir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		rb := rio.MustLoadRegalBundlePath(absRegalBundleDir)
+		rb := rio.MustLoadRegalBundleFS(embeds.EmbedBundleFS)
 		regalBundle = &rb
 	})
 


### PR DESCRIPTION
...by rewriting some refs on loading: data.regal becomes data.internal.regal,
both in package definitions and imports, e.g.

    package regal.main
    import data.regal.config

becomes

    package regal.internal.main
    import data.internal.regal.config

**Update** ☝️ This didn't work. Custom rules might use `data.regal` in their code, and direct refs would have to be rewritten too (so `data.regal.config.whatever` without an import).

⏩ We're now using a ModuleLoader to load packages from the embedded Regal module into `data.regal` as needed. This allows for running all of

- `regal test bundle` # all of it
- `regal test bundle/regal/main_test.rego` # individual test files
