### PR TITLE
Rule: chained-rule-body

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The following rules are currently available:
 | imports   | [redundant-alias](https://docs.styra.com/regal/rules/imports/redundant-alias)                     | Redundant alias                                           |
 | imports   | [redundant-data-import](https://docs.styra.com/regal/rules/imports/redundant-data-import)         | Redundant import of data                                  |
 | style     | [avoid-get-and-list-prefix](https://docs.styra.com/regal/rules/style/avoid-get-and-list-prefix)   | Avoid get_ and list_ prefix for rules and functions       |
+| style     | [chained-rule-body](https://docs.styra.com/regal/rules/style/chained-rule-body)                   | Avoid chaining rule bodies                                |
 | style     | [detached-metadata](https://docs.styra.com/regal/rules/style/detached-metadata)                   | Detached metadata annotation                              |
 | style     | [external-reference](https://docs.styra.com/regal/rules/style/external-reference)                 | Reference to input, data or rule ref in function body     |
 | style     | [file-length](https://docs.styra.com/regal/rules/style/file-length)                               | Max file length exceeded                                  |

--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -335,6 +335,21 @@ all_functions := object.union(opa.builtins, function_decls(input.rules))
 
 all_function_names := object.keys(all_functions)
 
+# METADATA
+# description: |
+#   true if rule head contains no identifier, but is a chained rule body immediately following the previous one:
+#   foo {
+#       input.bar
+#   } {	# <-- chained rule body
+#       input.baz
+#   }
+is_chained_rule_body(rule, lines) if {
+	row_text := lines[rule.head.location.row - 1]
+	col_text := substring(row_text, rule.head.location.col - 1, -1)
+
+	startswith(col_text, "{")
+}
+
 comments_decoded := [decoded |
 	some comment in input.comments
 	decoded := object.union(comment, {"Text": base64.decode(comment.Text)})

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -42,6 +42,8 @@ rules:
   style:
     avoid-get-and-list-prefix:
       level: error
+    chained-rule-body:
+      level: error
     detached-metadata:
       level: error
     external-reference:

--- a/bundle/regal/rules/style/chained_rule_body.rego
+++ b/bundle/regal/rules/style/chained_rule_body.rego
@@ -1,0 +1,18 @@
+# METADATA
+# description: Avoid chaining rule bodies
+package regal.rules.style["chained-rule-body"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.result
+
+report contains violation if {
+	some rule in input.rules
+
+	ast.is_chained_rule_body(rule, input.regal.file.lines)
+
+	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
+}

--- a/bundle/regal/rules/style/chained_rule_body_test.rego
+++ b/bundle/regal/rules/style/chained_rule_body_test.rego
@@ -1,0 +1,45 @@
+package regal.rules.style["chained-rule-body_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.style["chained-rule-body"] as rule
+
+test_fail_chained_incremental_definition if {
+	module := ast.policy(`rule {
+		input.x
+	} {
+		input.y
+	}`)
+
+	r := rule.report with input as module
+
+	r == {{
+		"category": "style",
+		"description": "Avoid chaining rule bodies",
+		"level": "error",
+		"location": {"col": 4, "file": "policy.rego", "row": 5, "text": "\t} {"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/chained-rule-body", "style"),
+		}],
+		"title": "chained-rule-body",
+	}}
+}
+
+test_success_not_chained_incremental_definition if {
+	module := ast.policy(`
+	rule {
+		input.x
+	}
+
+	rule {
+		input.y
+	}`)
+
+	r := rule.report with input as module
+	r == set()
+}

--- a/bundle/regal/rules/style/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use_assignment_operator.rego
@@ -16,6 +16,7 @@ report contains violation if {
 	not rule.head.assign
 	not rule.head.key
 	not ast.implicit_boolean_assignment(rule)
+	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule))
 }
@@ -45,6 +46,7 @@ report contains violation if {
 	rule.head.args
 	not rule.head.assign
 	not ast.implicit_boolean_assignment(rule)
+	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head.ref[0]))
 }

--- a/bundle/regal/rules/testing/metasyntactic_variable.rego
+++ b/bundle/regal/rules/testing/metasyntactic_variable.rego
@@ -32,6 +32,14 @@ report contains violation if {
 
 	lower(ref.value) in metasyntactic
 
+	# In case we have chained rule bodies — only flag the location where we have an actual name:
+	# foo {
+	#    input.x
+	# } {
+	#    input.y
+	# }
+	not ast.is_chained_rule_body(rule, input.regal.file.lines)
+
 	violation := result.fail(rego.metadata.chain(), result.location(location_of(ref, rule)))
 }
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,18 @@ for testing it. The code here will be a pretty simple template, but contains all
 rule. A good idea for learning more about what's needed is to take a look at some previous PRs adding new rules to
 Regal.
 
+### Guiding principles for new built-in rules
+
+- All rules should have succinct, descriptive names which are unique - even across categories
+- A rule that misses a few cases is better than no rule at all, but it's good to document any known edge cases 
+- False positives should however always be avoided
+- Add tests for as many cases as you can think of
+- Any new rule should have an example violation added in `e2e/testada/violations/most_violations.rego`
+- All the steps for building, testing and linting in this document should pass
+
+If you're struggling with any of the above points, or you're unsure of what to do, no worries! Just say so in your PR,
+or ask for advice in the `#regal` channel in the Styra Community [Slack](https://communityinviter.com/apps/styracommunity/signup)!
+
 ## Building
 
 Build the `regal` executable simply by running `go build`.

--- a/docs/rules/style/chained-rule-body.md
+++ b/docs/rules/style/chained-rule-body.md
@@ -1,0 +1,63 @@
+# chained-rule-body
+
+**Summary**: Avoid chaining rule bodies
+
+**Category**: Style
+
+**Avoid**
+```rego
+package policy
+
+has_x_or_y {
+    input.x
+} {
+    input.y
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+has_x_or_y {
+    input.x
+}
+
+has_x_or_y {
+    input.y
+}
+```
+
+## Rationale
+
+If the head of the rule is same, it's possible to chain multiple rule bodies together to obtain the same result. This
+form was more common in the past, but is no longer recommended as it is arguably less readable, and less likely to be
+understood by people new to Rego.
+
+## Exceptions
+
+The `opa fmt` command will automatically "unchain" chained rule bodies, so if you have enabled the [opa-fmt](opa-fmt)
+rule, you may safely configure the level of this rule to `ignore`. While we normally don't include style rules covered
+by `opa fmt`, this one is peculiar enough that we felt it was worthy of an exception.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  style:
+    chained-rule-body:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- OPA Docs: [Incremental Definitions](https://www.openpolicyagent.org/docs/latest/policy-language/#incremental-definitions)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -114,3 +114,9 @@ use_some_for_output_vars {
 
 # metasyntactic variable
 foo := "bar"
+
+chained_rule_body {
+	input.x
+} {
+	input.y
+}

--- a/internal/embeds/templates/builtin/builtin_test.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin_test.rego.tpl
@@ -23,7 +23,7 @@ test_rule_named_foo_not_allowed {
 		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo := true"},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/{{.NameOriginal}}", "{{.Category}}")"
+			"ref": config.docs.resolve_url("$baseUrl/$category/{{.NameOriginal}}", "{{.Category}}"),
 		}],
 		"title": "{{.NameOriginal}}"
 	}}


### PR DESCRIPTION
While `opa-fmt` fixes this, this is peculiar enough that the rule docs alone make for an informative source to point at.

Also some minor improvements here and there:
* Fix other rules that would report false positives when chained rules bodies were present
* Remove a trailing quote in the builtin test template used by `rego new rule`
* Add some guiding principles for new rules in development.md

Fixes #292