### PR TITLE
Add rq `pr` task to help prepare for PRs

### DIFF
--- a/build/do.rq
+++ b/build/do.rq
@@ -1,12 +1,50 @@
 #!/usr/bin/env rq
 # rq: query data.script.main
-# rq: output null
+# rq: output /dev/null
+
+# METADATA
+# title: Regal build tasks
+# description: |
+#   This is the `rq` build tasks used by the Regal project. Note that `rq` is possibly not
+#   intended as a build tool, but if we can lint Rego with Rego, surely we can build Regal
+#   with Rego too?
+#
+#   To run one or more tasks, make sure to first have `rq` installed
+#   (https://git.sr.ht/~charles/rq), then from the project root directory, run:
+#
+#   build/do.rq <tasks>
+#
+#   For example, to run the `test` task, run:
+#
+#   build/do.rq test
+#
+# authors:
+#   - https://github.com/StyraInc/regal/graphs/contributors
+# related_resources:
+#   - description: rq
+#     ref: https://git.sr.ht/~charles/rq
+package script
+
 import future.keywords
 
-what := rq.args()[0]
-main := do[what] { true }
-else := job[what]
+main contains do[what]  if some what in rq.args()
+main contains job[what] if some what in rq.args()
+main contains job.tasks if {
+	count(rq.args()) == 0
+	print("No task(s) provided. Available tasks:")
+	print()
+}
 
+main contains null if {
+	count(rq.args()) == 1
+	rq.args()[0] == "--help"
+
+	print(rego.metadata.chain()[1].annotations.description)
+}
+
+# METADATA
+# title: pull_request
+# description: Run all task to verify a pull request
 do.pull_request {
 	some x in ["test", "lint", "e2e", "check_readme"]
 	github("::group::", x)
@@ -14,38 +52,151 @@ do.pull_request {
 	github("::endgroup::", x)
 }
 
+# METADATA
+# title: tasks
+# description: Prints the name of all available tasks
+job.tasks {
+	some task in tasks
+	print("-", sprintf("%-20s", [task[0]]), "\t", strings.replace_n({"\n": ""}, task[1]))
+}
+
+# METADATA
+# title: pr
+# description: |
+#   Run all recommended tasks before submitting a PR
+# related_resources:
+#   - https://github.com/daixiang0/gci
+#   - https://github.com/mvdan/gofumpt
+#   - https://github.com/golangci/golangci-lint
+#   - https://github.com/open-policy-agent/opa
 job.pr {
-	print("thanks for contributing")
+	# format
+	fmt_all
+	write_readme
+
+	# verify
+	golangcilint
+	lint
+	test
+	e2e
 }
 
+# METADATA
+# title: test
+# description: Run all Regal unit tests (Go and Rego)
 job.test {
-	run("go test ./...")
+	test
 }
 
+# METADATA
+# title: lint
+# description: Run `regal lint` on the Regal bundle
 job.lint {
 	build
-	run("./regal lint --format github bundle")
+	lint_ci
 }
 
+# METADATA
+# title: e2e
+# description: Run the Regal end-to-end tests
 job.e2e {
 	build
-	run("go test -tags e2e ./e2e")
+	e2e
 }
 
+# METADATA
+# title: check_readme
+# description: Verify that the rules table in the README is up-to-date
 job.check_readme {
 	build
-	run("./regal table --compare-to-readme bundle")
+	check_readme
+}
+
+# METADATA
+# title: fetch_metadata
+# description: Fetch the built-in metadata definitions and store them in the bundle
+job.fetch_metadata {
+	out := rq.run([
+		"opa", "eval",
+		"--format", "pretty",
+		"--data", sprintf("%s/%s", [rq.dir(rq.scriptpath()), "builtin_metadata.rego"]),
+		"data.build.metadata.builtin_metadata"
+	], {})
+	spec := sprintf("raw:%s/../bundle/regal/opa/builtins/data.json", [rq.dir(rq.scriptpath())])
+
+	rq.write(out.stdout, spec)
 }
 
 build {
 	run("go build")
 }
 
+test {
+	run("go test ./...")
+}
+
+e2e {
+	run("go test -tags e2e ./e2e")
+}
+
+lint {
+	run("./regal lint --format pretty bundle")
+}
+
+lint_ci {
+	run("./regal lint --format github bundle")
+}
+
+check_readme {
+	run("./regal table --compare-to-readme bundle")
+}
+
+write_readme {
+	run("./regal table --write-to-readme bundle")
+}
+
+fmt_all {
+	gci
+	gofumpt
+	opafmt
+}
+
+gci {
+	run(concat(" ", [
+		"gci write",
+		"-s standard",
+		"-s default",
+		"-s prefix(github.com/open-policy-agent/opa)",
+		"-s prefix(github.com/styrainc/regal)",
+		"-s blank",
+		"-s dot",
+		".",
+	]))
+}
+
+gofumpt {
+	run("gofumpt -w .")
+}
+
+opafmt {
+	run("opa fmt --write bundle")
+}
+
+golangcilint {
+	run("golangci-lint run ./...")
+}
+
+tasks := sort([[annotation.title, annotation.description] |
+	# Right, like you never used the AST for reflection?
+	some annotation in json.unmarshal(rq.run(["./regal", "parse", rq.scriptpath()], {}).stdout).annotations
+	annotation.scope == "rule"
+])
+
 run(cmd) {
 	print(cmd)
 	args := split(cmd, " ")
 	out := rq.run(args, {})
-	{ rq.error(sprintf("stdout: %s; stderr: %s", [out.stdout, out.stderr])) | out.exitcode != 0 }
+	{ rq.error(sprintf("\nstdout: %s\nstderr: %s", [out.stdout, out.stderr])) | out.exitcode != 0 }
 	print(out.stdout)
 }
 

--- a/build/fetch_builtin_data.sh
+++ b/build/fetch_builtin_data.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)
-
-result=$(opa eval --format pretty --data "$SCRIPT_DIR/builtin_metadata.rego" 'data.build.metadata.builtin_metadata')
-
-echo "${result}" > "$SCRIPT_DIR/../bundle/regal/opa/builtins/data.json"

