### PR TITLE
Metrics

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,12 @@
+package metrics
+
+const (
+	RegalConfigSearch         = "regal_config_search"
+	RegalConfigParse          = "regal_config_parse"
+	RegalFilterIgnoredFiles   = "regal_filter_ignored_files"
+	RegalFilterIgnoredModules = "regal_filter_ignored_modules"
+	RegalInputParse           = "regal_input_parse"
+	RegalLint                 = "regal_lint_total"
+	RegalLintGo               = "regal_lint_go"
+	RegalLintRego             = "regal_lint_rego"
+)

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -1,6 +1,8 @@
 package report
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // RelatedResource provides documentation on a violation.
 type RelatedResource struct {
@@ -36,8 +38,9 @@ type Summary struct {
 
 // Report aggregate of Violation as returned by a linter run.
 type Report struct {
-	Violations []Violation `json:"violations"`
-	Summary    Summary     `json:"summary"`
+	Violations []Violation    `json:"violations"`
+	Summary    Summary        `json:"summary"`
+	Metrics    map[string]any `json:"metrics,omitempty"`
 }
 
 // ViolationsFileCount returns the number of files containing violations.

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -1,6 +1,7 @@
 package reporter
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -16,7 +17,7 @@ import (
 // Reporter releases linter reports in a format decided by the implementation.
 type Reporter interface {
 	// Publish releases a report to any appropriate target
-	Publish(report.Report) error
+	Publish(context.Context, report.Report) error
 }
 
 // PrettyReporter is a Reporter for representing reports as tables.
@@ -60,7 +61,7 @@ func NewGitHubReporter(out io.Writer) GitHubReporter {
 }
 
 // Publish prints a pretty report to the configured output.
-func (tr PrettyReporter) Publish(r report.Report) error {
+func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 	table := buildPrettyViolationsTable(r.Violations)
 
 	pluralScanned := ""
@@ -137,7 +138,7 @@ func buildPrettyViolationsTable(violations []report.Violation) string {
 }
 
 // Publish prints a compact report to the configured output.
-func (tr CompactReporter) Publish(r report.Report) error {
+func (tr CompactReporter) Publish(_ context.Context, r report.Report) error {
 	table := uitable.New()
 	table.MaxColWidth = 80
 	table.Wrap = true
@@ -152,7 +153,7 @@ func (tr CompactReporter) Publish(r report.Report) error {
 }
 
 // Publish prints a JSON report to the configured output.
-func (tr JSONReporter) Publish(r report.Report) error {
+func (tr JSONReporter) Publish(_ context.Context, r report.Report) error {
 	if r.Violations == nil {
 		r.Violations = []report.Violation{}
 	}
@@ -168,7 +169,7 @@ func (tr JSONReporter) Publish(r report.Report) error {
 }
 
 //nolint:nestif
-func (tr GitHubReporter) Publish(r report.Report) error {
+func (tr GitHubReporter) Publish(_ context.Context, r report.Report) error {
 	if r.Violations == nil {
 		r.Violations = []report.Violation{}
 	}

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -2,6 +2,7 @@ package reporter
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/styrainc/regal/pkg/report"
@@ -65,7 +66,7 @@ func TestPrettyReporterPublish(t *testing.T) {
 
 	pr := NewPrettyReporter(&buf)
 
-	err := pr.Publish(rep)
+	err := pr.Publish(context.Background(), rep)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +85,7 @@ func TestPrettyReporterPublishNoViolations(t *testing.T) {
 
 	pr := NewPrettyReporter(&buf)
 
-	err := pr.Publish(report.Report{})
+	err := pr.Publish(context.Background(), report.Report{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -101,7 +102,7 @@ func TestCompactReporterPublish(t *testing.T) {
 
 	cr := NewCompactReporter(&buf)
 
-	err := cr.Publish(rep)
+	err := cr.Publish(context.Background(), rep)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +123,7 @@ func TestCompactReporterPublishNoViolations(t *testing.T) {
 
 	cr := NewCompactReporter(&buf)
 
-	err := cr.Publish(report.Report{})
+	err := cr.Publish(context.Background(), report.Report{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,7 +140,7 @@ func TestJSONReporterPublish(t *testing.T) {
 
 	jr := NewJSONReporter(&buf)
 
-	err := jr.Publish(rep)
+	err := jr.Publish(context.Background(), rep)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +204,7 @@ func TestJSONReporterPublishNoViolations(t *testing.T) {
 
 	jr := NewJSONReporter(&buf)
 
-	err := jr.Publish(report.Report{})
+	err := jr.Publish(context.Background(), report.Report{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +232,7 @@ func TestGitHubReporterPublish(t *testing.T) {
 
 	cr := NewGitHubReporter(&buf)
 
-	err := cr.Publish(rep)
+	err := cr.Publish(context.Background(), rep)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +256,7 @@ func TestGitHubReporterPublishNoViolations(t *testing.T) {
 
 	cr := NewGitHubReporter(&buf)
 
-	err := cr.Publish(report.Report{})
+	err := cr.Publish(context.Background(), report.Report{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Add Regal-specific metrics in order to know what's taking the most time in linter evaluation.

Also:
* Pass metrics to EvalMetrics to get insights from OPA too
* Have Publish functions accept a context. Unused for now but could be useful later.

Fixes #26