### PR TITLE
Rule: `equals-pattern-matching`

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The following rules are currently available:
 | custom    | [naming-convention](https://docs.styra.com/regal/rules/custom/naming-convention)                    | Naming convention violation                               |
 | idiomatic | [custom-has-key-construct](https://docs.styra.com/regal/rules/idiomatic/custom-has-key-construct)   | Custom function may be replaced by `in` and `object.keys` |
 | idiomatic | [custom-in-construct](https://docs.styra.com/regal/rules/idiomatic/custom-in-construct)             | Custom function may be replaced by `in` keyword           |
+| idiomatic | [equals-pattern-matching](https://docs.styra.com/regal/rules/idiomatic/equals-pattern-matching)     | Prefer pattern matching in function arguments             |
 | idiomatic | [no-defined-entrypoint](https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint)         | Missing entrypoint annotation                             |
 | idiomatic | [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)         | Use raw strings for regex patterns                        |
 | idiomatic | [prefer-set-or-object-rule](https://docs.styra.com/regal/rules/idiomatic/prefer-set-or-object-rule) | Prefer set or object rule over comprehension              |

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -29,6 +29,8 @@ rules:
       level: error
     non-raw-regex-pattern:
       level: error
+    equals-pattern-matching:
+      level: error
     prefer-set-or-object-rule:
       level: error
     use-in-operator:

--- a/bundle/regal/rules/idiomatic/equals_pattern_matching.rego
+++ b/bundle/regal/rules/idiomatic/equals_pattern_matching.rego
@@ -1,0 +1,82 @@
+# METADATA
+# description: Prefer pattern matching in function arguments
+package regal.rules.idiomatic["equals-pattern-matching"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.result
+
+# Current limitations:
+# Only works for single comparison either in head or in body
+
+# f(x) := x == 1
+# ->
+# f(1)
+report contains violation if {
+	some fn in ast.functions
+	ast.generated_body(fn)
+
+	arg_var_names := {arg.value |
+		some arg in fn.head.args
+		arg.type == "var"
+	}
+
+	val := fn.head.value
+	val.type == "call"
+	val.value[0].type == "ref"
+	val.value[0].value[0].type == "var"
+	val.value[0].value[0].value == "equal"
+
+	terms := normalize_eq_terms(val.value)
+	terms[0].value in arg_var_names
+
+	violation := result.fail(rego.metadata.chain(), result.location(fn))
+}
+
+# f(x) if x == 1
+# ->
+# f(1)
+report contains violation if {
+	some fn in ast.functions
+	not ast.generated_body(fn)
+
+	arg_var_names := {arg.value |
+		some arg in fn.head.args
+		arg.type == "var"
+	}
+
+	# FOR NOW: Limit to a lone comparison
+	# More elaborate cases are certainly doable,
+	# but we'd need to keep track of whatever else
+	# each var is up to in the body, and that's..
+	# well, elaborate.
+	count(fn.body) == 1
+
+	expr := fn.body[0]
+
+	expr.terms[0].type == "ref"
+	expr.terms[0].value[0].type == "var"
+	expr.terms[0].value[0].value == "equal"
+
+	terms := normalize_eq_terms(expr.terms)
+	terms[0].value in arg_var_names
+
+	violation := result.fail(rego.metadata.chain(), result.location(fn))
+}
+
+# METADATA
+# description: Normalize var to always always be on the left hand side
+normalize_eq_terms(terms) := [terms[1], terms[2]] if {
+	terms[1].type == "var"
+	not startswith(terms[1].value, "$")
+	terms[2].type in ast.scalar_types
+}
+
+normalize_eq_terms(terms) := [terms[2], terms[1]] if {
+	terms[1].type in ast.scalar_types
+	terms[2].type == "var"
+	not startswith(terms[2].value, "$")
+}

--- a/bundle/regal/rules/idiomatic/equals_pattern_matching_test.rego
+++ b/bundle/regal/rules/idiomatic/equals_pattern_matching_test.rego
@@ -1,0 +1,81 @@
+package regal.rules.idiomatic["equals-pattern-matching_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.idiomatic["equals-pattern-matching"] as rule
+
+test_fail_simple_head_comparison_could_be_matched_in_arg if {
+	module := ast.policy("f(x) := x == 1")
+
+	r := rule.report with input as module
+	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := x == 1"})
+}
+
+test_fail_simple_head_comparison_could_be_matched_in_arg_eq_order if {
+	module := ast.policy("f(x) := 1 == x")
+
+	r := rule.report with input as module
+	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := 1 == x"})
+}
+
+test_fail_simple_head_comparison_could_be_matched_in_arg_multiple_args if {
+	module := ast.policy("f(_, x, _) := x == 1")
+
+	r := rule.report with input as module
+	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(_, x, _) := x == 1"})
+}
+
+test_fail_simple_body_comparison_could_be_matched_in_arg if {
+	module := ast.policy(`f(x) := "one" {
+		x == 1
+	}`)
+
+	r := rule.report with input as module
+	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := \"one\" {"})
+}
+
+test_fail_simple_body_comparison_could_be_matched_in_arg_eq_order if {
+	module := ast.policy(`f(x) := "one" {
+		1 == x
+	}`)
+
+	r := rule.report with input as module
+	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := \"one\" {"})
+}
+
+test_fail_simple_body_comparison_could_be_matched_using_if if {
+	module := ast.with_future_keywords(`f(x) := x if x == 1`)
+
+	r := rule.report with input as module
+	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 8, "text": "f(x) := x if x == 1"})
+}
+
+test_success_actually_pattern_matching if {
+	module := ast.policy("f(1)")
+
+	r := rule.report with input as module
+	r == set()
+}
+
+expected := {
+	"category": "idiomatic",
+	"description": "Prefer pattern matching in function arguments",
+	"level": "error",
+	"related_resources": [{
+		"description": "documentation",
+		"ref": config.docs.resolve_url("$baseUrl/$category/equals-pattern-matching", "idiomatic"),
+	}],
+	"title": "equals-pattern-matching",
+}
+
+expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)
+
+expected_with_location(locations) := {object.union(expected, {"location": location}) |
+	some location in locations
+} if {
+	is_set(locations)
+}