--- a/bundle/regal/opa/builtins/data.json
+++ b/bundle/regal/opa/builtins/data.json
@@ -2980,6 +2980,19 @@
       "type": "string"
     }
   },
+  "uuid.parse": {
+    "args": [
+      {
+        "name": "uuid",
+        "type": "string"
+      }
+    ],
+    "result": {
+      "description": "Properties of UUID if valid (version, variant, etc). Undefined otherwise.",
+      "name": "result",
+      "type": "object[string: any]"
+    }
+  },
   "uuid.rfc4122": {
     "args": [
       {

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,21 @@ If you'd like to contribute to Regal, here are some pointers to help get you sta
 Before you start, the [architecture](./architecture) guide provides a useful overview of how Regal works, so you might
 want to read that before diving into the code!
 
+## Prerequisites
+
+The following tools are required to build, test and lint Regal:
+
+- The latest version of [Go](https://go.dev/doc/install)
+- The [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) linter
+- The [gci](https://github.com/daixiang0/gci) import formatter
+- The [gofumpt](https://github.com/mvdan/gofumpt) formatter
+
+Recommended, but not required:
+
+- The [rq](https://git.sr.ht/~charles/rq) tool. This is used for automating and simplifying many of the tasks outlined
+  in this document, and is (ab)used as a Rego-based replacement for Make in this project. Check out the
+  [do.rq](../build/do.rq) file to see what that looks like, and for documentation on the available tasks.
+
 ## Contributing New Rules
 
 If you'd like to contribute a new built-in rule, the simplest way to get started is to run the `regal new rule` command.
@@ -33,7 +48,7 @@ or ask for advice in the `#regal` channel in the Styra Community [Slack](https:/
 
 ## Building
 
-Build the `regal` executable simply by running `go build`.
+Build the `regal` executable simply by running `go build`, or with `rq` installed, by running `build/do.rq build`.
 
 Occasionally you may want to run the `fetch_builtin_data.sh` script from inside the `build` directory. This will
 populate the `data` directory with any data necessary for linting (such as the built-in function metadata from OPA).
@@ -52,6 +67,12 @@ To run all tests — Go and Rego:
 go test ./...
 ```
 
+Or using `rq`:
+
+```shell
+build/do.rq test
+```
+
 ### E2E tests
 
 End-to-End (E2E) tests assert the behaviour of the `regal` binary called with certain configs, and test files.
@@ -60,6 +81,12 @@ locally via
 
 ```shell
 go test -tags e2e ./e2e
+```
+
+Alternatively, using `rq`:
+
+```shell
+build/do.rq e2e
 ```
 
 ## Linting
@@ -82,6 +109,18 @@ gci write \
   -s blank \
   -s dot .
 ```
+
+## Preparing a pull request
+
+Using `rq`, run all the required steps with:
+
+```shell
+build/do.rq pr
+```
+
+This will run all the formatters, linters and tests. Make sure all of them pass before submitting your PR. If there's
+anything you can't figure out, don't hesitate to ask for help in the `#regal` Slack channel (see `Community` below).
+
 ## Documentation
 
 The table in the [Rules](../README.md#rules) section of the README is generated with the following command:


### PR DESCRIPTION
And have some fun while trying out `rq` as a build tool:

- Allow more than one task to be provided to `do.rq`
- Add `do.rq tasks` command to list all tasks (hack alert!)
- Replace shell script to fetch built-in metadata definitions with `do.rq fetch_metadata` command
- Add metadata annotations to package and tasks (used in `tasks` command via hack)
- Update development docs to include prerequisites and references to the `rq` tool, and a section for how to prepare a PR.

`do.rq tasks` in action:

![Screenshot 2023-09-14 at 10 05 02](https://github.com/StyraInc/regal/assets/510711/de89ea6e-f9ce-4dab-86d0-3b1d23d8f86a)



Fixes #269