### PR TITLE
`identically-named-tests`: add precise location

### DIFF
--- a/bundle/regal/rules/testing/identically_named_tests.rego
+++ b/bundle/regal/rules/testing/identically_named_tests.rego
@@ -16,7 +16,10 @@ report contains violation if {
 
 	name in array.slice(test_names, 0, i)
 
-	# We don't currently have location for rule heads, but this should
-	# change soon: https://github.com/open-policy-agent/opa/pull/5811
-	violation := result.fail(rego.metadata.chain(), {"location": {"file": input.regal.file.name}})
+	violation := result.fail(rego.metadata.chain(), result.location(rule_by_name(name, ast.tests)))
 }
+
+rule_by_name(name, rules) := regal.last([rule |
+	some rule in rules
+	rule.head.ref[0].value == name
+])

--- a/bundle/regal/rules/testing/identically_named_tests_test.rego
+++ b/bundle/regal/rules/testing/identically_named_tests_test.rego
@@ -14,8 +14,8 @@ test_fail_identically_named_tests if {
 	test_foo { false }
 	test_foo { true }
 	`)
-	result := rule.report with input as ast
-	result == {{
+	r := rule.report with input as ast
+	r == {{
 		"category": "testing",
 		"description": "Multiple tests with same name",
 		"related_resources": [{
@@ -23,7 +23,7 @@ test_fail_identically_named_tests if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/identically-named-tests", "testing"),
 		}],
 		"title": "identically-named-tests",
-		"location": {"file": "foo_test.rego"},
+		"location": {"col": 2, "file": "foo_test.rego", "row": 5, "text": "\ttest_foo { true }"},
 		"level": "error",
 	}}
 }
@@ -36,6 +36,6 @@ test_success_differently_named_tests if {
 	test_bar { true }
 	test_baz { 1 == 1 }
 	`)
-	result := rule.report with input as ast
-	result == set()
+	r := rule.report with input as ast
+	r == set()
 }

--- a/docs/rules/style/rule-length.md
+++ b/docs/rules/style/rule-length.md
@@ -18,7 +18,7 @@ Splitting up large rules into smaller ones, and liberally using helper rules and
 others to read and understand, and for yourself and your team to maintain.
 
 Note that this rule only counts the number of lines of a rule, and currently does not take into account the actual
-content inside of a rule. Neither does it try to analyze the complexity of the code in the rule.
+content inside of it. Neither does it try to analyze the complexity of the code in the rule.
 
 ## Configuration Options
 
@@ -36,7 +36,7 @@ rules:
       # likely an assignment of long values rather than a "rule"
       # with conditions:
       #
-      # users = [ 
+      # users := [
       #     {"username": "ted"},
       #     {"username": "alice"},
       #     {"username": "bob"},


### PR DESCRIPTION
We did not have that option when this rule was written, but we do now.

Also some unrelated doc fixes for the `rule-length` rule.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->