### PR TITLE
Check for presence of binary before running e2e tests

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"log"
 	"os"
@@ -465,11 +466,19 @@ func TestMergeRuleConfigWithoutLevel(t *testing.T) {
 }
 
 func binary() string {
+	location := "../regal"
+
 	if b := os.Getenv("REGAL_BIN"); b != "" {
-		return b
+		location = b
 	}
 
-	return "../regal"
+	if _, err := os.Stat(location); errors.Is(err, os.ErrNotExist) {
+		log.Fatal("regal binary not found — make sure to run go build before running the e2e tests")
+	} else if err != nil {
+		log.Fatal(err)
+	}
+
+	return location
 }
 
 func regal(outs ...io.Writer) func(...string) error {


### PR DESCRIPTION
Rather than causing a panic, exit gracefully with a message in case the binary doesn't exist.

I entertained the idea of building the binary if needed, but since these tests run in parallel, that would be problematic.

Tried using the [TestMain](https://pkg.go.dev/testing#hdr-Main) function to check only once, but there seems to be no way to get print output from that function unless `-v` is used, as none of the t.Log functions are available there.

Fixes #294