### PR TITLE
Add `--compare-to-readme` flag to `regal table`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,3 +23,4 @@ jobs:
       - run: chmod +x regal
       - run: ./regal lint --format github bundle
       - run: go test -tags e2e ./e2e
+      - run: go run main.go table --compare-to-readme bundle


### PR DESCRIPTION
And add check in CI so that we don't forget about this when any change would update the table, like when a new rule is added, or the name/description of a current one is modified.

Fixes #258