### PR TITLE
Unmarshalling: Remove extra attributes "level" and "ignore"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -160,6 +160,9 @@ func (rule *Rule) UnmarshalYAML(value *yaml.Node) error {
 	return rule.mapToConfig(result) //nolint:errcheck
 }
 
+// Note that this function will mutate the result map. This isn't a problem right now
+// as we only use this after unmarshalling, but if we use this for other purposes later
+// we need to make a copy of the map first.
 func (rule *Rule) mapToConfig(result map[string]any) error {
 	level, ok := result["level"].(string)
 	if ok {
@@ -178,6 +181,9 @@ func (rule *Rule) mapToConfig(result map[string]any) error {
 	}
 
 	rule.Extra = result
+
+	delete(rule.Extra, "level")
+	delete(rule.Extra, "ignore")
 
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -113,3 +113,51 @@ func TestMarshalConfig(t *testing.T) {
 		t.Errorf("expected %s, got %s", expect, string(bs))
 	}
 }
+
+func TestUnmarshalConfig(t *testing.T) {
+	t.Parallel()
+
+	bs := []byte(`rules:
+  testing:
+    foo:
+      bar: baz
+      ignore:
+        files:
+          - foo.rego
+      level: error
+`)
+
+	var conf Config
+
+	if err := yaml.Unmarshal(bs, &conf); err != nil {
+		t.Fatal(err)
+	}
+
+	if conf.Rules["testing"]["foo"].Level != "error" {
+		t.Errorf("expected level to be error")
+	}
+
+	if conf.Rules["testing"]["foo"].Ignore == nil {
+		t.Errorf("expected ignore attribute to be set")
+	}
+
+	if len(conf.Rules["testing"]["foo"].Ignore.Files) != 1 {
+		t.Errorf("expected ignore files to be set")
+	}
+
+	if conf.Rules["testing"]["foo"].Ignore.Files[0] != "foo.rego" {
+		t.Errorf("expected ignore files to contain foo.rego")
+	}
+
+	if conf.Rules["testing"]["foo"].Extra["bar"] != "baz" {
+		t.Errorf("expected extra attribute 'bar' to be baz")
+	}
+
+	if conf.Rules["testing"]["foo"].Extra["ignore"] != nil {
+		t.Errorf("expected extra attribute 'ignore' to be removed")
+	}
+
+	if conf.Rules["testing"]["foo"].Extra["level"] != nil {
+		t.Errorf("expected extra attribute 'level' to be removed")
+	}
+}


### PR DESCRIPTION
As these are assigned to "real" struct attributes, they should not be present in extra attributes too.

Add test to verify.

From discussion in #304