### PR TITLE
Introduce broader scope for custom rules

### DIFF
--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -51,6 +51,13 @@ report contains violation if {
 	not ignored(violation, ignore_directives)
 }
 
+aggregate contains aggregate if {
+	some category, title
+	config.for_rule(category, title).level != "ignore"
+	not config.excluded_file(category, title, input.regal.file.name)
+	aggregate := data.custom.regal.rules[category][title].aggregate[_]
+}
+
 ignored(violation, directives) if {
 	ignored_rules := directives[violation.location.row]
 	violation.title in ignored_rules

--- a/e2e/testdata/aggregates/rego/policy_1.rego
+++ b/e2e/testdata/aggregates/rego/policy_1.rego
@@ -1,0 +1,3 @@
+package mypolicy1.public
+
+my_policy_1 := true

--- a/e2e/testdata/aggregates/rego/policy_2.rego
+++ b/e2e/testdata/aggregates/rego/policy_2.rego
@@ -1,0 +1,3 @@
+package mypolicy2.public
+
+export := []

--- a/e2e/testdata/aggregates/rules/custom_rules_using_aggregates.rego
+++ b/e2e/testdata/aggregates/rules/custom_rules_using_aggregates.rego
@@ -1,0 +1,20 @@
+# METADATA
+# description: Collect data in aggregates and validate it
+package custom.regal.rules.testcase["aggregates"]
+
+import future.keywords
+import data.regal.result
+
+aggregate contains entry if {
+    entry := { "file" : input.regal.file.name }
+}
+
+report contains violation if {
+	not two_files_processed
+    violation := result.fail(rego.metadata.chain(), {})
+}
+
+two_files_processed {
+	files := [x | x = input.aggregate[_].file]
+	count(files) == 2
+}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -218,7 +218,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 	var aggregates []report.Aggregate
 
 	if len(input.Modules) > 1 {
-		// No need to collect agregates if there's only one file
+		// No need to collect aggregates if there's only one file
 		aggregates, err = l.collectAggregates(ctx, input)
 		if err != nil {
 			return report.Report{}, fmt.Errorf("failed to collect aggregates using Rego rules: %w", err)

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -27,6 +27,12 @@ type Violation struct {
 	Location         Location          `json:"location,omitempty"`
 }
 
+// An Aggregate is data collected by some rule while processing a file AST, to be used later by other rules needing a
+// global context (i.e. broader than per-file)
+// Rule authors are expected to collect the minimum needed data, to avoid performance problems
+// while working with large Rego code repositories.
+type Aggregate map[string]any
+
 type Summary struct {
 	FilesScanned  int `json:"files_scanned"`
 	FilesFailed   int `json:"files_failed"`
@@ -37,6 +43,9 @@ type Summary struct {
 // Report aggregate of Violation as returned by a linter run.
 type Report struct {
 	Violations []Violation `json:"violations"`
+	// We don't have aggregates when publishing the final report (see JSONReporter), so omitempty is needed here
+	// to avoid surfacing a null/empty field.
+	Aggregates []Aggregate `json:"aggregates,omitempty"`
 	Summary    Summary     `json:"summary"`
 }
 


### PR DESCRIPTION
This (preliminary) addresses https://github.com/StyraInc/regal/issues/282

I'd recommend reviewing it commit by commit.

1) First commit: introduced the change in the simplest possible way. Unit and e2e tests still green.
2) Second change: the added function (`collectAggregates`) duplicates the file iteration logic happening goroutines in `lintWithRegoRules`. The common logic is extracted into a new third function, `evalAndCollect`. This makes the diff a little messy, being the reason why it's in another comment.

Next actions: if this implementation is OK, I'll be happy to add more commits with unit tests and documentation updates (some expectations/guidance welcome) 
