### PR TITLE
Let `--format github` log pretty output to console

### DIFF
--- a/docs/rules/bugs/invalid-metadata-attribute.md
+++ b/docs/rules/bugs/invalid-metadata-attribute.md
@@ -27,7 +27,7 @@ Metadata comments should follow the schema expected by
 [annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations). Custom attributes, like
 `category` above, should be placed under the `custom` key, which is a map of arbitrary key-value pairs.
 
-While arbitrary attributes is accepted, they will not be treated as metadata annotations but regular comments, and as
+While arbitrary attributes are accepted, they will not be treated as metadata annotations but regular comments, and as
 such won't be available to other tools that
 [process annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#accessing-annotations).
 These tools include built-in functions like

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -3,6 +3,7 @@ package reporter
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/styrainc/regal/pkg/report"
@@ -237,13 +238,19 @@ func TestGitHubReporterPublish(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	expectTable := "Rule:         \tbreaking-the-law"
+
+	if !strings.Contains(buf.String(), expectTable) {
+		t.Errorf("expected table output %q, got %q", expectTable, buf.String())
+	}
+
 	//nolint:lll
-	expect := `::error file=a.rego,line=1,col=1::Rego must not break the law!. To learn more, see: https://example.com/illegal
+	expectGithub := `::error file=a.rego,line=1,col=1::Rego must not break the law!. To learn more, see: https://example.com/illegal
 ::warning file=b.rego,line=22,col=18::Questionable decision found. To learn more, see: https://example.com/questionable
 `
 
-	if buf.String() != expect {
-		t.Errorf("expected %q, got %q", expect, buf.String())
+	if !strings.Contains(buf.String(), expectGithub) {
+		t.Errorf("expected workflow command output %q, got %q", expectGithub, buf.String())
 	}
 }
 
@@ -261,7 +268,7 @@ func TestGitHubReporterPublishNoViolations(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if buf.String() != "" {
+	if buf.String() != "0 files linted. No violations found.\n" {
 		t.Errorf("expected %q, got %q", "", buf.String())
 	}
 }


### PR DESCRIPTION
Using *only* annotations makes it hard to tell from the actions check view what went wrong, or more specifically, *where*. Now users will see both the pretty table, _and_ get annotations in the PR.

<img width="1050" alt="Screenshot 2023-10-04 at 22 43 59" src="https://github.com/StyraInc/regal/assets/510711/32a3ebb7-33b9-4e4b-a6e5-a6ef5c8332e5">

Fixes #345