### PR TITLE
Implement Aggregates Collection and Usage

### DIFF
--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -51,6 +51,13 @@ report contains violation if {
 	not ignored(violation, ignore_directives)
 }
 
+aggregate contains aggregate if {
+	some category, title
+	config.for_rule(category, title).level != "ignore"
+	not config.excluded_file(category, title, input.regal.file.name)
+	aggregate := data.custom.regal.rules[category][title].aggregate[_]
+}
+
 ignored(violation, directives) if {
 	ignored_rules := directives[violation.location.row]
 	violation.title in ignored_rules

--- a/e2e/testdata/aggregates/rego/policy_1.rego
+++ b/e2e/testdata/aggregates/rego/policy_1.rego
@@ -1,0 +1,3 @@
+package mypolicy1.public
+
+my_policy_1 := true

--- a/e2e/testdata/aggregates/rego/policy_2.rego
+++ b/e2e/testdata/aggregates/rego/policy_2.rego
@@ -1,0 +1,3 @@
+package mypolicy2.public
+
+export := []

--- a/e2e/testdata/aggregates/rules/custom_rules_using_aggregates.rego
+++ b/e2e/testdata/aggregates/rules/custom_rules_using_aggregates.rego
@@ -1,0 +1,20 @@
+# METADATA
+# description: Collect data in aggregates and validate it
+package custom.regal.rules.testcase["aggregates"]
+
+import future.keywords
+import data.regal.result
+
+aggregate contains entry if {
+    entry := { "file" : input.regal.file.name }
+}
+
+report contains violation if {
+	not two_files_processed
+    violation := result.fail(rego.metadata.chain(), {})
+}
+
+two_files_processed {
+	files := [x | x = input.aggregate[_].file]
+	count(files) == 2
+}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -277,7 +277,6 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 	}
 
 	return aggregateReport, nil
-
 }
 
 func (l Linter) lintWithGoRules(ctx context.Context, input rules.Input) (report.Report, error) {
@@ -481,7 +480,9 @@ func (l Linter) prepareRegoArgs(query ast.Body) []func(*rego.Rego) {
 	return regoArgs
 }
 
-func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input, aggregates []report.Aggregate) (report.Report, error) {
+func (l Linter) lintWithRegoRules(
+	ctx context.Context, input rules.Input, aggregates []report.Aggregate,
+) (report.Report, error) {
 	l.startTimer(regalmetrics.RegalLintRego)
 	defer l.stopTimer(regalmetrics.RegalLintRego)
 
@@ -517,7 +518,7 @@ func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input, aggreg
 				return
 			}
 
-			if aggregates != nil && len(aggregates) > 0 {
+			if len(aggregates) > 0 {
 				enhancedAST["aggregate"] = aggregates
 			}
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -27,6 +27,12 @@ type Violation struct {
 	Location         Location          `json:"location,omitempty"`
 }
 
+// An Aggregate is data collected by some rule while processing a file AST, to be used later by other rules needing a
+// global context (i.e. broader than per-file)
+// Rule authors are expected to collect the minimum needed data, to avoid performance problems
+// while working with large Rego code repositories.
+type Aggregate map[string]any
+
 type Summary struct {
 	FilesScanned  int `json:"files_scanned"`
 	FilesFailed   int `json:"files_failed"`
@@ -37,6 +43,9 @@ type Summary struct {
 // Report aggregate of Violation as returned by a linter run.
 type Report struct {
 	Violations []Violation `json:"violations"`
+	// We don't have aggregates when publishing the final report (see JSONReporter), so omitempty is needed here
+	// to avoid surfacing a null/empty field.
+	Aggregates []Aggregate `json:"-"`
 	Summary    Summary     `json:"summary"`
 }
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -45,7 +45,7 @@ type Report struct {
 	Violations []Violation `json:"violations"`
 	// We don't have aggregates when publishing the final report (see JSONReporter), so omitempty is needed here
 	// to avoid surfacing a null/empty field.
-	Aggregates []Aggregate `json:"-"`
+	Aggregates []Aggregate `json:"aggregates,omitempty"`
 	Summary    Summary     `json:"summary"`
 }
 


### PR DESCRIPTION
Feature described by: https://github.com/StyraInc/regal/issues/282

Summary: 

This change allows custom rules to collect aggregate data while processing a file AST, which can be used later by other linter rules that require a global context.

Highlights of the change:

1. Added a new feature in the linter to collect aggregates. This is done by creating a new type `Aggregate` that collects data while processing a file AST and can be used later by other rules that need a global context.
2. Modified the `lintWithRegoRules` function to include the aggregates in the evaluation process.
3. Created a helper function `evalAndCollect` to extract common code that processes each file in a goroutine.
4. Updated the end-to-end testing to include the aggregates in the testing process. This includes positive and negative tests.

