### PR TITLE
Add `--profile` option to `regal lint`

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -37,6 +37,7 @@ type lintCommandParams struct {
 	debug           bool
 	enablePrint     bool
 	metrics         bool
+	profile         bool
 	disable         repeatedStringFlag
 	disableAll      bool
 	disableCategory repeatedStringFlag
@@ -141,6 +142,8 @@ func init() {
 		"enable print output from policy")
 	lintCommand.Flags().BoolVar(&params.metrics, "metrics", false,
 		"enable metrics reporting (currently supported only for JSON output format)")
+	lintCommand.Flags().BoolVar(&params.profile, "profile", false,
+		"enable profiling metrics to be added to reporting (currently supported only for JSON output format)")
 
 	lintCommand.Flags().VarP(&params.disable, "disable", "d",
 		"disable specific rule(s). This flag can be repeated.")
@@ -251,6 +254,10 @@ func lint(args []string, params lintCommandParams) (report.Report, error) {
 	if params.metrics {
 		regal = regal.WithMetrics(m)
 		m.Timer(regalmetrics.RegalConfigParse).Start()
+	}
+
+	if params.profile {
+		regal = regal.WithProfiling(true)
 	}
 
 	var userConfig config.Config

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,5 +1,11 @@
 package metrics
 
+import (
+	"github.com/open-policy-agent/opa/profiler"
+
+	"github.com/styrainc/regal/pkg/report"
+)
+
 const (
 	RegalConfigSearch         = "regal_config_search"
 	RegalConfigParse          = "regal_config_parse"
@@ -11,3 +17,13 @@ const (
 	RegalLintRego             = "regal_lint_rego"
 	RegalLintRegoAggregate    = "regal_lint_rego_aggregate"
 )
+
+func FromExprStats(stats profiler.ExprStats) report.ProfileEntry {
+	return report.ProfileEntry{
+		Location:    stats.Location.String(),
+		TotalTimeNs: stats.ExprTimeNs,
+		NumEval:     stats.NumEval,
+		NumRedo:     stats.NumRedo,
+		NumGenExpr:  stats.NumGenExpr,
+	}
+}


### PR DESCRIPTION
This sets a profiler on eval in each goroutine, and then accumulates the result from each into a final report. At this point we're only including this in the JSON output format (similar to `--metrics`) but we'll want to support this for each format some time later.

Fixes #334

```shell
go run main.go lint -f json --profile bundle
```
```json
{
  "violations": [],
  "summary": {
    "files_scanned": 98,
    "files_failed": 0,
    "files_skipped": 0,
    "num_violations": 0
  },
  "profile": [
    {
      "location": "/regal/ast.rego:278",
      "total_time_ns": 1329484096,
      "num_eval": 4,
      "num_redo": 27214,
      "num_gen_expr": 4
    },
    {
      "location": "/regal/config/config.rego:90",
      "total_time_ns": 1122320502,
      "num_eval": 176,
      "num_redo": 88,
      "num_gen_expr": 4
    },
    {
      "location": "/regal/ast.rego:218",
      "total_time_ns": 984304114,
      "num_eval": 130766,
      "num_redo": 66674,
      "num_gen_expr": 6
    },
    {
      "location": "/regal/main.rego:69",
      "total_time_ns": 795476410,
      "num_eval": 252,
      "num_redo": 84,
      "num_gen_expr": 6
    },
    {
      "location": "/regal/config/config.rego:39",
      "total_time_ns": 792559582,
      "num_eval": 88,
      "num_redo": 0,
      "num_gen_expr": 2
    },
    {
      "location": "/regal/ast.rego:307",
      "total_time_ns": 726335912,
      "num_eval": 140,
      "num_redo": 102,
      "num_gen_expr": 4
    },
    {
      "location": "/regal/main.rego:46",
      "total_time_ns": 648658586,
      "num_eval": 84,
      "num_redo": 0,
      "num_gen_expr": 2
    },
    {
      "location": "/regal/main.rego:44",
      "total_time_ns": 576676664,
      "num_eval": 252,
      "num_redo": 84,
      "num_gen_expr": 6
    },
    {
      "location": "/regal/rules/testing/metasyntactic_variable.rego:48",
      "total_time_ns": 530986756,
      "num_eval": 16,
      "num_redo": 24,
      "num_gen_expr": 4
    },
    {
      "location": "/regal/config/config.rego:17",
      "total_time_ns": 526488250,
      "num_eval": 8,
      "num_redo": 8,
      "num_gen_expr": 8
    }
  ]
}
```