### PR TITLE
Rule: `rule-length`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ The following rules are currently available:
 | style     | [opa-fmt](https://docs.styra.com/regal/rules/style/opa-fmt)                                       | File should be formatted with `opa fmt`                   |
 | style     | [prefer-snake-case](https://docs.styra.com/regal/rules/style/prefer-snake-case)                   | Prefer snake_case for names                               |
 | style     | [prefer-some-in-iteration](https://docs.styra.com/regal/rules/style/prefer-some-in-iteration)     | Prefer `some .. in` for iteration                         |
+| style     | [rule-length](https://docs.styra.com/regal/rules/style/rule-length)                               | Max rule length exceeded                                  |
 | style     | [todo-comment](https://docs.styra.com/regal/rules/style/todo-comment)                             | Avoid TODO comments                                       |
 | style     | [unconditional-assignment](https://docs.styra.com/regal/rules/style/unconditional-assignment)     | Unconditional assignment in rule body                     |
 | style     | [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)       | Prefer := over = for assignment                           |

--- a/bundle/regal/ast_test.rego
+++ b/bundle/regal/ast_test.rego
@@ -5,6 +5,7 @@ import future.keywords.in
 
 import data.regal.ast
 
+# regal ignore:rule-length
 test_find_vars if {
 	policy := `
 	package p
@@ -116,7 +117,7 @@ allow := true
 	blocks := ast.comment_blocks(module.comments)
 	blocks == [
 		[
-			{"Location": {"col": 1, "file": "p.rego", "row": 3}, "Text": "IE1FVEFEQVRB"},
+			{"Location": {"col": 1, "file": "p.rego", "row": 3, "text": "IyBNRVRBREFUQQ=="}, "Text": "IE1FVEFEQVRB"},
 			{"Location": {"col": 1, "file": "p.rego", "row": 4}, "Text": "IHRpdGxlOiBmb28="},
 			{"Location": {"col": 1, "file": "p.rego", "row": 5}, "Text": "IGJhcjogaW52YWxpZA=="},
 		],
@@ -128,6 +129,7 @@ allow := true
 	]
 }
 
+# regal ignore:rule-length
 test_find_vars_in_local_scope if {
 	policy := `
 	package p
@@ -181,10 +183,10 @@ test_find_vars_in_local_scope_complex_comprehension_term if {
 	allow_rule := module.rules[0]
 
 	ast.find_vars_in_local_scope(allow_rule, {"col": 10, "row": 10}) == [
-		{"location": {"col": 3, "file": "p.rego", "row": 7}, "type": "var", "value": "a"},
-		{"location": {"col": 15, "file": "p.rego", "row": 7}, "type": "var", "value": "b"},
-		{"location": {"col": 20, "file": "p.rego", "row": 7}, "type": "var", "value": "c"},
-		{"location": {"col": 31, "file": "p.rego", "row": 7}, "type": "var", "value": "b"},
+		{"location": {"col": 3, "file": "p.rego", "row": 7, "text": "YQ=="}, "type": "var", "value": "a"},
+		{"location": {"col": 15, "file": "p.rego", "row": 7, "text": "Yg=="}, "type": "var", "value": "b"},
+		{"location": {"col": 20, "file": "p.rego", "row": 7, "text": "Yw=="}, "type": "var", "value": "c"},
+		{"location": {"col": 31, "file": "p.rego", "row": 7, "text": "Yg=="}, "type": "var", "value": "b"},
 	]
 }
 
@@ -212,11 +214,9 @@ test_find_names_in_scope if {
 	}`
 
 	module := regal.parse_module("p.rego", policy)
-
 	allow_rule := module.rules[3]
 
 	in_scope := ast.find_names_in_scope(allow_rule, {"col": 1, "row": 30}) with input as module
-
 	in_scope == {"bar", "global", "comp", "allow", "a", "b", "c", "d", "e"}
 }
 

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -72,6 +72,10 @@ rules:
     prefer-some-in-iteration:
       level: error
       ignore-nesting-level: 2
+    rule-length:
+      except-empty-body: true
+      level: error
+      max-rule-length: 30
     todo-comment:
       level: error
     unconditional-assignment:

--- a/bundle/regal/result_test.rego
+++ b/bundle/regal/result_test.rego
@@ -83,6 +83,7 @@ test_related_resources_generated_by_result_fail_for_builtin_rule if {
 	}
 }
 
+# regal ignore:rule-length
 test_aggregate_function_builtin_rule if {
 	chain := [
 		{"path": ["regal", "rules", "testing", "aggregation", "report"]},
@@ -99,7 +100,6 @@ test_aggregate_function_builtin_rule if {
 		"regal": {"file": {"name": "policy.rego"}},
 		"package": {"path": [{"value": "data"}, {"value": "a"}, {"value": "b"}, {"value": "c"}]},
 	}
-
 	r == {
 		"rule": {
 			"category": "testing",
@@ -127,12 +127,10 @@ test_aggregate_function_custom_rule if {
 			"path": ["custom", "regal", "rules", "testing", "aggregation"],
 		},
 	]
-
 	r := result.aggregate(chain, {"foo": "bar", "baz": [1, 2, 3]}) with input as {
 		"regal": {"file": {"name": "policy.rego"}},
 		"package": {"path": [{"value": "data"}, {"value": "a"}, {"value": "b"}, {"value": "c"}]},
 	}
-
 	r == {
 		"rule": {
 			"category": "testing",

--- a/bundle/regal/rules/custom/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming_convention.rego
@@ -24,7 +24,7 @@ report contains violation if {
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(input["package"])),
 		sprintf(
-			"Naming convention violation: package name %q does not match pattern %q",
+			"Naming convention violation: package name %q does not match pattern '%s'",
 			[ast.package_name, convention.pattern],
 		),
 	)
@@ -45,7 +45,7 @@ report contains violation if {
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
 		sprintf(
-			"Naming convention violation: rule name %q does not match pattern %q",
+			"Naming convention violation: rule name %q does not match pattern '%s'",
 			[ast.name(rule), convention.pattern],
 		),
 	)
@@ -66,7 +66,7 @@ report contains violation if {
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
 		sprintf(
-			"Naming convention violation: function name %q does not match pattern %q",
+			"Naming convention violation: function name %q does not match pattern '%s'",
 			[ast.name(rule), convention.pattern],
 		),
 	)
@@ -86,7 +86,7 @@ report contains violation if {
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(var)),
 		sprintf(
-			"Naming convention violation: variable name %q does not match pattern %q",
+			"Naming convention violation: variable name %q does not match pattern '%s'",
 			[var.value, convention.pattern],
 		),
 	)

--- a/bundle/regal/rules/custom/naming_convention_test.rego
+++ b/bundle/regal/rules/custom/naming_convention_test.rego
@@ -12,18 +12,10 @@ test_fail_package_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["package"], "pattern": `^foo\.bar\..+$`}],
 	}
 	r := rule.report with input as regal.parse_module("policy.rego", "package foo.bar") with config.for_rule as cfg
-	r == {{
-		"category": "custom",
-		# regal ignore:line-length
-		"description": "Naming convention violation: package name \"foo.bar\" does not match pattern \"^foo\\\\.bar\\\\..+$\"",
-		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
-		"related_resources": [{
-			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
-		}],
-		"title": "naming-convention",
-	}}
+	r == {expected(
+		`Naming convention violation: package name "foo.bar" does not match pattern '^foo\.bar\..+$'`,
+		{"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
+	)}
 }
 
 test_success_package_name_matches_pattern if {
@@ -41,17 +33,10 @@ test_fail_rule_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["rule"], "pattern": "^[a-z]+$"}],
 	}
 	r := rule.report with input as ast.policy(`FOO := true`) with config.for_rule as cfg
-	r == {{
-		"category": "custom",
-		"description": "Naming convention violation: rule name \"FOO\" does not match pattern \"^[a-z]+$\"",
-		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "FOO := true"},
-		"related_resources": [{
-			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
-		}],
-		"title": "naming-convention",
-	}}
+	r == {expected(
+		`Naming convention violation: rule name "FOO" does not match pattern '^[a-z]+$'`,
+		{"col": 1, "file": "policy.rego", "row": 3, "text": "FOO := true"},
+	)}
 }
 
 test_success_rule_name_matches_pattern if {
@@ -69,17 +54,10 @@ test_fail_function_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["function"], "pattern": "^[a-z]+$"}],
 	}
 	r := rule.report with input as ast.policy(`fooBar(_) := true`) with config.for_rule as cfg
-	r == {{
-		"category": "custom",
-		"description": "Naming convention violation: function name \"fooBar\" does not match pattern \"^[a-z]+$\"",
-		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "fooBar(_) := true"},
-		"related_resources": [{
-			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
-		}],
-		"title": "naming-convention",
-	}}
+	r == {expected(
+		`Naming convention violation: function name "fooBar" does not match pattern '^[a-z]+$'`,
+		{"col": 1, "file": "policy.rego", "row": 3, "text": "fooBar(_) := true"},
+	)}
 }
 
 test_success_function_name_matches_pattern if {
@@ -103,17 +81,10 @@ test_fail_var_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["variable"], "pattern": "^[a-z_]+$"}],
 	}
 	r := rule.report with input as policy with config.for_rule as cfg
-	r == {{
-		"category": "custom",
-		"description": "Naming convention violation: variable name \"fooBar\" does not match pattern \"^[a-z_]+$\"",
-		"level": "error",
-		"location": {"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tfooBar := true"},
-		"related_resources": [{
-			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
-		}],
-		"title": "naming-convention",
-	}}
+	r == {expected(
+		`Naming convention violation: variable name "fooBar" does not match pattern '^[a-z_]+$'`,
+		{"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tfooBar := true"},
+	)}
 }
 
 test_success_var_name_matches_pattern if {
@@ -142,48 +113,35 @@ test_fail_multiple_conventions if {
 		fooBar == true
 	}
 	`)
-	cfg := {
-		"level": "error",
-		"conventions": [
-			{"targets": ["package"], "pattern": `^acmecorp\.[a-z_\.]+$`},
-			{"targets": ["rule", "variable"], "pattern": "^bar$|^foo_bar$"},
-		],
-	}
+	cfg := {"level": "error", "conventions": [
+		{"targets": ["package"], "pattern": `^acmecorp\.[a-z_\.]+$`},
+		{"targets": ["rule", "variable"], "pattern": "^bar$|^foo_bar$"},
+	]}
 	r := rule.report with input as policy with config.for_rule as cfg
 	r == {
-		{
-			"category": "custom",
-			# regal ignore:line-length
-			"description": "Naming convention violation: package name \"foo.bar\" does not match pattern \"^acmecorp\\\\.[a-z_\\\\.]+$\"",
-			"level": "error",
-			"location": {"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
-			"related_resources": [{
-				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
-			}],
-			"title": "naming-convention",
-		},
-		{
-			"category": "custom",
-			"description": "Naming convention violation: rule name \"foo\" does not match pattern \"^bar$|^foo_bar$\"",
-			"level": "error",
-			"location": {"col": 2, "file": "policy.rego", "row": 3, "text": "\tfoo := true"},
-			"related_resources": [{
-				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
-			}],
-			"title": "naming-convention",
-		},
-		{
-			"category": "custom",
-			"description": "Naming convention violation: variable name \"fooBar\" does not match pattern \"^bar$|^foo_bar$\"",
-			"level": "error",
-			"location": {"col": 3, "file": "policy.rego", "row": 6, "text": "\t\tfooBar := true"},
-			"related_resources": [{
-				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
-			}],
-			"title": "naming-convention",
-		},
+		expected(
+			`Naming convention violation: package name "foo.bar" does not match pattern '^acmecorp\.[a-z_\.]+$'`,
+			{"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
+		),
+		expected(
+			`Naming convention violation: rule name "foo" does not match pattern '^bar$|^foo_bar$'`,
+			{"col": 2, "file": "policy.rego", "row": 3, "text": "\tfoo := true"},
+		),
+		expected(
+			`Naming convention violation: variable name "fooBar" does not match pattern '^bar$|^foo_bar$'`,
+			{"col": 3, "file": "policy.rego", "row": 6, "text": "\t\tfooBar := true"},
+		),
 	}
+}
+
+expected(description, location) := {
+	"category": "custom",
+	"description": description,
+	"level": "error",
+	"location": location,
+	"related_resources": [{
+		"description": "documentation",
+		"ref": config.docs.resolve_url("$baseUrl/$category/naming-convention", "custom"),
+	}],
+	"title": "naming-convention",
 }

--- a/bundle/regal/rules/style/rule_length.rego
+++ b/bundle/regal/rules/style/rule_length.rego
@@ -1,0 +1,31 @@
+# METADATA
+# description: Max rule length exceeded
+package regal.rules.style["rule-length"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+import data.regal.result
+
+cfg := config.for_rule("style", "rule-length")
+
+report contains violation if {
+	some rule in input.rules
+	lines := split(base64.decode(rule.location.text), "\n")
+
+	count(lines) > cfg["max-rule-length"]
+
+	not empty_body_exception(cfg, rule)
+
+	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
+}
+
+empty_body_exception(conf, rule) if {
+	conf["except-empty-body"] == true
+	count(rule.body) == 1
+	rule.body[0].terms.type == "boolean"
+	rule.body[0].terms.value == true
+}

--- a/bundle/regal/rules/style/rule_length_test.rego
+++ b/bundle/regal/rules/style/rule_length_test.rego
@@ -1,0 +1,68 @@
+package regal.rules.style["rule-length_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.style["rule-length"] as rule
+
+test_fail_rule_longer_than_configured_max_length if {
+	module := regal.parse_module("policy.rego", `package p
+
+	my_long_rule {
+		# this rule is longer than the configured max length
+		# which in this case is only 3 lines
+		#
+		input.x
+	}
+	`)
+
+	r := rule.report with input as module with config.for_rule as {
+		"level": "error",
+		"max-rule-length": 3,
+	}
+	r == {{
+		"category": "style",
+		"description": "Max rule length exceeded",
+		"level": "error",
+		"location": {"col": 2, "file": "policy.rego", "row": 3, "text": "\tmy_long_rule {"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/rule-length", "style"),
+		}],
+		"title": "rule-length",
+	}}
+}
+
+test_success_rule_not_longer_than_configured_max_length if {
+	module := regal.parse_module("policy.rego", `package p
+
+	my_short_rule {
+		# this rule is not longer than the configured max length
+		# which in this case is 30 lines
+		#
+		input.x
+	}
+	`)
+
+	r := rule.report with input as module with config.for_rule as {
+		"level": "error",
+		"max-rule-length": 30,
+	}
+	r == set()
+}
+
+test_success_rule_length_equals_max_length if {
+	module := regal.parse_module("policy.rego", `package p
+
+	my_tiny_rule := true
+	`)
+
+	r := rule.report with input as module with config.for_rule as {
+		"level": "error",
+		"max-rule-length": 1,
+	}
+	r == set()
+}

--- a/bundle/regal/rules/style/unconditional_assignment.rego
+++ b/bundle/regal/rules/style/unconditional_assignment.rego
@@ -8,6 +8,7 @@ import future.keywords.in
 
 import data.regal.result
 
+# regal ignore:rule-length
 report contains violation if {
 	some rule in input.rules
 

--- a/bundle/regal/rules/testing/print_or_trace_call_test.rego
+++ b/bundle/regal/rules/testing/print_or_trace_call_test.rego
@@ -15,27 +15,29 @@ test_fail_call_to_print_and_trace if {
 		x := [i | i = 0; trace("bar")]
 	}`)
 	r == {
-		{
-			"category": "testing",
-			"description": "Call to print or trace function",
-			"level": "error",
-			"location": {"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tprint(\"foo\")"},
-			"related_resources": [{
-				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/print-or-trace-call", "testing"),
-			}],
-			"title": "print-or-trace-call",
-		},
-		{
-			"category": "testing",
-			"description": "Call to print or trace function",
-			"level": "error",
-			"location": {"col": 20, "file": "policy.rego", "row": 6, "text": "\t\tx := [i | i = 0; trace(\"bar\")]"},
-			"related_resources": [{
-				"description": "documentation",
-				"ref": config.docs.resolve_url("$baseUrl/$category/print-or-trace-call", "testing"),
-			}],
-			"title": "print-or-trace-call",
-		},
+		expected_with_location({
+			"col": 3,
+			"file": "policy.rego",
+			"row": 4,
+			"text": "\t\tprint(\"foo\")",
+		}),
+		expected_with_location({
+			"col": 20,
+			"file": "policy.rego",
+			"row": 6,
+			"text": "\t\tx := [i | i = 0; trace(\"bar\")]",
+		}),
 	}
+}
+
+expected_with_location(location) := {
+	"category": "testing",
+	"description": "Call to print or trace function",
+	"level": "error",
+	"location": location,
+	"related_resources": [{
+		"description": "documentation",
+		"ref": config.docs.resolve_url("$baseUrl/$category/print-or-trace-call", "testing"),
+	}],
+	"title": "print-or-trace-call",
 }

--- a/docs/rules/style/file-length.md
+++ b/docs/rules/style/file-length.md
@@ -43,6 +43,8 @@ rules:
 ## Related Resources
 
 - Styra Blog: [Dynamic Policy Composition](https://www.styra.com/blog/dynamic-policy-composition-for-opa/)
+- Regal Docs: [line-length](https://docs.styra.com/regal/rules/style/line-length)
+- Regal Docs: [rule-length](https://docs.styra.com/regal/rules/style/rule-length)
 
 ## Community
 

--- a/docs/rules/style/line-length.md
+++ b/docs/rules/style/line-length.md
@@ -38,6 +38,11 @@ rules:
       non-breakable-word-threshold: 100
 ```
 
+## Related Resources
+
+- Regal Docs: [file-length](https://docs.styra.com/regal/rules/style/file-length)
+- Regal Docs: [rule-length](https://docs.styra.com/regal/rules/style/rule-length)
+
 ## Community
 
 If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,

--- a/docs/rules/style/rule-length.md
+++ b/docs/rules/style/rule-length.md
@@ -1,0 +1,59 @@
+# rule-length
+
+**Summary**: Max rule length exceeded
+
+**Category**: Style
+
+**Avoid**
+
+Having too much logic placed in a single rule body.
+
+**Prefer**
+
+To use helper rules and functions to compose your rules.
+
+## Rationale
+
+Splitting up large rules into smaller ones, and liberally using helper rules and functions, makes your policy easier for
+others to read and understand, and for yourself and your team to maintain.
+
+Note that this rule only counts the number of lines of a rule, and currently does not take into account the actual
+content inside of a rule. Neither does it try to analyze the complexity of the code in the rule.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  style:
+    rule-length:
+      # one of "error", "warning", "ignore"
+      level: error
+      # default limit is 30 lines
+      max-rule-length: 30
+      # except rules with empty bodies from this rule, as they're
+      # likely an assignment of long values rather than a "rule"
+      # with conditions:
+      #
+      # users = [ 
+      #     {"username": "ted"},
+      #     {"username": "alice"},
+      #     {"username": "bob"},
+      #     # ... many more lines
+      # ]
+      #
+      # the default value is true
+      except-empty-body: true
+```
+
+## Related Resources
+
+- Regal Docs: [file-length](https://docs.styra.com/regal/rules/style/file-length)
+- Regal Docs: [line-length](https://docs.styra.com/regal/rules/style/line-length)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -308,8 +308,8 @@ func TestLintRuleNamingConventionFromCustomCategory(t *testing.T) {
 	}
 
 	expectedViolations := []string{
-		`Naming convention violation: package name "this.fails" does not match pattern "^acmecorp\\.[a-z_\\.]+$"`,
-		`Naming convention violation: rule name "naming_convention_fail" does not match pattern "^_[a-z_]+$|^allow$"`,
+		`Naming convention violation: package name "this.fails" does not match pattern '^acmecorp\.[a-z_\.]+$'`,
+		`Naming convention violation: rule name "naming_convention_fail" does not match pattern '^_[a-z_]+$|^allow$'`,
 	}
 
 	for _, violation := range rep.Violations {

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -59,6 +59,16 @@ custom_in_construct(coll, item) {
 	item == coll[_]
 }
 
+use_some_for_output_vars {
+	input.foo[output_var]
+}
+
+non_raw_regex_pattern := regex.match("[0-9]", "1")
+
+use_in_operator {
+	"item" == input.coll[_]
+}
+
 ### Style ###
 
 # avoid-get-and-list-prefix
@@ -94,9 +104,46 @@ x := y {
 
 use_assignment = "oparator"
 
-use_in_operator {
-	"item" == input.coll[_]
+chained_rule_body {
+	input.x
+} {
+	input.y
 }
+
+rule_length {
+	input.x1
+	input.x2
+	input.x3
+	input.x4
+	input.x5
+	input.x6
+	input.x7
+	input.x8
+	input.x9
+	input.x10
+	input.x11
+	input.x12
+	input.x13
+	input.x14
+	input.x15
+	input.x16
+	input.x17
+	input.x18
+	input.x19
+	input.x20
+	input.x21
+	input.x22
+	input.x23
+	input.x24
+	input.x25
+	input.x26
+	input.x27
+	input.x28
+	input.x29
+	input.x30
+}
+
+### Testing ###
 
 # this will also tringger the test-outside-test-package rule
 test_identically_named_tests := true
@@ -110,20 +157,8 @@ print_or_trace_call {
 	print("forbidden!")
 }
 
-non_raw_regex_pattern := regex.match("[0-9]", "1")
-
-use_some_for_output_vars {
-	input.foo[output_var]
-}
-
 # metasyntactic variable
 foo := "bar"
-
-chained_rule_body {
-	input.x
-} {
-	input.y
-}
 
 # dubious print sprintf
 y {

--- a/internal/embeds/schemas/regal-ast.json
+++ b/internal/embeds/schemas/regal-ast.json
@@ -273,6 +273,9 @@
         },
         "col": {
           "type": "integer"
+        },
+        "text": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -30,6 +30,7 @@ func ParserOptions() ast.ParserOptions {
 					Annotations:    true,
 					AnnotationsRef: true,
 				},
+				IncludeLocationText: true,
 			},
 		},
 	}


### PR DESCRIPTION
Made easy by now having the `text` attribute present in the AST. Thanks for that @charlieegan3!

Fixed existing violations against this rule, which were almost exlusively in tests. Sprinkled a few ignore directives in the places where it wasn't possible to make rules any shorter.

Fixes #236