### PR TITLE
`equals-pattern-matching`: fix false positive with `else`

### DIFF
--- a/bundle/regal/rules/idiomatic/equals_pattern_matching.rego
+++ b/bundle/regal/rules/idiomatic/equals_pattern_matching.rego
@@ -19,6 +19,8 @@ report contains violation if {
 	some fn in ast.functions
 	ast.generated_body(fn)
 
+	not fn["else"]
+
 	arg_var_names := {arg.value |
 		some arg in fn.head.args
 		arg.type == "var"
@@ -42,6 +44,8 @@ report contains violation if {
 report contains violation if {
 	some fn in ast.functions
 	not ast.generated_body(fn)
+
+	not fn["else"]
 
 	arg_var_names := {arg.value |
 		some arg in fn.head.args

--- a/bundle/regal/rules/idiomatic/equals_pattern_matching_test.rego
+++ b/bundle/regal/rules/idiomatic/equals_pattern_matching_test.rego
@@ -61,6 +61,15 @@ test_success_actually_pattern_matching if {
 	r == set()
 }
 
+test_success_skipped_on_else if {
+	module := ast.policy(`f(x) {
+		x == 1
+	} else := false`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
 expected := {
 	"category": "idiomatic",
 	"description": "Prefer pattern matching in function arguments",


### PR DESCRIPTION
Fixes #433

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->