### PR TITLE
Fix `constant-condition` flagging multi-value rules without body

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -51,10 +51,20 @@ _is_name(ref, pos) if {
 	ref.type == "string"
 }
 
-# i.e. allow {..}, or allow := true, which expands to allow = true { true }
-no_body(rule) if rule.body[0].location == rule.head.value.location
+# allow := true, which expands to allow = true { true }
+generated_body(rule) if rule.body[0].location == rule.head.value.location
 
-no_body(rule) if rule["default"] == true
+generated_body(rule) if rule["default"] == true
+
+# rule["message"] or
+# rule contains "message"
+generated_body(rule) if {
+	rule.body[0].location.row == rule.head.key.location.row
+
+	# this is a quirk in the AST — the generated body will have a location
+	# set before the key, i.e. "message"
+	rule.body[0].location.col < rule.head.key.location.col
+}
 
 rules := [rule |
 	some rule in input.rules

--- a/bundle/regal/rules/bugs/constant_condition.rego
+++ b/bundle/regal/rules/bugs/constant_condition.rego
@@ -17,7 +17,7 @@ _operators := {"equal", "gt", "gte", "lt", "lte", "neq"}
 
 _rules_with_bodies := [rule |
 	some rule in input.rules
-	not ast.no_body(rule)
+	not ast.generated_body(rule)
 ]
 
 report contains violation if {

--- a/bundle/regal/rules/bugs/constant_condition_test.rego
+++ b/bundle/regal/rules/bugs/constant_condition_test.rego
@@ -65,3 +65,8 @@ test_success_non_constant_condition if {
 	r := rule.report with input as ast.policy(`allow { 1 == input.one }`)
 	r == set()
 }
+
+test_success_adding_constant_to_set if {
+	r := rule.report with input as ast.with_future_keywords(`rule contains "message"`)
+	r == set()
+}

--- a/bundle/regal/rules/style/rule_length.rego
+++ b/bundle/regal/rules/style/rule_length.rego
@@ -18,12 +18,12 @@ report contains violation if {
 
 	count(lines) > cfg["max-rule-length"]
 
-	not empty_body_exception(cfg, rule)
+	not generated_body_exception(cfg, rule)
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }
 
-empty_body_exception(conf, rule) if {
+generated_body_exception(conf, rule) if {
 	conf["except-empty-body"] == true
-	ast.no_body(rule)
+	ast.generated_body(rule)
 }


### PR DESCRIPTION
Fixes #399

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->