### PR TITLE
Remove code that set the ref head env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Regal
 
 [![Build Status](https://github.com/styrainc/regal/workflows/Build/badge.svg?branch=main)](https://github.com/styrainc/regal/actions)
-![OPA v0.56.0](https://openpolicyagent.org/badge/v0.56.0)
+![OPA v0.57.0](https://openpolicyagent.org/badge/v0.57.0)
 
 Regal is a linter for [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/), with the goal of making your
 Rego magnificent!

--- a/internal/test/rego_test.go
+++ b/internal/test/rego_test.go
@@ -15,11 +15,8 @@ import (
 	"github.com/styrainc/regal/pkg/builtins"
 )
 
-// nolint:paralleltest,tparallel
 func TestRunRegoUnitTests(t *testing.T) {
-	// TODO: Temporary until this requirement is removed from OPA
-	//       Once removed, re-add t.Parallel()
-	t.Setenv("EXPERIMENTAL_GENERAL_RULE_REFS", "true")
+	t.Parallel()
 
 	ctx := context.Background()
 	bdl := filepath.Join("..", "..", "bundle")

--- a/main.go
+++ b/main.go
@@ -12,11 +12,6 @@ func main() {
 	// Evaluate options for logging later
 	log.SetFlags(0)
 
-	// TODO: Temporary until this requirement is removed from OPA
-	if err := os.Setenv("EXPERIMENTAL_GENERAL_RULE_REFS", "true"); err != nil {
-		log.Fatal(err)
-	}
-
 	if err := cmd.RootCommand.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -3,8 +3,6 @@ package linter
 import (
 	"bytes"
 	"context"
-	"log"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -16,15 +14,6 @@ import (
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/rules"
 )
-
-func TestMain(m *testing.M) {
-	// Temporary until this requirement is removed from OPA
-	if err := os.Setenv("EXPERIMENTAL_GENERAL_RULE_REFS", "true"); err != nil {
-		log.Fatal(err)
-	}
-
-	os.Exit(m.Run())
-}
 
 func TestLintWithDefaultBundle(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
We don't need that anymore since @johanfylling bumped us up to v0.57.0