### PR TITLE
Rule: `import-shadows-builtin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The following rules are currently available:
 | imports   | [avoid-importing-input](https://docs.styra.com/regal/rules/imports/avoid-importing-input)         | Avoid importing input                                     |
 | imports   | [implicit-future-keywords](https://docs.styra.com/regal/rules/imports/implicit-future-keywords)   | Use explicit future keyword imports                       |
 | imports   | [import-after-rule](https://docs.styra.com/regal/rules/imports/import-after-rule)                 | Import declared after rule                                |
+| imports   | [import-shadows-builtin](https://docs.styra.com/regal/rules/imports/import-shadows-builtin)       | Import shadows built-in namespace                         |
 | imports   | [import-shadows-import](https://docs.styra.com/regal/rules/imports/import-shadows-import)         | Import shadows another import                             |
 | imports   | [prefer-package-imports](https://docs.styra.com/regal/rules/imports/prefer-package-imports)       | Prefer importing packages over rules                      |
 | imports   | [redundant-alias](https://docs.styra.com/regal/rules/imports/redundant-alias)                     | Redundant alias                                           |

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -40,6 +40,8 @@ rules:
       level: error
     import-after-rule:
       level: error
+    import-shadows-builtin:
+      level: error
     import-shadows-import:
       level: error
     prefer-package-imports:

--- a/bundle/regal/rules/imports/import_shadows_builtin.rego
+++ b/bundle/regal/rules/imports/import_shadows_builtin.rego
@@ -1,0 +1,34 @@
+# METADATA
+# description: Import shadows built-in namespace
+package regal.rules.imports["import-shadows-builtin"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.result
+
+builtin_namespaces contains namespace if {
+	some name in ast.builtin_names
+
+	namespace := split(name, ".")[0]
+}
+
+report contains violation if {
+	some imp in input.imports
+
+	imp.path.value[0].value in {"data", "input"}
+
+	name := significant_name(imp)
+	name in builtin_namespaces
+
+	# AST quirk: while we'd ideally provide the location of the *path component*,
+	# there is no location data provided for aliases. In order to be consistent,
+	# we'll just provide the location of the import.
+	violation := result.fail(rego.metadata.chain(), result.location(imp))
+}
+
+significant_name(imp) := imp.alias
+
+significant_name(imp) := regal.last(imp.path.value).value if not imp.alias

--- a/bundle/regal/rules/imports/import_shadows_builtin_test.rego
+++ b/bundle/regal/rules/imports/import_shadows_builtin_test.rego
@@ -1,0 +1,57 @@
+package regal.rules.imports["import-shadows-builtin_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.imports["import-shadows-builtin"] as rule
+
+test_fail_import_shadows_builtin_name if {
+	module := ast.policy(`import data.print`)
+
+	r := rule.report with input as module
+	r == {{
+		"category": "imports",
+		"description": "Import shadows built-in namespace",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import data.print"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-builtin", "imports"),
+		}],
+		"title": "import-shadows-builtin",
+	}}
+}
+
+test_fail_import_shadows_builtin_namespace if {
+	module := ast.policy(`import input.foo.http`)
+
+	r := rule.report with input as module
+	r == {{
+		"category": "imports",
+		"description": "Import shadows built-in namespace",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import input.foo.http"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-builtin", "imports"),
+		}],
+		"title": "import-shadows-builtin",
+	}}
+}
+
+test_success_import_does_not_shadows_builtin_name if {
+	module := ast.policy(`import data.users`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_import_shadows_but_alias_does_not if {
+	module := ast.policy(`import data.http as http_attributes`)
+
+	r := rule.report with input as module
+	r == set()
+}

--- a/docs/rules/imports/import-shadows-builtin.md
+++ b/docs/rules/imports/import-shadows-builtin.md
@@ -1,0 +1,81 @@
+# import-shadows-builtin
+
+**Summary**: Import shadows built-in namespace
+
+**Category**: Imports
+
+**Avoid**
+```rego
+package policy
+
+# Shadows the built-in `print` function
+import data.print
+
+# Shadows the built-in `http.send` function
+import input.attributes.http
+```
+
+**Prefer**
+To either use different names for your packages, or use import aliases to avoid shadowing built-ins.
+```rego
+package policy
+
+# Using a different package name
+import data.printer
+
+# Using an alias
+import input.attributes.http as http_attributes
+```
+
+## Rationale
+
+OPA will not complain about an import shadowing the name or the "namespace" (i.e. `array` in `array.slice`) until a
+conflicting built-in function is used in the same policy. Preventing this to happen in the first place is a better
+option!
+
+Why does this happen? The OPA compiler rewrites any import used in a policy, so that the shorthand form expands to its
+longer form. Provided a simple policy like this:
+
+```rego
+package policy
+
+import future.keywords.if
+
+import data.http
+
+allow if {
+    http.send({"method": "GET", "url": "https://example.com"})
+}
+```
+
+The compiler will go ahead and rewrite the `http.send` call using the import:
+
+```rego
+allow if {
+    data.http.send({"method": "GET", "url": "https://example.com"})
+}
+```
+
+This is obviously not what the policy author intended.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  imports:
+    import-shadows-builtin:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -22,6 +22,9 @@ import data.redundant.alias as alias
 # redundant-data-import
 import data
 
+# import-shadows-builtin
+import data.http
+
 # prefer-package-imports
 # aggregate rule, so will only fail if more than one file is linted
 import data.rule_named_if.allow


### PR DESCRIPTION
Forbid imports that may shadow a built-in function, like `data.print`, or `input.http`.

Fixes #406

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->