### PR TITLE
Store list of refs for use by rules

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -263,19 +263,27 @@ is_output_var(rule, ref, location) if {
 	not ref.value in (find_names_in_scope(rule, location) - find_some_decl_names_in_scope(rule, location))
 }
 
-# METADATA
-# description: |
-#   traverses all nodes under provided node (using `walk`), and returns an array with
-#   all calls to builtin functions
-find_builtin_calls(node) := [value |
-	walk(node, [path, value])
+all_refs := [value.value |
+	walk(input.rules, [_, value])
 
-	regal.last(path) == "terms"
-
-	value[0].type == "ref"
-	value[0].value[0].type == "var"
-	value[0].value[0].value in builtin_names
+	value.type == "ref"
 ]
+
+# METADATA
+# description: provides a set of all built-in function calls made in input policy
+builtin_functions_called contains name if {
+	some ref in all_refs
+
+	ref[0].type == "var"
+	not ref[0].value in {"input", "data"}
+
+	name := concat(".", [value |
+		some part in ref
+		value := part.value
+	])
+
+	name in builtin_names
+}
 
 # METADATA
 # description: |

--- a/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
@@ -6,6 +6,7 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 # Mapping of regex.* functions and the position(s)
@@ -21,7 +22,26 @@ re_pattern_functions := {
 	"template_match": [1],
 }
 
+re_pattern_function_names := {
+	"regex.find_all_string_submatch_n",
+	"regex.find_n",
+	"regex.globs_match",
+	"regex.is_valid",
+	"regex.match",
+	"regex.replace",
+	"regex.split",
+	"regex.template_match",
+}
+
+any_regex_function_called if {
+	some name in re_pattern_function_names
+	name in ast.builtin_functions_called
+}
+
 report contains violation if {
+	# skip expensive walk if no builtin regex function calls are registered
+	any_regex_function_called
+
 	walk(input.rules, [_, value])
 
 	value[0].type == "ref"

--- a/bundle/regal/rules/style/function_arg_return.rego
+++ b/bundle/regal/rules/style/function_arg_return.rego
@@ -14,6 +14,10 @@ cfg := config.for_rule("style", "function-arg-return")
 
 except_functions := array.concat(object.get(cfg, "except-functions", []), ["print"])
 
+part_to_string(ref) := ref.value if ref.type == "string"
+
+part_to_string(ref) := "$" if ref.type != "string"
+
 report contains violation if {
 	walk(input.rules, [path, value])
 
@@ -22,8 +26,15 @@ report contains violation if {
 	value[0].type == "ref"
 	value[0].value[0].type == "var"
 
-	fn_name := value[0].value[0].value
+	fn_name_parts := array.concat([value[0].value[0].value], [s |
+		some i, part in value[0].value
+		i > 0
+		s := part_to_string(part)
+	])
 
+	fn_name := concat(".", fn_name_parts)
+
+	not contains(fn_name, "$")
 	not fn_name in except_functions
 	fn_name in ast.all_function_names
 

--- a/bundle/regal/rules/style/function_arg_return_test.rego
+++ b/bundle/regal/rules/style/function_arg_return_test.rego
@@ -22,6 +22,22 @@ test_fail_function_arg_return_value if {
 	}}
 }
 
+test_fail_function_arg_return_value_multi_part_ref if {
+	r := rule.report with input as ast.policy(`foo := r { regex.match("foo", "foo", r) }`)
+		with config.for_rule as {"level": "error"}
+	r == {{
+		"category": "style",
+		"description": "Function argument used for return value",
+		"level": "error",
+		"location": {"col": 38, "file": "policy.rego", "row": 3, "text": `foo := r { regex.match("foo", "foo", r) }`},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/function-arg-return", "style"),
+		}],
+		"title": "function-arg-return",
+	}}
+}
+
 test_success_function_arg_return_value_except_function if {
 	r := rule.report with input as ast.with_future_keywords(`foo := i { indexof("foo", "o", i) }`)
 		with config.for_rule as {

--- a/bundle/regal/rules/testing/dubious_print_sprintf.rego
+++ b/bundle/regal/rules/testing/dubious_print_sprintf.rego
@@ -10,6 +10,9 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
+	# skip expensive walk operation if no print calls are registered
+	"print" in ast.builtin_functions_called
+
 	walk(input.rules, [_, value])
 
 	value[0].type == "ref"

--- a/bundle/regal/rules/testing/print_or_trace_call.rego
+++ b/bundle/regal/rules/testing/print_or_trace_call.rego
@@ -9,11 +9,19 @@ import future.keywords.in
 import data.regal.ast
 import data.regal.result
 
+print_or_trace_called if {
+	some name in {"print", "trace"}
+	name in ast.builtin_functions_called
+}
+
 report contains violation if {
-	some call in ast.find_builtin_calls(input)
+	# skip iteration of refs if no print or trace calls are registered
+	print_or_trace_called
 
-	name := call[0].value[0].value
-	name in {"print", "trace"}
+	some ref in ast.all_refs
 
-	violation := result.fail(rego.metadata.chain(), result.location(call[0].value[0]))
+	ref[0].type == "var"
+	ref[0].value in {"print", "trace"}
+
+	violation := result.fail(rego.metadata.chain(), result.location(ref[0]))
 }


### PR DESCRIPTION
And use this to guard expensive `walks` when possible

This gives a modest performance improvement:

**main**
```
go run main.go lint --enable-all ~/tmp/kics/assets  199.62s user 8.53s system 604% cpu 34.459 total
```

**change**
```
go run main.go lint --enable-all ~/tmp/kics/assets  183.42s user 8.19s system 588% cpu 32.560 total
```

But importantly, it'll allow more rules to use this guard in the future, as well as quickly retrieve all built-in functions called in a policy.

Also, fix a correctness issue in `function-arg-return`, where it previously would only report functions with a single part in their name, i.e. `indexof` but not `regex.match`.