### PR TITLE
Surface parse errors from input building

### DIFF
--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -41,12 +41,7 @@ func MustParseModule(policy string) *ast.Module {
 
 // Module works like ast.ParseModule but with the Regal parser options applied.
 func Module(filename, policy string) (*ast.Module, error) {
-	mod, err := ast.ParseModuleWithOpts(filename, policy, ParserOptions())
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse module: %w", err)
-	}
-
-	return mod, nil
+	return ast.ParseModuleWithOpts(filename, policy, ParserOptions()) // nolint:wrapcheck
 }
 
 // EnhanceAST TODO rename with https://github.com/StyraInc/regal/issues/86.

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"context"
-	"fmt"
 	"sort"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -78,7 +77,7 @@ func InputFromPaths(paths []string) (Input, error) {
 func InputFromText(fileName, text string) (Input, error) {
 	mod, err := parse.Module(fileName, text)
 	if err != nil {
-		return Input{}, fmt.Errorf("failed to parse module: %w", err)
+		return Input{}, err //nolint:wrapcheck
 	}
 
 	return NewInput(map[string]string{fileName: text}, map[string]*ast.Module{fileName: mod}), nil


### PR DESCRIPTION
This makes it possible to work with the parse errors when building integrations.

This change is also consistent with the behavior of: InputFromPaths.