### PR TITLE
`rule-length`: add `count-comments` configuration option

### DIFF
--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -93,6 +93,7 @@ rules:
       ignore-nesting-level: 2
       level: error
     rule-length:
+      count-comments: false
       except-empty-body: true
       level: error
       max-rule-length: 30

--- a/bundle/regal/rules/style/rule_length_test.rego
+++ b/bundle/regal/rules/style/rule_length_test.rego
@@ -21,6 +21,7 @@ test_fail_rule_longer_than_configured_max_length if {
 	r := rule.report with input as module with config.for_rule as {
 		"level": "error",
 		"max-rule-length": 3,
+		"count-comments": true,
 	}
 	r == {{
 		"category": "style",
@@ -49,6 +50,26 @@ test_success_rule_not_longer_than_configured_max_length if {
 	r := rule.report with input as module with config.for_rule as {
 		"level": "error",
 		"max-rule-length": 30,
+		"count-comments": true,
+	}
+	r == set()
+}
+
+test_success_rule_longer_than_configured_max_length_but_comments if {
+	module := regal.parse_module("policy.rego", `package p
+
+	my_short_rule {
+		# this rule is not longer than the configured max length
+		# which in this case is 30 lines
+		#
+		input.x
+	}
+	`)
+
+	r := rule.report with input as module with config.for_rule as {
+		"level": "error",
+		"max-rule-length": 2,
+		"count-comments": false,
 	}
 	r == set()
 }
@@ -62,6 +83,7 @@ test_success_rule_length_equals_max_length if {
 	r := rule.report with input as module with config.for_rule as {
 		"level": "error",
 		"max-rule-length": 1,
+		"count-comments": false,
 	}
 	r == set()
 }

--- a/docs/rules/style/rule-length.md
+++ b/docs/rules/style/rule-length.md
@@ -32,6 +32,9 @@ rules:
       level: error
       # default limit is 30 lines
       max-rule-length: 30
+      # whether to count comments as lines
+      # by default, this is set to false
+      count-comments: false
       # except rules with empty bodies from this rule, as they're
       # likely an assignment of long values rather than a "rule"
       # with conditions:

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -154,6 +154,7 @@ rule_length {
 	input.x28
 	input.x29
 	input.x30
+	input.x31
 }
 
 default_over_else := 1 {


### PR DESCRIPTION
This is set to `false` by default, as we don't want to "punish" comments in rules.

Fixes #432