### PR TITLE
Allow not providing level in user configuration

### DIFF
--- a/bundle/regal/config/config_test.rego
+++ b/bundle/regal/config/config_test.rego
@@ -176,3 +176,19 @@ test_all_configured_rules_exist {
 
 	count(missing_rules - go_rules) == 0
 }
+
+test_merged_configuration_inherits_empty_user_level_from_provided_conf {
+	base_conf := {"rules": {"test": {"test-case": {"level": "error"}}}}
+	user_conf := {"rules": {"test": {"test-case": {"level": "", "foo": "bar"}}}}
+
+	merged := config.merged_config with config.user_config as user_conf
+		with data.regal.config.provided as base_conf
+
+	object_equals(merged, {"rules": {"test": {"test-case": {
+		"level": "error",
+		"foo": "bar",
+	}}}})
+}
+
+# begone, compile time type checker!
+object_equals(o, exp) := o == exp

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -447,6 +447,23 @@ func TestCreateNewBuiltinRuleFromTemplate(t *testing.T) {
 	}
 }
 
+func TestMergeRuleConfigWithoutLevel(t *testing.T) {
+	t.Parallel()
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	cwd := must(os.Getwd)
+
+	// No violations from the built-in configuration in the policy provided, but
+	// the user --config-file changes the max-file-length to 1, so this should fail
+	err := regal(&stdout, &stderr)("lint", "--config-file", cwd+"/testdata/configs/rule_without_level.yaml", cwd+"/testdata/custom_naming_convention")
+
+	if exp, act := 3, ExitStatus(err); exp != act {
+		t.Errorf("expected exit status %d, got %d", exp, act)
+	}
+}
+
 func binary() string {
 	if b := os.Getenv("REGAL_BIN"); b != "" {
 		return b

--- a/e2e/testdata/configs/rule_without_level.yaml
+++ b/e2e/testdata/configs/rule_without_level.yaml
@@ -1,0 +1,4 @@
+rules:
+  style:
+    file-length:
+      max-file-length: 1

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -82,7 +82,7 @@ func TestMarshalConfig(t *testing.T) {
 			"testing": {
 				"foo": Rule{
 					Level: "error",
-					Ignore: Ignore{
+					Ignore: &Ignore{
 						Files: []string{"foo.rego"},
 					},
 					Extra: ExtraAttributes{


### PR DESCRIPTION
Previously, this would lead to the rule level getting set to "" (empty string), which "worked" as it would still print the violation, but since it wasn't set to `error` it would not change the exit code of the lint command.

If the level is not provided in user configuration now, we simply inherit the value from the provided configuration.

Fixes #285