--- a/docs/rules/idiomatic/equals-pattern-matching.md
+++ b/docs/rules/idiomatic/equals-pattern-matching.md
@@ -1,0 +1,105 @@
+# equals-pattern-matching
+
+**Summary**: Prefer pattern matching in function arguments
+
+**Category**: Idiomatic
+
+**Avoid**
+```rego
+package policy
+
+import future.keywords.if
+
+readable_number(x) := "one" if x == 1
+readable_number(x) := "two" if x == 2
+```
+
+**Prefer**
+```rego
+package policy
+
+readable_number(1) := "one"
+readable_number(2) := "two"
+```
+
+## Rationale
+
+Pattern matching on equality in function arguments is one of Rego's most well-kept secrets. As secret as it might be,
+it's a great way to simplify custom functions performing equality checks on their arguments in the rule body, by
+moving the equality check to match on the function call itself. This means that a function like the one below:
+
+```rego
+package policy
+
+import future.keywords.if
+
+normalize_role(role) := "admin" if {
+    role == "administrator"
+}
+
+normalize_role(role) := "admin" if {
+    role == "root"
+}
+```
+
+May have the equality check moved to the function argument, and the function only evaluated in case the argument matches
+the equality "pattern":
+
+```rego
+package policy
+
+import future.keywords.if
+
+normalize_role("administrator") := "admin"
+
+normalize_role("root") := "admin"
+```
+
+Rules that evaluate to `true` may even have the assignment removed altogether, i.e.:
+
+```rego
+package policy
+
+import future.keywords.if
+
+is_admin(role) if role == "admin"
+
+is_admin(role) if role == "administrator"
+
+is_admin(role) if role == "root"
+```
+
+Can be simplified to just:
+
+```rego
+package policy
+
+is_admin("admin")
+
+is_admin("administrator")
+
+is_admin("root")
+```
+
+## Limitations
+
+This rule is currently limited to simple rules where the equality check is the **only** condition in the rule body. This
+will be improved in future releases.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  idiomatic:
+    equals-pattern-matching:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -78,6 +78,8 @@ use_in_operator {
 
 prefer_set_or_object_rule := {x | some x in input; x == "violation"}
 
+equals_pattern_matching(x) := x == "x"
+
 ### Style ###
 
 # avoid-get-and-list-prefix


### PR DESCRIPTION
Prefer to use pattern matching for equality in function args.

Currently limited to simple rules where the equality check is the only condition in the rule head or rule body (and this limitation is described in the rule docs). I'm hoping to improve this in the future, but as I think there's value in this already, so let's ship and iterate.

Fixes #397

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->