### PR TITLE
Add `--debug` flag to `regal lint` command

### DIFF
--- a/bundle/regal/rules/style/file_length.rego
+++ b/bundle/regal/rules/style/file_length.rego
@@ -6,7 +6,6 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 import data.regal.result
 

--- a/bundle/regal/rules/style/file_length_test.rego
+++ b/bundle/regal/rules/style/file_length_test.rego
@@ -3,7 +3,6 @@ package regal.rules.style["file-length_test"]
 import future.keywords.if
 import future.keywords.in
 
-import data.regal.ast
 import data.regal.config
 
 import data.regal.rules.style["file-length"] as rule

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -254,6 +254,29 @@ func TestLintRuleIgnoreFiles(t *testing.T) {
 	}
 }
 
+func TestLintWithDebugOption(t *testing.T) {
+	t.Parallel()
+
+	cwd := must(os.Getwd)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	err := regal(&stdout, &stderr)("lint", "--debug", "--config-file", cwd+"/testdata/configs/ignore_files_prefer_snake_case.yaml", cwd+"/testdata/violations")
+
+	if exp, act := 3, ExitStatus(err); exp != act {
+		t.Errorf("expected exit status %d, got %d", exp, act)
+	}
+
+	if exp, act := "", stderr.String(); exp != act {
+		t.Errorf("expected stderr %q, got %q", exp, act)
+	}
+
+	if !strings.Contains(stdout.String(), "rules:") {
+		t.Errorf("expected stdout to print configuration, got %q", stdout.String())
+	}
+}
+
 func TestLintRuleNamingConventionFromCustomCategory(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/open-policy-agent/opa/util/test"
 
 	rio "github.com/styrainc/regal/internal/io"
@@ -70,4 +72,44 @@ func TestFindConfig(t *testing.T) {
 			t.Errorf("expected no config file to be found")
 		}
 	})
+}
+
+func TestMarshalConfig(t *testing.T) {
+	t.Parallel()
+
+	conf := Config{
+		Rules: map[string]Category{
+			"testing": {
+				"foo": Rule{
+					Level: "error",
+					Ignore: Ignore{
+						Files: []string{"foo.rego"},
+					},
+					Extra: ExtraAttributes{
+						"bar":    "baz",
+						"ignore": "this should be removed by the marshaller",
+					},
+				},
+			},
+		},
+	}
+
+	bs, err := yaml.Marshal(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `rules:
+    testing:
+        foo:
+            bar: baz
+            ignore:
+                files:
+                    - foo.rego
+            level: error
+`
+
+	if string(bs) != expect {
+		t.Errorf("expected %s, got %s", expect, string(bs))
+	}
 }


### PR DESCRIPTION
More capabilities to be added in time, but for now:

* Disable `print` output unless the debug flag is provided
* Print the location of the user configuration file found
* Print the final configuration merged from provided and user conf
* Fix bug that made configuration be parsed and merged twice