### PR TITLE
Rule: `use-if` and `use-contains`

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ The following rules are currently available:
 | idiomatic | [no-defined-entrypoint](https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint)         | Missing entrypoint annotation                             |
 | idiomatic | [non-raw-regex-pattern](https://docs.styra.com/regal/rules/idiomatic/non-raw-regex-pattern)         | Use raw strings for regex patterns                        |
 | idiomatic | [prefer-set-or-object-rule](https://docs.styra.com/regal/rules/idiomatic/prefer-set-or-object-rule) | Prefer set or object rule over comprehension              |
+| idiomatic | [use-contains](https://docs.styra.com/regal/rules/idiomatic/use-contains)                           | Use the `contains` keyword                                |
+| idiomatic | [use-if](https://docs.styra.com/regal/rules/idiomatic/use-if)                                       | Use the `if` keyword                                      |
 | idiomatic | [use-in-operator](https://docs.styra.com/regal/rules/idiomatic/use-in-operator)                     | Use in to check for membership                            |
 | idiomatic | [use-some-for-output-vars](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars)   | Use `some` to declare output variables                    |
 | imports   | [avoid-importing-input](https://docs.styra.com/regal/rules/imports/avoid-importing-input)           | Avoid importing input                                     |

--- a/bundle/regal/capabilities.rego
+++ b/bundle/regal/capabilities.rego
@@ -19,4 +19,10 @@ has_object_keys if "object.keys" in object.keys(config.capabilities.builtins)
 # if if if!
 has_if if "if" in config.capabilities.future_keywords
 
-has_if if "rego_v1_import" in config.capabilities.features
+has_if if has_rego_v1_feature
+
+has_contains if "contains" in config.capabilities.future_keywords
+
+has_contains if has_rego_v1_feature
+
+has_rego_v1_feature if "rego_v1_import" in config.capabilities.features

--- a/bundle/regal/config/config_test.rego
+++ b/bundle/regal/config/config_test.rego
@@ -1,5 +1,7 @@
 package regal.config_test
 
+import future.keywords.if
+
 import data.regal.config
 
 rules_config := {"rules": {"test": {"test-case": {
@@ -18,20 +20,20 @@ params := {
 
 # disable all
 
-test_disable_all_no_config {
+test_disable_all_no_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_all": true})
 
 	c == {"level": "ignore"}
 }
 
-test_disable_all_with_config {
+test_disable_all_with_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_all": true})
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
 }
 
-test_disable_all_with_category_override {
+test_disable_all_with_category_override if {
 	p := object.union(params, {"disable_all": true, "enable_category": ["test"]})
 	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
@@ -39,7 +41,7 @@ test_disable_all_with_category_override {
 	c == {"level": "error", "important_setting": 42}
 }
 
-test_disable_all_with_rule_override {
+test_disable_all_with_rule_override if {
 	p := object.union(params, {"disable_all": true, "enable": ["test-case"]})
 	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
@@ -49,20 +51,20 @@ test_disable_all_with_rule_override {
 
 # disable category
 
-test_disable_category_no_config {
+test_disable_category_no_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_category": ["test"]})
 
 	c == {"level": "ignore"}
 }
 
-test_disable_category_with_config {
+test_disable_category_with_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable_category": ["test"]})
 		with config.merged_config as rules_config
 
 	c == {"level": "ignore", "important_setting": 42}
 }
 
-test_disable_category_with_rule_override {
+test_disable_category_with_rule_override if {
 	p := object.union(params, {"disable_category": ["test"], "enable": ["test-case"]})
 	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
@@ -72,13 +74,13 @@ test_disable_category_with_rule_override {
 
 # disable rule
 
-test_disable_single_rule {
+test_disable_single_rule if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable": ["test-case"]})
 
 	c == {"level": "ignore"}
 }
 
-test_disable_single_rule_with_config {
+test_disable_single_rule_with_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"disable": ["test-case"]})
 		with config.merged_config as rules_config
 
@@ -87,20 +89,20 @@ test_disable_single_rule_with_config {
 
 # enable all
 
-test_enable_all_no_config {
+test_enable_all_no_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_all": true})
 
 	c == {"level": "error"}
 }
 
-test_enable_all_with_config {
+test_enable_all_with_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_all": true})
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
 }
 
-test_enable_all_with_category_override {
+test_enable_all_with_category_override if {
 	p := object.union(params, {"enable_all": true, "disable_category": ["test"]})
 	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
@@ -108,7 +110,7 @@ test_enable_all_with_category_override {
 	c == {"level": "ignore", "important_setting": 42}
 }
 
-test_enable_all_with_rule_override {
+test_enable_all_with_rule_override if {
 	p := object.union(params, {"enable_all": true, "disable": ["test-case"]})
 	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
@@ -118,20 +120,20 @@ test_enable_all_with_rule_override {
 
 # disable category
 
-test_enable_category_no_config {
+test_enable_category_no_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_category": ["test"]})
 
 	c == {"level": "error"}
 }
 
-test_enable_category_with_config {
+test_enable_category_with_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable_category": ["test"]})
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
 }
 
-test_enable_category_with_rule_override {
+test_enable_category_with_rule_override if {
 	p := object.union(params, {"enable_category": ["test"], "disable": ["test-case"]})
 	c := config.for_rule("test", "test-case") with data.eval.params as p
 		with config.merged_config as rules_config
@@ -141,20 +143,20 @@ test_enable_category_with_rule_override {
 
 # enable rule
 
-test_enable_single_rule {
+test_enable_single_rule if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable": ["test-case"]})
 
 	c == {"level": "error"}
 }
 
-test_enable_single_rule_with_config {
+test_enable_single_rule_with_config if {
 	c := config.for_rule("test", "test-case") with data.eval.params as object.union(params, {"enable": ["test-case"]})
 		with config.merged_config as rules_config
 
 	c == {"level": "error", "important_setting": 42}
 }
 
-test_all_rules_are_in_provided_configuration {
+test_all_rules_are_in_provided_configuration if {
 	missing_config := {title |
 		some category, title
 		data.regal.rules[category][title]
@@ -165,7 +167,7 @@ test_all_rules_are_in_provided_configuration {
 	count(missing_config) == 0
 }
 
-test_all_configured_rules_exist {
+test_all_configured_rules_exist if {
 	go_rules := {"opa-fmt"}
 
 	missing_rules := {title |

--- a/bundle/regal/config/exclusion_test.rego
+++ b/bundle/regal/config/exclusion_test.rego
@@ -1,5 +1,7 @@
 package regal.config_test
 
+import future.keywords.if
+
 import data.regal.config
 
 # map[pattern: string]map[filename: string]excluded: bool
@@ -42,7 +44,7 @@ cases := {
 	},
 }
 
-test_all_cases_are_as_expected {
+test_all_cases_are_as_expected if {
 	not_exp := {pattern: res |
 		subcases := cases[pattern]
 		res := {file: res1 |
@@ -63,26 +65,26 @@ rules_config_ignore_delta := {"rules": {"test": {"test-case": {"ignore": {"files
 
 config_ignore := {"ignore": {"files": ["p.rego"]}}
 
-test_excluded_file_default {
+test_excluded_file_default if {
 	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
 		with config.merged_config as rules_config_error
 
 	e == false
 }
 
-test_excluded_file_with_ignore {
+test_excluded_file_with_ignore if {
 	c := object.union(rules_config_error, rules_config_ignore_delta)
 	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
 		with config.merged_config as c
 	e == true
 }
 
-test_excluded_file_config {
+test_excluded_file_config if {
 	e := config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
 	e == true
 }
 
-test_excluded_file_cli_flag {
+test_excluded_file_cli_flag if {
 	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as object.union(
 		params,
 		{"ignore_files": ["p.rego"]},
@@ -90,7 +92,7 @@ test_excluded_file_cli_flag {
 	e == true
 }
 
-test_excluded_file_cli_overrides_config {
+test_excluded_file_cli_overrides_config if {
 	e := config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
 		with data.eval.params as object.union(params, {"ignore_files": [""]})
 	e == false

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -44,6 +44,10 @@ rules:
       level: error
     prefer-set-or-object-rule:
       level: error
+    use-contains:
+      level: error
+    use-if:
+      level: error
     use-in-operator:
       level: error
     use-some-for-output-vars:

--- a/bundle/regal/rules/idiomatic/use_contains.rego
+++ b/bundle/regal/rules/idiomatic/use_contains.rego
@@ -1,0 +1,30 @@
+# METADATA
+# description: Use the `contains` keyword
+package regal.rules.idiomatic["use-contains"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.capabilities
+import data.regal.result
+
+# METADATA
+# description: Missing capability for keyword `contains`
+# custom:
+#   severity: warning
+notices contains result.notice(rego.metadata.chain()) if not capabilities.has_contains
+
+report contains violation if {
+	some rule in ast.rules
+
+	rule.head.key
+	not rule.head.value
+
+	text := base64.decode(rule.head.location.text)
+
+	not contains(text, " contains ")
+
+	violation := result.fail(rego.metadata.chain(), result.location(rule))
+}

--- a/bundle/regal/rules/idiomatic/use_contains_test.rego
+++ b/bundle/regal/rules/idiomatic/use_contains_test.rego
@@ -1,0 +1,47 @@
+package regal.rules.idiomatic["use-contains_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.idiomatic["use-contains"] as rule
+
+test_fail_should_use_contains if {
+	module := ast.with_future_keywords(`rule[item] {
+		some item in input.items
+	}`)
+
+	r := rule.report with input as module
+	r == {{
+		"category": "idiomatic",
+		"description": "Use the `contains` keyword",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 8, "text": "rule[item] {"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-contains", "idiomatic"),
+		}],
+		"title": "use-contains",
+	}}
+}
+
+test_success_uses_contains if {
+	module := ast.with_future_keywords(`rule contains item if {
+		some item in input.items
+	}`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_object_rule if {
+	module := ast.with_future_keywords(`rule[foo] := bar if {
+		foo := "bar"
+		bar := "baz"
+	}`)
+
+	r := rule.report with input as module
+	r == set()
+}

--- a/bundle/regal/rules/idiomatic/use_if.rego
+++ b/bundle/regal/rules/idiomatic/use_if.rego
@@ -1,0 +1,34 @@
+# METADATA
+# description: Use the `if` keyword
+package regal.rules.idiomatic["use-if"]
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.capabilities
+import data.regal.result
+
+# Note: think more about what UX we want when import_rego_v1
+# capbility is available. Should we simply just recommend that
+# and silence this rule in that case? I'm inclined to say yes.
+
+# METADATA
+# description: Missing capability for keyword `if`
+# custom:
+#   severity: warning
+notices contains result.notice(rego.metadata.chain()) if not capabilities.has_if
+
+report contains violation if {
+	some rule in input.rules
+
+	not ast.generated_body(rule)
+
+	head_len := count(base64.decode(rule.head.location.text))
+	text := trim_space(substring(base64.decode(rule.location.text), head_len, -1))
+
+	not startswith(text, "if")
+
+	violation := result.fail(rego.metadata.chain(), result.location(rule))
+}

--- a/bundle/regal/rules/idiomatic/use_if_test.rego
+++ b/bundle/regal/rules/idiomatic/use_if_test.rego
@@ -1,0 +1,48 @@
+package regal.rules.idiomatic["use-if_test"]
+
+import future.keywords.if
+import future.keywords.in
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.idiomatic["use-if"] as rule
+
+test_fail_should_use_if if {
+	module := ast.with_future_keywords(`rule := [true |
+		input[_]
+	] {
+		input.attribute
+	}`)
+
+	r := rule.report with input as module
+	r == {{
+		"category": "idiomatic",
+		"description": "Use the `if` keyword",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 8, "text": "rule := [true |"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/use-if", "idiomatic"),
+		}],
+		"title": "use-if",
+	}}
+}
+
+test_success_uses_if if {
+	module := ast.with_future_keywords(`rule := [true |
+		input[_]
+	] if {
+		input.attribute
+	}`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_no_body_no_if if {
+	module := ast.with_future_keywords(`rule := "without body"`)
+
+	r := rule.report with input as module
+	r == set()
+}

--- a/docs/rules/idiomatic/use-contains.md
+++ b/docs/rules/idiomatic/use-contains.md
@@ -1,0 +1,71 @@
+# use-contains
+
+**Summary**: Use the `contains` keyword
+
+**Category**: Idiomatic
+
+**Avoid**
+```rego
+package policy
+
+import future.keywords.in
+
+report[item] if {
+    some item in input.items
+    startswith(item, "report")
+}
+
+# unconditinally add an item to report
+report["report1"]
+```
+
+**Prefer**
+```rego
+package policy
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+report contains item if {
+    some item in input.items
+    startswith(item, "report")
+}
+
+# unconditinally add an item to report
+report contains "report1"
+```
+
+## Rationale
+
+The `contains` keyword helps to clearly distinguish *multi-value rules* (or "partial rules") from
+single-value rules ("complete rules"). Just like the `if` keyword, `contains` additionally makes the rule read the same
+way in English as OPA interprets its meaning — a set that contains one or more values given some (optional) conditions.
+
+**Note**: don't forget to `import future.keywords.contains`! Or from OPA v0.59.0 and onwards, `import rego.v1`.
+
+**Tip**: When either of the imports mentioned above are found in a Rego file, the `contains` keyword will be inserted
+automatically at any applicable location by the `opa fmt` tool.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  idiomatic:
+    use-contains:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Regal Docs: [use-if](https://docs.styra.com/regal/rules/idiomatic/use-if)
+- OPA Docs: [Future Keywords](https://www.openpolicyagent.org/docs/latest/policy-language/#future-keywords)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/docs/rules/idiomatic/use-if.md
+++ b/docs/rules/idiomatic/use-if.md
@@ -1,0 +1,69 @@
+# use-if
+
+**Summary**: Use the `if` keyword
+
+**Category**: Idiomatic
+
+**Avoid**
+```rego
+package policy
+
+import future.keywords.in
+
+is_admin {
+    "admin" in input.user.roles
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+import future.keywords.if
+import future.keywords.in
+
+is_admin if {
+    "admin" in input.user.roles
+}
+
+# alternatively
+
+is_admin if "admin" in input.user.roles
+```
+
+## Rationale
+
+The `if` keyword helps communicate what Rego rules really are — conditional assignments. Using `if` in other words makes
+the rule read the same way in English as it will be interpreted by OPA, i.e: 
+
+```rego
+rule := "some value" if some_condition
+```
+
+**Note**: don't forget to `import future.keywords.if`! Or from OPA v0.59.0 and onwards, `import rego.v1`. 
+
+**Tip**: When either of the imports mentioned above are found in a Rego file, the `if` keyword will be inserted
+automatically at any applicable location by the `opa fmt` tool.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules: 
+  idiomatic:
+    use-if:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Regal Docs: [use-contains](https://docs.styra.com/regal/rules/idiomatic/use-contains)
+- OPA Docs [Future Keywords](https://www.openpolicyagent.org/docs/latest/policy-language/#future-keywords)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/capabilities/custom_has_key.rego
+++ b/e2e/testdata/capabilities/custom_has_key.rego
@@ -1,5 +1,7 @@
 package custom_has_key
 
-has_key(map, key) {
+import future.keywords.if
+
+has_key(map, key) if {
 	_ = map[key]
 }

--- a/e2e/testdata/capabilities/custom_has_key_2.rego
+++ b/e2e/testdata/capabilities/custom_has_key_2.rego
@@ -1,7 +1,9 @@
 package custom_has_key_2
 
+import future.keywords.if
+
 # This is here to make sure we deal with multiple notices correctly,
 # and don't report duplicates multiple times.
-has_key(map, key) {
+has_key(map, key) if {
 	_ = map[key]
 }

--- a/e2e/testdata/custom_naming_convention/policy.rego
+++ b/e2e/testdata/custom_naming_convention/policy.rego
@@ -1,8 +1,10 @@
 # package name must start with "acmecorp"
 package this.fails
 
+import future.keywords.if
+
 # rules must either start with "_" or be named "allow"
-naming_convention_fail {
+naming_convention_fail if {
 	input.foo == "bar"
 }
 

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -35,7 +35,7 @@ import data.after.rule
 
 ### Bugs ###
 
-constant_condition {
+constant_condition if {
 	1 == 1
 }
 
@@ -43,7 +43,7 @@ constant_condition {
 # invalid-metadata-attribute: true
 should := "fail"
 
-not_equals_in_loop {
+not_equals_in_loop if {
 	"foo" != input.bar[_]
 }
 
@@ -52,17 +52,17 @@ contains := true
 
 top_level_iteration := input[_]
 
-unused_return_value {
+unused_return_value if {
 	indexof("foo", "o")
 }
 
 zero_arity_function() := true
 
-inconsistent_args(a, b) {
+inconsistent_args(a, b) if {
 	a == b
 }
 
-inconsistent_args(b, a) {
+inconsistent_args(b, a) if {
 	b == a
 }
 
@@ -70,27 +70,35 @@ if_empty_object if {}
 
 ### Idiomatic ###
 
-custom_has_key_construct(map, key) {
+custom_has_key_construct(map, key) if {
 	_ = map[key]
 }
 
-custom_in_construct(coll, item) {
+custom_in_construct(coll, item) if {
 	item == coll[_]
 }
 
-use_some_for_output_vars {
+use_some_for_output_vars if {
 	input.foo[output_var]
 }
 
 non_raw_regex_pattern := regex.match("[0-9]", "1")
 
-use_in_operator {
+use_in_operator if {
 	"item" == input.coll[_]
 }
 
 prefer_set_or_object_rule := {x | some x in input; x == "violation"}
 
 equals_pattern_matching(x) := x == "x"
+
+use_if {
+	data.foo
+}
+
+use_contains[item] {
+	some item in input.items
+}
 
 ### Style ###
 
@@ -102,11 +110,11 @@ get_foo(foo) := foo
 
 annotation := "detached"
 
-external_reference(_) {
+external_reference(_) if {
 	data.foo
 }
 
-function_arg_return {
+function_arg_return if {
 	indexof("foo", "o", i)
 	i == 1
 }
@@ -121,19 +129,19 @@ preferSnakeCase := "fail"
 
 # todo-comment
 
-x := y {
+x := y if {
 	y := 1
 }
 
 use_assignment = "oparator"
 
-chained_rule_body {
+chained_rule_body if {
 	input.x
 } {
 	input.y
 }
 
-rule_length {
+rule_length if {
 	input.x1
 	input.x2
 	input.x3
@@ -167,15 +175,15 @@ rule_length {
 	input.x31
 }
 
-default_over_else := 1 {
+default_over_else := 1 if {
 	input.x
 } else := 3
 
-unnecessary_some {
+unnecessary_some if {
 	some "x" in ["x"]
 }
 
-yoda_condition {
+yoda_condition if {
 	"foo" == input.bar
 }
 
@@ -185,11 +193,11 @@ yoda_condition {
 test_identically_named_tests := true
 test_identically_named_tests := true
 
-todo_test_bad {
+todo_test_bad if {
 	input.bad
 }
 
-print_or_trace_call {
+print_or_trace_call if {
 	print("forbidden!")
 }
 
@@ -197,6 +205,6 @@ print_or_trace_call {
 foo := "bar"
 
 # dubious print sprintf
-y {
+y if {
 	print(sprintf("name is: %s domain is: %s", [input.name, input.domain]))
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -21,9 +21,12 @@ func TestLintWithDefaultBundle(t *testing.T) {
 
 	input := test.InputPolicy("p.rego", `package p
 
+import future.keywords.if
+
 # TODO: fix this
-camelCase {
+camelCase if {
 	input.one == 1
+	input.two == 2
 }
 `)
 
@@ -39,7 +42,7 @@ camelCase {
 		t.Errorf("expected first violation to be 'todo-comments', got %s", result.Violations[0].Title)
 	}
 
-	if result.Violations[0].Location.Row != 3 {
+	if result.Violations[0].Location.Row != 5 {
 		t.Errorf("expected first violation to be on line 3, got %d", result.Violations[0].Location.Row)
 	}
 
@@ -55,7 +58,7 @@ camelCase {
 		t.Errorf("expected second violation to be 'prefer-snake-case', got %s", result.Violations[1].Title)
 	}
 
-	if result.Violations[1].Location.Row != 4 {
+	if result.Violations[1].Location.Row != 6 {
 		t.Errorf("expected second violation to be on line 4, got %d", result.Violations[1].Location.Row)
 	}
 
@@ -63,8 +66,9 @@ camelCase {
 		t.Errorf("expected second violation to be on column 1, got %d", result.Violations[1].Location.Column)
 	}
 
-	if *result.Violations[1].Location.Text != "camelCase {" {
-		t.Errorf("expected second violation to be on 'camelCase {', got %s", *result.Violations[1].Location.Text)
+	if *result.Violations[1].Location.Text != "camelCase if {" {
+		t.Errorf("expected second violation to be on 'camelCase if {', got %s",
+			*result.Violations[1].Location.Text)
 	}
 }
 


### PR DESCRIPTION
Recommend the use of `if` and `contains` when available as capabilities.

Some fixes to tests where we didn't live up to this standard ourselves. Great!

(Note that this is targeting the `if-empty-object` branch as that contained a few improvements that I wanted here, so that should be merged before this PR)

Fixes #468