### PR TITLE
`use-assignment-operator`: check for assignment operator in else assignment

### DIFF
--- a/bundle/regal/rules/style/default_over_else.rego
+++ b/bundle/regal/rules/style/default_over_else.rego
@@ -39,4 +39,4 @@ report contains violation if {
 
 considered_rules := input.rules if cfg["prefer-default-functions"] == true
 
-considered_rules := [rule | some rule in input.rules; not rule.head.args] if not cfg["prefer-default-functions"]
+considered_rules := ast.rules if not cfg["prefer-default-functions"]

--- a/bundle/regal/rules/style/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use_assignment_operator.rego
@@ -11,8 +11,10 @@ import data.regal.result
 
 report contains violation if {
 	# foo = "bar"
+	# default foo = "bar
+	# foo(bar) = "baz"
+	# default foo(_) = "bar
 	some rule in input.rules
-	not rule["default"]
 	not rule.head.assign
 	not rule.head.key
 	not ast.implicit_boolean_assignment(rule)
@@ -22,17 +24,8 @@ report contains violation if {
 }
 
 report contains violation if {
-	# default foo = "bar"
-	some rule in input.rules
-	rule["default"] == true
-	not rule.head.assign
-
-	violation := result.fail(rego.metadata.chain(), result.location(rule))
-}
-
-report contains violation if {
 	# foo["bar"] = "baz"
-	some rule in input.rules
+	some rule in ast.rules
 	rule.head.key
 	rule.head.value
 	not rule.head.assign
@@ -41,12 +34,24 @@ report contains violation if {
 }
 
 report contains violation if {
-	# foo(bar) = "baz"
 	some rule in input.rules
-	rule.head.args
-	not rule.head.assign
-	not ast.implicit_boolean_assignment(rule)
-	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule.head.ref[0]))
+	# walking is expensive but necessary here, since there could be
+	# any number of `else` clauses nested below. no need to traverse
+	# the rule if there isn't a single `else` present though!
+	rule["else"]
+
+	# NOTE: the same logic is used in default-over-else
+	# we should consider having a helper function to return
+	# all else clauses, for a given rule, as potentially that
+	# would be cached on the second invocation of the function
+	walk(rule, [_, value])
+	value["else"]
+
+	# extract the text from location to see if '=' is used for
+	# assignment
+	text := base64.decode(value["else"].head.location.text)
+	regex.match(`^else\s*=`, text)
+
+	violation := result.fail(rego.metadata.chain(), result.location(value["else"].head))
 }

--- a/bundle/regal/rules/style/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use_assignment_operator_test.rego
@@ -71,8 +71,28 @@ test_fail_unification_in_default_assignment if {
 	}}
 }
 
+test_fail_unification_in_default_function_assignment if {
+	r := rule.report with input as ast.policy(`default x(_) = false`)
+	r == {{
+		"category": "style",
+		"description": "Prefer := over = for assignment",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+		}],
+		"title": "use-assignment-operator",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "default x(_) = false"},
+		"level": "error",
+	}}
+}
+
 test_success_assignment_in_default_assignment if {
 	r := rule.report with input as ast.policy(`default x := false`)
+	r == set()
+}
+
+test_success_assignment_in_default_function_assignment if {
+	r := rule.report with input as ast.policy(`default x(_) := false`)
 	r == set()
 }
 
@@ -133,5 +153,53 @@ test_success_using_if if {
 
 test_success_ref_head_rule_if if {
 	r := rule.report with input as ast.with_future_keywords(`a.b.c if true`)
+	r == set()
+}
+
+# regal ignore:rule-length
+test_fail_unification_in_else if {
+	r := rule.report with input as ast.with_future_keywords(`
+	allow if {
+		input.x
+	} else = true {
+		input.y
+	} else = false
+	`)
+	r == {
+		{
+			"category": "style",
+			"description": "Prefer := over = for assignment",
+			"related_resources": [{
+				"description": "documentation",
+				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			}],
+			"title": "use-assignment-operator",
+			"location": {"col": 4, "file": "policy.rego", "row": 11, "text": "\t} else = true {"},
+			"level": "error",
+		},
+		{
+			"category": "style",
+			"description": "Prefer := over = for assignment",
+			"related_resources": [{
+				"description": "documentation",
+				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
+			}],
+			"title": "use-assignment-operator",
+			"location": {"col": 4, "file": "policy.rego", "row": 13, "text": "\t} else = false"},
+			"level": "error",
+		},
+	}
+}
+
+test_success_assignment_in_else if {
+	r := rule.report with input as ast.with_future_keywords(`
+	allow if {
+		input.x
+	} else := true {
+		input.y
+	} else {
+		input.z
+	} else := false
+	`)
 	r == set()
 }


### PR DESCRIPTION
Also simplified the logic of this rule for other types of rule assignment.

Fixes #385

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->