### PR TITLE
Topic 282 broader scope for custom rules

### DIFF
--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -51,6 +51,13 @@ report contains violation if {
 	not ignored(violation, ignore_directives)
 }
 
+aggregate contains aggregate if {
+	some category, title
+	config.for_rule(category, title).level != "ignore"
+	not config.excluded_file(category, title, input.regal.file.name)
+	aggregate := data.custom.regal.rules[category][title].aggregate[_]
+}
+
 ignored(violation, directives) if {
 	ignored_rules := directives[violation.location.row]
 	violation.title in ignored_rules

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -421,36 +421,20 @@ func (l Linter) prepareRegoArgs(query ast.Body) []func(*rego.Rego) {
 }
 
 func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input, aggregates []report.Aggregate) (report.Report, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	aggregate := report.Report{}
 
 	regoArgs := l.prepareRegoArgs(query)
-
 	linterQuery, err := rego.New(regoArgs...).PrepareForEval(ctx)
 	if err != nil {
 		return report.Report{}, fmt.Errorf("failed preparing query for linting: %w", err)
 	}
 
-	aggregate := report.Report{}
-
-	var wg sync.WaitGroup
-
-	var mu sync.Mutex
-
-	errCh := make(chan error)
-	doneCh := make(chan bool)
-
-	for _, name := range input.FileNames {
-		wg.Add(1)
-
-		go func(name string) {
-			defer wg.Done()
-
+	err = l.evalAndCollect(ctx, input, linterQuery,
+		//input builder for each file eval
+		func(name string, content string, module *ast.Module) (map[string]any, error) {
 			enhancedAST, err := parse.EnhanceAST(name, input.FileContent[name], input.Modules[name])
 			if err != nil {
-				errCh <- fmt.Errorf("failed preparing AST: %w", err)
-
-				return
+				return nil, err
 			}
 			if aggregates == nil {
 				// if the value is nil, inserting it "as is" will make it null-defined, and
@@ -462,40 +446,18 @@ func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input, aggreg
 			} else {
 				enhancedAST["aggregate"] = aggregates
 			}
-			resultSet, err := linterQuery.Eval(ctx, rego.EvalInput(enhancedAST))
-			if err != nil {
-				errCh <- fmt.Errorf("error encountered in query evaluation %w", err)
-
-				return
-			}
-
-			result, err := resultSetToReport(resultSet)
-			if err != nil {
-				errCh <- fmt.Errorf("failed to convert result set to report: %w", err)
-
-				return
-			}
-
-			mu.Lock()
-			aggregate.Violations = append(aggregate.Violations, result.Violations...)
-			aggregate.Aggregates = append(aggregate.Aggregates, result.Aggregates...)
-			mu.Unlock()
-		}(name)
+			return enhancedAST, nil
+		},
+		// result collector
+		func(report report.Report) {
+			aggregate.Violations = append(aggregate.Violations, report.Violations...)
+			aggregate.Aggregates = append(aggregate.Aggregates, report.Aggregates...)
+		},
+	)
+	if err != nil {
+		return report.Report{}, err
 	}
-
-	go func() {
-		wg.Wait()
-		doneCh <- true
-	}()
-
-	select {
-	case <-ctx.Done():
-		return report.Report{}, fmt.Errorf("context cancelled: %w", ctx.Err())
-	case err := <-errCh:
-		return report.Report{}, fmt.Errorf("error encountered in rule evaluation %w", err)
-	case <-doneCh:
-		return aggregate, nil
-	}
+	return aggregate, nil
 }
 
 func resultSetToReport(resultSet rego.ResultSet) (report.Report, error) {
@@ -692,20 +654,39 @@ func (l Linter) getBundleByName(name string) (*bundle.Bundle, error) {
 }
 
 func (l Linter) collectAggregates(ctx context.Context, input rules.Input) ([]report.Aggregate, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	var result []report.Aggregate
 
 	regoArgs := l.prepareRegoArgs(ast.MustParseBody("aggregates = data.regal.main.aggregate"))
-
 	linterQuery, err := rego.New(regoArgs...).PrepareForEval(ctx)
 	if err != nil {
 		return []report.Aggregate{}, fmt.Errorf("failed preparing query for linting: %w", err)
 	}
 
-	var result []report.Aggregate
+	err = l.evalAndCollect(ctx, input, linterQuery,
+		//input builder for each file eval
+		func(name string, content string, module *ast.Module) (map[string]any, error) {
+			return parse.EnhanceAST(name, input.FileContent[name], input.Modules[name])
+		},
+		// result collector
+		func(report report.Report) {
+			result = append(result, report.Aggregates...)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Process each file in input.Filenames in a goroutine, with the given Rego query and building the eval input using the
+// provided function. Collects the results via the provided collector. The collector is guaranteed to
+// run sequentially via a mutex.
+func (l Linter) evalAndCollect(ctx context.Context, input rules.Input, query rego.PreparedEvalQuery, queryInputBuilder func(name string, content string, module *ast.Module) (map[string]any, error), reportCollector func(report report.Report)) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	var wg sync.WaitGroup
 	var mu sync.Mutex
-
 	errCh := make(chan error)
 	doneCh := make(chan bool)
 
@@ -715,26 +696,25 @@ func (l Linter) collectAggregates(ctx context.Context, input rules.Input) ([]rep
 		go func(name string) {
 			defer wg.Done()
 
-			enhancedAST, err := parse.EnhanceAST(name, input.FileContent[name], input.Modules[name])
+			queryInput, err := queryInputBuilder(name, input.FileContent[name], input.Modules[name])
 			if err != nil {
-				errCh <- fmt.Errorf("failed preparing AST: %w", err)
+				errCh <- fmt.Errorf("failed building query input: %w", err)
 				return
 			}
-
-			resultSet, err := linterQuery.Eval(ctx, rego.EvalInput(enhancedAST))
+			resultSet, err := query.Eval(ctx, rego.EvalInput(queryInput))
 			if err != nil {
 				errCh <- fmt.Errorf("error encountered in query evaluation %w", err)
 				return
 			}
 
-			ruleReport, err := resultSetToReport(resultSet)
+			result, err := resultSetToReport(resultSet)
 			if err != nil {
 				errCh <- fmt.Errorf("failed to convert result set to report: %w", err)
 				return
 			}
 
 			mu.Lock()
-			result = append(result, ruleReport.Aggregates...)
+			reportCollector(result)
 			mu.Unlock()
 		}(name)
 	}
@@ -746,10 +726,10 @@ func (l Linter) collectAggregates(ctx context.Context, input rules.Input) ([]rep
 
 	select {
 	case <-ctx.Done():
-		return []report.Aggregate{}, fmt.Errorf("context cancelled: %w", ctx.Err())
+		return fmt.Errorf("context cancelled: %w", ctx.Err())
 	case err := <-errCh:
-		return []report.Aggregate{}, fmt.Errorf("error encountered in rule evaluation %w", err)
+		return fmt.Errorf("error encountered in rule evaluation %w", err)
 	case <-doneCh:
-		return result, nil
+		return nil
 	}
 }

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -206,7 +206,11 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 
 	aggregate.Violations = append(aggregate.Violations, goReport.Violations...)
 
-	regoReport, err := l.lintWithRegoRules(ctx, input)
+	aggregates, err := l.collectAggregates(ctx, input)
+	if err != nil {
+		return report.Report{}, fmt.Errorf("failed to collect aggregates using Rego rules: %w", err)
+	}
+	regoReport, err := l.lintWithRegoRules(ctx, input, aggregates)
 	if err != nil {
 		return report.Report{}, fmt.Errorf("failed to lint using Rego rules: %w", err)
 	}
@@ -369,7 +373,7 @@ func (l Linter) paramsToRulesConfig() map[string]any {
 	}
 }
 
-func (l Linter) prepareRegoArgs() []func(*rego.Rego) {
+func (l Linter) prepareRegoArgs(query ast.Body) []func(*rego.Rego) {
 	var regoArgs []func(*rego.Rego)
 
 	roots := []string{"eval"}
@@ -416,11 +420,11 @@ func (l Linter) prepareRegoArgs() []func(*rego.Rego) {
 	return regoArgs
 }
 
-func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input) (report.Report, error) {
+func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input, aggregates []report.Aggregate) (report.Report, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	regoArgs := l.prepareRegoArgs()
+	regoArgs := l.prepareRegoArgs(query)
 
 	linterQuery, err := rego.New(regoArgs...).PrepareForEval(ctx)
 	if err != nil {
@@ -448,7 +452,16 @@ func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input) (repor
 
 				return
 			}
-
+			if aggregates == nil {
+				// if the value is nil, inserting it "as is" will make it null-defined, and
+				// `count(input.aggregate) == 0` and `not input.aggregate` will not evaluate.
+				// For simplicity and to avoid error-prone code, ensure it's always defined as an array,
+				// so that authors can always check `count(input.aggregate)`
+				// not worrying about nil/null/undefined nuances.
+				enhancedAST["aggregate"] = []report.Aggregate{}
+			} else {
+				enhancedAST["aggregate"] = aggregates
+			}
 			resultSet, err := linterQuery.Eval(ctx, rego.EvalInput(enhancedAST))
 			if err != nil {
 				errCh <- fmt.Errorf("error encountered in query evaluation %w", err)
@@ -465,6 +478,7 @@ func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input) (repor
 
 			mu.Lock()
 			aggregate.Violations = append(aggregate.Violations, result.Violations...)
+			aggregate.Aggregates = append(aggregate.Aggregates, result.Aggregates...)
 			mu.Unlock()
 		}(name)
 	}
@@ -675,4 +689,67 @@ func (l Linter) getBundleByName(name string) (*bundle.Bundle, error) {
 	}
 
 	return nil, fmt.Errorf("no regal bundle found")
+}
+
+func (l Linter) collectAggregates(ctx context.Context, input rules.Input) ([]report.Aggregate, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	regoArgs := l.prepareRegoArgs(ast.MustParseBody("aggregates = data.regal.main.aggregate"))
+
+	linterQuery, err := rego.New(regoArgs...).PrepareForEval(ctx)
+	if err != nil {
+		return []report.Aggregate{}, fmt.Errorf("failed preparing query for linting: %w", err)
+	}
+
+	var result []report.Aggregate
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	errCh := make(chan error)
+	doneCh := make(chan bool)
+
+	for _, name := range input.FileNames {
+		wg.Add(1)
+
+		go func(name string) {
+			defer wg.Done()
+
+			enhancedAST, err := parse.EnhanceAST(name, input.FileContent[name], input.Modules[name])
+			if err != nil {
+				errCh <- fmt.Errorf("failed preparing AST: %w", err)
+				return
+			}
+
+			resultSet, err := linterQuery.Eval(ctx, rego.EvalInput(enhancedAST))
+			if err != nil {
+				errCh <- fmt.Errorf("error encountered in query evaluation %w", err)
+				return
+			}
+
+			ruleReport, err := resultSetToReport(resultSet)
+			if err != nil {
+				errCh <- fmt.Errorf("failed to convert result set to report: %w", err)
+				return
+			}
+
+			mu.Lock()
+			result = append(result, ruleReport.Aggregates...)
+			mu.Unlock()
+		}(name)
+	}
+
+	go func() {
+		wg.Wait()
+		doneCh <- true
+	}()
+
+	select {
+	case <-ctx.Done():
+		return []report.Aggregate{}, fmt.Errorf("context cancelled: %w", ctx.Err())
+	case err := <-errCh:
+		return []report.Aggregate{}, fmt.Errorf("error encountered in rule evaluation %w", err)
+	case <-doneCh:
+		return result, nil
+	}
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -27,6 +27,12 @@ type Violation struct {
 	Location         Location          `json:"location,omitempty"`
 }
 
+// An Aggregate is data collected by some rule while processing a file AST, to be used later by other rules needing a
+// global context (i.e. broader than per-file)
+// Rule authors are expected to collect the minimum needed data, to avoid performance problems
+// while working with large Rego code repositories.
+type Aggregate map[string]any
+
 type Summary struct {
 	FilesScanned  int `json:"files_scanned"`
 	FilesFailed   int `json:"files_failed"`
@@ -37,6 +43,9 @@ type Summary struct {
 // Report aggregate of Violation as returned by a linter run.
 type Report struct {
 	Violations []Violation `json:"violations"`
+	// We don't have aggregates when publishing the final report (see JSONReporter), so omitempty is needed here
+	// to avoid surfacing a null/empty field.
+	Aggregates []Aggregate `json:"aggregates,omitempty"`
 	Summary    Summary     `json:"summary"`
 }
 


### PR DESCRIPTION
This (preliminary) addresses https://github.com/StyraInc/regal/issues/282

I'd recommend reviewing it commit by commit.

1) First commit: introduced the change in the simplest possible way. Unit and e2e tests still green.
2) Second change: the added function (`collectAggregates`) duplicates the file iteration logic happening goroutines in `lintWithRegoRules`. The common logic is extracted into a new third function, `evalAndCollect`. This makes the diff a little messy, being the reason why it's in another comment.

Next actions: if this implementation is OK, I'll be happy to add more commits with unit tests and documentation updates (some expectations/guidance welcome) 

