### PR TITLE
`no-whitespace-comment`: add `except-pattern` config attribute

### DIFF
--- a/bundle/regal/rules/style/no_whitespace_comment.rego
+++ b/bundle/regal/rules/style/no_whitespace_comment.rego
@@ -7,7 +7,10 @@ import future.keywords.if
 import future.keywords.in
 
 import data.regal.ast
+import data.regal.config
 import data.regal.result
+
+cfg := config.for_rule("style", "no-whitespace-comment")
 
 report contains violation if {
 	some comment in ast.comments_decoded
@@ -18,3 +21,5 @@ report contains violation if {
 }
 
 _whitespace_comment(text) if regex.match(`^(#*)(\s+.*|$)`, text)
+
+_whitespace_comment(text) if regex.match(cfg["except-pattern"], text)

--- a/bundle/regal/rules/style/no_whitespace_comment_test.rego
+++ b/bundle/regal/rules/style/no_whitespace_comment_test.rego
@@ -6,7 +6,7 @@ import data.regal.ast
 import data.regal.config
 import data.regal.rules.style["no-whitespace-comment"] as rule
 
-test_no_leading_whitespace if {
+test_fail_no_leading_whitespace if {
 	r := rule.report with input as ast.policy(`#foo`)
 	r == {{
 		"category": "style",
@@ -21,7 +21,7 @@ test_no_leading_whitespace if {
 	}}
 }
 
-test_no_leading_whitespace_multiple_hashes if {
+test_fail_no_leading_whitespace_multiple_hashes if {
 	r := rule.report with input as ast.policy(`##foo`)
 	r == {{
 		"category": "style",
@@ -34,6 +34,11 @@ test_no_leading_whitespace_multiple_hashes if {
 		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "##foo"},
 		"level": "error",
 	}}
+}
+
+test_success_excepted_pattern if {
+	r := rule.report with input as ast.policy(`#-- foo`) with config.for_rule as {"except-pattern": "^--"}
+	r == set()
 }
 
 test_success_leading_whitespace if {

--- a/docs/rules/style/no-whitespace-comment.md
+++ b/docs/rules/style/no-whitespace-comment.md
@@ -48,6 +48,10 @@ rules:
     no-whitespace-comment:
       # one of "error", "warning", "ignore"
       level: error
+      # optional pattern to except from this rule
+      # this example would allow comments like "#--"
+      # use or (`|`) to separate multiple patterns  
+      except-pattern: '^--'
 ```
 
 ## Community


### PR DESCRIPTION
This allows policy authors to list patterns other than whitespace that should be considered OK by this rule.

Fixes #379

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->