### PR TITLE
Rule: `prefer-value-in-head`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ The following rules are currently available:
 | bugs      | [unused-return-value](https://docs.styra.com/regal/rules/bugs/unused-return-value)                  | Non-boolean return value unused                           |
 | custom    | [forbidden-function-call](https://docs.styra.com/regal/rules/custom/forbidden-function-call)        | Forbidden function call                                   |
 | custom    | [naming-convention](https://docs.styra.com/regal/rules/custom/naming-convention)                    | Naming convention violation                               |
+| custom    | [prefer-value-in-head](https://docs.styra.com/regal/rules/custom/prefer-value-in-head)              | Prefer value in rule head                                 |
 | idiomatic | [custom-has-key-construct](https://docs.styra.com/regal/rules/idiomatic/custom-has-key-construct)   | Custom function may be replaced by `in` and `object.keys` |
 | idiomatic | [custom-in-construct](https://docs.styra.com/regal/rules/idiomatic/custom-in-construct)             | Custom function may be replaced by `in` keyword           |
 | idiomatic | [equals-pattern-matching](https://docs.styra.com/regal/rules/idiomatic/equals-pattern-matching)     | Prefer pattern matching in function arguments             |

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -20,6 +20,8 @@ rules:
       level: ignore
     naming-convention:
       level: ignore
+    prefer-value-in-head:
+      level: ignore
   idiomatic:
     custom-has-key-construct:
       level: error

--- a/bundle/regal/rules/custom/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer_value_in_head.rego
@@ -1,0 +1,41 @@
+# METADATA
+# description: Prefer value in rule head
+package regal.rules.custom["prefer-value-in-head"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+import data.regal.result
+
+cfg := config.for_rule("custom", "prefer-value-in-head")
+
+report contains violation if {
+	some rule in input.rules
+
+	var := var_in_head(rule)
+	last := regal.last(rule.body)
+
+	last.terms[0].value[0].type == "var"
+	last.terms[0].value[0].value in {"eq", "assign"}
+	last.terms[1].type == "var"
+	last.terms[1].value == var
+
+	not configured_exception(cfg, last.terms[2])
+
+	violation := result.fail(rego.metadata.chain(), result.location(last))
+}
+
+var_in_head(rule) := rule.head.value.value if rule.head.value.type == "var"
+
+var_in_head(rule) := rule.head.key.value if {
+	not rule.head.value
+	rule.head.key.type == "var"
+}
+
+configured_exception(cfg, term) if {
+	cfg["only-scalars"] == true
+	term.type in ast.scalar_types
+}

--- a/bundle/regal/rules/custom/prefer_value_in_head_test.rego
+++ b/bundle/regal/rules/custom/prefer_value_in_head_test.rego
@@ -1,0 +1,107 @@
+package regal.rules.custom["prefer-value-in-head_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.custom["prefer-value-in-head"] as rule
+
+test_fail_value_could_be_in_head_assign if {
+	module := ast.policy(`value := x {
+		input.x
+		x := 10
+	}`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := 10"})
+}
+
+test_fail_value_could_be_in_head_assign_composite if {
+	module := ast.policy(`value := x {
+		input.x
+		x := {"foo": 10}
+	}`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := {\"foo\": 10}"})
+}
+
+test_fail_value_is_in_head_assign if {
+	module := ast.policy(`value := 10 { input.x }`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r == set()
+}
+
+test_fail_value_could_be_in_head_eq if {
+	module := ast.policy(`value := x {
+		input.x
+		x = 10
+	}`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx = 10"})
+}
+
+test_success_value_is_in_head_eq if {
+	module := ast.policy(`value = x { input.x }`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r == set()
+}
+
+test_fail_value_could_be_in_head_but_not_a_required_scalar if {
+	module := ast.policy(`value := x {
+		input.x
+		x := [i | i := input[_]]
+	}`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
+	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := [i | i := input[_]]"})
+}
+
+test_success_value_could_be_in_head_and_is_a_required_scalar if {
+	module := ast.policy(`value := x {
+		input.x
+		x := 5
+	}`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
+	r == set()
+}
+
+test_fail_value_could_be_in_head_multivalue_rule if {
+	module := ast.with_future_keywords(`violations contains violation if {
+		input.bad
+		violation := "not good!"
+	}`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 10, "text": "\t\tviolation := \"not good!\""})
+}
+
+test_fail_value_could_be_in_head_object_rule if {
+	module := ast.policy(`foo["bar"] := x {
+		input.foo
+		x := "bar"
+	}`)
+
+	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := \"bar\""})
+}
+
+expected := {
+	"category": "custom",
+	"description": "Prefer value in rule head",
+	"level": "error",
+	"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo := true"},
+	"related_resources": [{
+		"description": "documentation",
+		"ref": config.docs.resolve_url("$baseUrl/$category/prefer-value-in-head", "custom"),
+	}],
+	"title": "prefer-value-in-head",
+}
+
+expected_with_location(location) := {object.union(expected, {"location": location})}

--- a/docs/rules/custom/prefer-value-in-head.md
+++ b/docs/rules/custom/prefer-value-in-head.md
@@ -1,0 +1,88 @@
+# prefer-value-in-head
+
+**Summary**: Prefer value in rule head
+
+**Category**: Custom
+
+**Avoid**
+```rego
+package policy
+
+import future.keywords.contains
+import future.keywords.if
+
+pin_as_number := val if {
+    is_number(input.pin_code)
+    val := to_number(input.pin_code)
+}
+
+deny contains message if {
+    not input.user
+    message := "user attribute missing from input"
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+import future.keywords.contains
+import future.keywords.if
+
+pin_as_number := to_number(input.pin_code) if is_number(input.pin_code)
+
+deny contains "user attribute missing from input" if not input.user
+```
+
+## Rationale
+
+Rules that return the value assigned in the last expression of the rule body may have the value, or the function
+returning the value, moved directly to the rule head. This creates more succinct rules, and often allows for rules to be
+expressed as "one-liners". This is not a general recommendation, but a style preference that a team or organization 
+might want to standardize on. As such, it is placed in the custom category, and must be explicitly enabled in
+configuration.
+
+The `only-literals` configuration option may be used to only suggest moving literal values to the head, and not
+expressions or functions returning a value. With this option set to `true`, the following example would be flagged:
+
+```rego
+deny contains message if {
+    not input.user
+    # value is a string literal
+    message := "user attribute missing from input"
+}
+```
+
+But not:
+
+```rego
+deny contains message if {
+    not input.user
+    # value returned from a function call, not suggested if `only-literals` is set to `true`
+    message := sprintf("user attribute missing from input: %v", [input])
+}
+```
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  custom:
+    prefer-value-in-head:
+      # note that all rules in the "custom" category are disabled by default
+      # (i.e. level "ignore")
+      #
+      # one of "error", "warning", "ignore"
+      level: error
+      # whether to only suggest moving literal values to the head, and not
+      # expressions or functions
+      only-literals: false
+```
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!


### PR DESCRIPTION
This is a custom rule allowing teams to standardize on this as a preference should they want to.

Fixes #398

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->