### PR TITLE
Optimization: less use of walk

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -299,10 +299,10 @@ is_output_var(rule, ref, location) if {
 	not ref.value in (find_names_in_scope(rule, location) - find_some_decl_names_in_scope(rule, location))
 }
 
-all_refs := [value.value |
+all_refs := [value |
 	walk(input.rules, [_, value])
 
-	value.type == "ref"
+	value[0].type == "ref"
 ]
 
 ref_to_string(ref) := concat(".", [_ref_part_to_string(i, part) | some i, part in ref])
@@ -319,13 +319,13 @@ _ref_part_to_string(i, ref) := concat("", ["$", ref.value]) if {
 # METADATA
 # description: provides a set of all built-in function calls made in input policy
 builtin_functions_called contains name if {
-	some ref in all_refs
+	some value in all_refs
 
-	ref[0].type == "var"
-	not ref[0].value in {"input", "data"}
+	value[0].value[0].type == "var"
+	not value[0].value[0].value in {"input", "data"}
 
 	name := concat(".", [value |
-		some part in ref
+		some part in value[0].value
 		value := part.value
 	])
 

--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -4,6 +4,7 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.config
 
 lint.notices := notices
@@ -154,8 +155,8 @@ ignored(violation, directives) if {
 }
 
 ignore_directives[row] := rules if {
-	some comment in input.comments
-	text := trim_space(base64.decode(comment.Text))
+	some comment in ast.comments_decoded
+	text := trim_space(comment.Text)
 
 	startswith(text, "regal")
 

--- a/bundle/regal/main.rego
+++ b/bundle/regal/main.rego
@@ -37,6 +37,14 @@ report contains violation if {
 	}
 }
 
+rules_to_run[category][title] if {
+	some category, title
+	config.merged_config.rules[category][title]
+
+	config.for_rule(category, title).level != "ignore"
+	not config.excluded_file(category, title, input.regal.file.name)
+}
+
 notices contains notice if {
 	some category, title
 	some notice in grouped_notices[category][title]
@@ -44,9 +52,7 @@ notices contains notice if {
 
 grouped_notices[category][title] contains notice if {
 	some category, title
-	config.merged_config.rules[category][title]
-
-	config.for_rule(category, title).level != "ignore"
+	rules_to_run[category][title]
 
 	some notice in data.regal.rules[category][title].notices
 }
@@ -54,10 +60,7 @@ grouped_notices[category][title] contains notice if {
 # Check bundled rules
 report contains violation if {
 	some category, title
-	config.merged_config.rules[category][title]
-
-	config.for_rule(category, title).level != "ignore"
-	not config.excluded_file(category, title, input.regal.file.name)
+	rules_to_run[category][title]
 
 	count(object.get(grouped_notices, [category, title], [])) == 0
 
@@ -81,10 +84,7 @@ report contains violation if {
 # Collect aggregates in bundled rules
 aggregate[category_title] contains entry if {
 	some category, title
-	config.merged_config.rules[category][title]
-
-	config.for_rule(category, title).level != "ignore"
-	not config.excluded_file(category, title, input.regal.file.name)
+	rules_to_run[category][title]
 
 	some entry in data.regal.rules[category][title].aggregate
 
@@ -109,10 +109,7 @@ aggregate[category_title] contains entry if {
 #   - input: schema.regal.aggregate
 aggregate_report contains violation if {
 	some category, title
-	config.merged_config.rules[category][title]
-
-	config.for_rule(category, title).level != "ignore"
-	not config.excluded_file(category, title, input.regal.file.name)
+	rules_to_run[category][title]
 
 	key := concat("/", [category, title])
 	input_for_rule := object.remove(

--- a/bundle/regal/rules/custom/forbidden_function_call.rego
+++ b/bundle/regal/rules/custom/forbidden_function_call.rego
@@ -23,7 +23,7 @@ report contains violation if {
 
 	some ref in ast.all_refs
 
-	name := ast.ref_to_string(ref)
+	name := ast.ref_to_string(ref[0].value)
 	name in cfg["forbidden-functions"]
 
 	violation := result.fail(rego.metadata.chain(), result.location(ref))

--- a/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
@@ -42,9 +42,8 @@ report contains violation if {
 	# skip expensive walk if no builtin regex function calls are registered
 	any_regex_function_called
 
-	walk(input.rules, [_, value])
+	some value in ast.all_refs
 
-	value[0].type == "ref"
 	value[0].value[0].type == "var"
 	value[0].value[0].value == "regex"
 

--- a/bundle/regal/rules/imports/prefer_package_imports.rego
+++ b/bundle/regal/rules/imports/prefer_package_imports.rego
@@ -16,8 +16,9 @@ aggregate contains entry if {
 		some _import in input.imports
 
 		_import.path.value[0].value == "data"
-		count(_import.path.value) > 1
-		path := [part.value | some part in array.slice(_import.path.value, 1, count(_import.path.value))]
+		len := count(_import.path.value)
+		len > 1
+		path := [part.value | some part in array.slice(_import.path.value, 1, len)]
 
 		imp := object.union(result.location(_import), {"path": path})
 	]

--- a/bundle/regal/rules/style/function_arg_return.rego
+++ b/bundle/regal/rules/style/function_arg_return.rego
@@ -18,9 +18,7 @@ report contains violation if {
 	# note that traversing the ast.all_refs is not enough here,
 	# as we need the outer node to determine the arguments provided
 	# to the function call
-	walk(input.rules, [path, value])
-
-	regal.last(path) == "terms"
+	walk(input.rules, [_, value])
 
 	value[0].type == "ref"
 	value[0].value[0].type == "var"

--- a/bundle/regal/rules/style/todo_comment.rego
+++ b/bundle/regal/rules/style/todo_comment.rego
@@ -6,6 +6,7 @@ import future.keywords.contains
 import future.keywords.if
 import future.keywords.in
 
+import data.regal.ast
 import data.regal.result
 
 # For comments, OPA uses capital-cases Text and Location rather
@@ -17,9 +18,8 @@ todo_identifiers := ["todo", "TODO", "fixme", "FIXME"]
 todo_pattern := sprintf(`^\s*(%s)`, [concat("|", todo_identifiers)])
 
 report contains violation if {
-	some comment in input.comments
-	text := base64.decode(comment.Text)
-	regex.match(todo_pattern, text)
+	some comment in ast.comments_decoded
+	regex.match(todo_pattern, comment.Text)
 
 	violation := result.fail(rego.metadata.chain(), result.location(comment))
 }

--- a/bundle/regal/rules/style/yoda_condition.rego
+++ b/bundle/regal/rules/style/yoda_condition.rego
@@ -10,9 +10,8 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	walk(input.rules, [_, value])
+	some value in ast.all_refs
 
-	value[0].type == "ref"
 	value[0].value[0].type == "var"
 	value[0].value[0].value in {"equal", "neq"} # perhaps add more operators here?
 	value[1].type in ast.scalar_types

--- a/bundle/regal/rules/testing/dubious_print_sprintf.rego
+++ b/bundle/regal/rules/testing/dubious_print_sprintf.rego
@@ -13,9 +13,8 @@ report contains violation if {
 	# skip expensive walk operation if no print calls are registered
 	"print" in ast.builtin_functions_called
 
-	walk(input.rules, [_, value])
+	some value in ast.all_refs
 
-	value[0].type == "ref"
 	value[0].value[0].type == "var"
 	value[0].value[0].value == "print"
 	value[1].type == "call"

--- a/bundle/regal/rules/testing/print_or_trace_call.rego
+++ b/bundle/regal/rules/testing/print_or_trace_call.rego
@@ -20,8 +20,8 @@ report contains violation if {
 
 	some ref in ast.all_refs
 
-	ref[0].type == "var"
-	ref[0].value in {"print", "trace"}
+	ref[0].value[0].type == "var"
+	ref[0].value[0].value in {"print", "trace"}
 
 	violation := result.fail(rego.metadata.chain(), result.location(ref[0]))
 }


### PR DESCRIPTION
The rules that walk refs may benefit from having the AST tree walked *once* with refs collected, and then simply iterate over that collection. Also, a few  micro-optimizations in the hotspots reported by `--profile`.

Eval time reduced by 4-5%, so nothing dramatic, but still good.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->