### PR TITLE
Rule: `forbidden-function-call` (custom)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The following rules are currently available:
 | bugs      | [rule-shadows-builtin](https://docs.styra.com/regal/rules/bugs/rule-shadows-builtin)              | Rule name shadows built-in                                |
 | bugs      | [top-level-iteration](https://docs.styra.com/regal/rules/bugs/top-level-iteration)                | Iteration in top-level assignment                         |
 | bugs      | [unused-return-value](https://docs.styra.com/regal/rules/bugs/unused-return-value)                | Non-boolean return value unused                           |
+| custom    | [forbidden-function-call](https://docs.styra.com/regal/rules/custom/forbidden-function-call)      | Forbidden function call                                   |
 | custom    | [naming-convention](https://docs.styra.com/regal/rules/custom/naming-convention)                  | Naming convention violation                               |
 | idiomatic | [custom-has-key-construct](https://docs.styra.com/regal/rules/idiomatic/custom-has-key-construct) | Custom function may be replaced by `in` and `object.keys` |
 | idiomatic | [custom-in-construct](https://docs.styra.com/regal/rules/idiomatic/custom-in-construct)           | Custom function may be replaced by `in` keyword           |

--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -269,6 +269,17 @@ all_refs := [value.value |
 	value.type == "ref"
 ]
 
+ref_to_string(ref) := concat(".", [_ref_part_to_string(i, part) | some i, part in ref])
+
+_ref_part_to_string(0, ref) := ref.value
+
+_ref_part_to_string(_, ref) := ref.value if ref.type == "string"
+
+_ref_part_to_string(i, ref) := concat("", ["$", ref.value]) if {
+	ref.type != "string"
+	i > 0
+}
+
 # METADATA
 # description: provides a set of all built-in function calls made in input policy
 builtin_functions_called contains name if {

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -14,6 +14,12 @@ rules:
       level: error
     unused-return-value:
       level: error
+  custom:
+    forbidden-function-call:
+      level: ignore
+      forbidden-functions: []
+    naming-convention:
+      level: ignore
   idiomatic:
     custom-has-key-construct:
       level: error
@@ -25,9 +31,6 @@ rules:
       level: error
     use-some-for-output-vars:
       level: error
-  custom:
-    naming-convention:
-      level: ignore
   imports:
     avoid-importing-input:
       level: error
@@ -75,7 +78,7 @@ rules:
       level: error
   testing:
     dubious-print-sprintf:
-      level: error  
+      level: error
     file-missing-test-suffix:
       level: error
     identically-named-tests:

--- a/bundle/regal/result.rego
+++ b/bundle/regal/result.rego
@@ -96,6 +96,8 @@ with_text(location) := {"location": object.union(location, {"text": input.regal.
 
 location(x) := with_text(x.location) if x.location
 
+location(x) := with_text(x[0].location) if is_array(x)
+
 # Special case for comments, where this typo sadly is hard to change at this point
 location(x) := with_text(x.Location) if x.Location
 

--- a/bundle/regal/rules/custom/forbidden_function_call.rego
+++ b/bundle/regal/rules/custom/forbidden_function_call.rego
@@ -1,0 +1,30 @@
+# METADATA
+# description: Forbidden function call
+package regal.rules.custom["forbidden-function-call"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+import data.regal.result
+
+cfg := config.for_rule("custom", "forbidden-function-call")
+
+any_forbidden_function_called if {
+	some function in cfg["forbidden-functions"]
+	function in ast.builtin_functions_called
+}
+
+report contains violation if {
+	# avoid traversal if no forbidden function is called
+	any_forbidden_function_called
+
+	some ref in ast.all_refs
+
+	name := ast.ref_to_string(ref)
+	name in cfg["forbidden-functions"]
+
+	violation := result.fail(rego.metadata.chain(), result.location(ref))
+}

--- a/bundle/regal/rules/custom/forbidden_function_call_test.rego
+++ b/bundle/regal/rules/custom/forbidden_function_call_test.rego
@@ -1,0 +1,35 @@
+package regal.rules.custom["forbidden-function-call_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.custom["forbidden-function-call"] as rule
+
+test_fail_forbidden_function if {
+	module := ast.policy(`foo := http.send({"method": "GET", "url": "https://example.com"})`)
+
+	r := rule.report with input as module with config.for_rule as {
+		"level": "error",
+		"forbidden-functions": ["http.send"],
+	}
+
+	r == {{
+		"category": "custom",
+		"description": "Forbidden function call",
+		"level": "error",
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"text": `foo := http.send({"method": "GET", "url": "https://example.com"})`,
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/forbidden-function-call", "custom"),
+		}],
+		"title": "forbidden-function-call",
+	}}
+}

--- a/docs/rules/custom/forbidden-function-call.md
+++ b/docs/rules/custom/forbidden-function-call.md
@@ -1,0 +1,55 @@
+# forbidden-function-call
+
+**Summary**: Forbidden function call
+
+**Category**: Custom
+
+## Description
+
+This custom rule allows providing Regal a list of
+[built-in functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions) that should be
+considered forbidden. Any call to a function in the list will be reported as a violation.
+
+Another, more advanced, option to achieve the same result is the
+[capabilities](https://www.openpolicyagent.org/docs/latest/deployments/#capabilities) feature in OPA. While a more
+capable option, allowing things like:
+
+- Adding new custom built-in functions that OPA should be aware of
+- Disabling certain features not necessarily being built-in functions, like "future" keywords
+- List allowed hosts in network calls
+
+...it is also more demanding to configure and maintain. If you're already using the capabilities feature
+to forbid certain functions as part of your policy development process, there's no need to enable this rule.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  custom:
+    forbidden-function-call:
+      # note that all rules in the "custom" category are disabled by default
+      # (i.e. level "ignore") as some configuration needs to be provided by
+      # the user (i.e. you!) in order for them to be useful.
+      #
+      # one of "error", "warning", "ignore"
+      level: error
+      # Just an example — no functions forbidden by default
+      forbidden-functions:
+        # Prefer to use asymmetric algorithms
+        - io.jwt.verify_hs256
+        - io.jwt.verify_hs384
+        - io.jwt.verify_hs512
+```
+
+## Related Resources
+
+- OPA docs: [Capabilities](https://www.openpolicyagent.org/docs/latest/deployments/#capabilities)
+- OPA docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!


### PR DESCRIPTION
This rule allows teams and orgs to provide a list of built-in functions that Regal should treat as linter errors.

Fixes #223