### PR TITLE
Fix false positive on function without body in `constant-condition`

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -66,6 +66,9 @@ generated_body(rule) if {
 	rule.body[0].location.col < rule.head.key.location.col
 }
 
+# f("x")
+generated_body(rule) if rule.body[0].location == rule.head.location
+
 rules := [rule |
 	some rule in input.rules
 	not rule.head.args

--- a/bundle/regal/ast_test.rego
+++ b/bundle/regal/ast_test.rego
@@ -257,3 +257,13 @@ test_find_some_decl_names_in_scope if {
 }
 
 var_names(vars) := {var.value | some var in vars}
+
+test_generated_body_function if {
+	policy := `package p
+
+	f("x")`
+
+	module := regal.parse_module("p.rego", policy)
+
+	ast.generated_body(module.rules[0])
+}


### PR DESCRIPTION
Fixes #403

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->