### PR TITLE
Fix issues blocking Windows usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 
 /regal
+/regal.exe


### PR DESCRIPTION
The logic traversing directories looking for a `.regal` directory did not take a possible volume name (like `C:`) into account. With this, all tests (unit + e2e)  now pass on Windows as well as UNIX.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->