### PR TITLE
`unconditional-assignment`: extend to include multi-value rules

### DIFF
--- a/bundle/regal/rules/style/unconditional_assignment_test.rego
+++ b/bundle/regal/rules/style/unconditional_assignment_test.rego
@@ -56,3 +56,37 @@ test_success_unconditional_assignment_but_else if {
     } else := input.bar`)
 	r == set()
 }
+
+test_fail_unconditional_multi_value_assignment if {
+	r := rule.report with input as ast.with_future_keywords(`x contains y if {
+		y := 1
+	}`)
+	r == {{
+		"category": "style",
+		"description": "Unconditional assignment in rule body",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
+		}],
+		"title": "unconditional-assignment",
+		"location": {"col": 3, "file": "policy.rego", "row": 9, "text": "\t\ty := 1"},
+		"level": "error",
+	}}
+}
+
+test_fail_unconditional_map_assignment if {
+	r := rule.report with input as ast.with_future_keywords(`x["y"] := y if {
+		y := 1
+	}`)
+	r == {{
+		"category": "style",
+		"description": "Unconditional assignment in rule body",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
+		}],
+		"title": "unconditional-assignment",
+		"location": {"col": 3, "file": "policy.rego", "row": 9, "text": "\t\ty := 1"},
+		"level": "error",
+	}}
+}

--- a/docs/rules/style/unconditional-assignment.md
+++ b/docs/rules/style/unconditional-assignment.md
@@ -8,12 +8,19 @@
 ```rego
 package policy
 
-full_name := name {
+import future.keywords.contains
+import future.keywords.if
+
+full_name := name if {
     name := concat(", ", [input.first_name, input.last_name])
 }
 
-divide_by_ten(x) := y {
+divide_by_ten(x) := y if {
     y := x / 10
+}
+
+names contains name if {
+    name := "Regal"
 }
 ```
 
@@ -21,9 +28,14 @@ divide_by_ten(x) := y {
 ```rego
 package policy
 
+import future.keywords.contains
+import future.keywords.if
+
 full_name := concat(", ", [input.first_name, input.last_name])
 
 divide_by_ten(x) := x / 10
+
+names contains "Regal"
 ```
 
 ## Rationale


### PR DESCRIPTION
```rego
x contains y if {
    y := 1
}
```

Would be better simplified to:

```rego
x contains 1
```

Fixes #384

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->