### PR TITLE
Add run_quiet to rq build script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,8 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: 1.20.1
+      - run: go install git.sr.ht/~charles/rq/cmd/rq@latest
+      - run: build/do.rq pull_request
       - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.52.2
-      - run: go install git.sr.ht/~charles/rq/cmd/rq@latest
-      - run: build/do.rq pull_request

--- a/build/do.rq
+++ b/build/do.rq
@@ -159,7 +159,7 @@ lint {
 }
 
 lint_ci {
-	run("./regal lint --format github bundle")
+	run_quiet("./regal lint --format github bundle")
 }
 
 check_readme {
@@ -213,6 +213,18 @@ run(cmd) {
 	out := rq.run(args, {})
 	{ rq.error(sprintf("\nstdout: %s\nstderr: %s", [out.stdout, out.stderr])) | out.exitcode != 0 }
 	print(out.stdout)
+}
+
+run_quiet(cmd) {
+	print(cmd)
+	args := split(cmd, " ")
+	out := rq.run(args, {})
+	print(out.stdout)
+	{true |
+		out.exitcode != 0
+		print(out.stderr)
+		rq.error("")
+	}
 }
 
 github(what, j) {

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -86,6 +86,11 @@ func init() {
 		},
 
 		Run: func(_ *cobra.Command, args []string) {
+			// Allow setting debug mode via GitHub UI for failing actions
+			if os.Getenv("RUNNER_DEBUG") != "" {
+				params.debug = true
+			}
+
 			rep, err := lint(args, params)
 			if err != nil {
 				log.SetOutput(os.Stderr)


### PR DESCRIPTION
So that we don't silence the GitHub workflow commands

Fixes https://github.com/StyraInc/regal/issues/356