### PR TITLE
Use capabilities from v0.58.0

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -400,6 +400,20 @@ is_chained_rule_body(rule, lines) if {
 	startswith(col_text, "{")
 }
 
+default imports := []
+
+# METADATA
+# description: |
+#   same as input.imports but with a default value (`[]`), making
+#   it safe to refer to without risk of halting evaluation
+imports := input.imports
+
+imports_has_path(imports, path) if {
+	some imp in imports
+
+	_arr(imp) == path
+}
+
 # METADATA
 # description: |
 #   returns whether a keyword is imported in the policy, either explicitly
@@ -407,10 +421,10 @@ is_chained_rule_body(rule, lines) if {
 imports_keyword(imports, keyword) if {
 	some imp in imports
 
-	_has_keyword(arr(imp), keyword)
+	_has_keyword(_arr(imp), keyword)
 }
 
-arr(xs) := [y.value | some y in xs.path.value]
+_arr(xs) := [y.value | some y in xs.path.value]
 
 _has_keyword(["future", "keywords"], _)
 

--- a/bundle/regal/rules/idiomatic/use_contains.rego
+++ b/bundle/regal/rules/idiomatic/use_contains.rego
@@ -15,6 +15,9 @@ import data.regal.result
 notices contains result.notice(rego.metadata.chain()) if not capabilities.has_contains
 
 report contains violation if {
+	# if rego.v1 is imported, OPA will ensure this anyway
+	not ast.imports_has_path(ast.imports, ["rego", "v1"])
+
 	some rule in ast.rules
 
 	rule.head.key

--- a/bundle/regal/rules/idiomatic/use_if.rego
+++ b/bundle/regal/rules/idiomatic/use_if.rego
@@ -19,6 +19,9 @@ import data.regal.result
 notices contains result.notice(rego.metadata.chain()) if not capabilities.has_if
 
 report contains violation if {
+	# if rego.v1 is imported, OPA will ensure this anyway
+	not ast.imports_has_path(ast.imports, ["rego", "v1"])
+
 	some rule in input.rules
 
 	not ast.generated_body(rule)

--- a/docs/rules/idiomatic/use-contains.md
+++ b/docs/rules/idiomatic/use-contains.md
@@ -42,6 +42,9 @@ The `contains` keyword helps to clearly distinguish *multi-value rules* (or "par
 single-value rules ("complete rules"). Just like the `if` keyword, `contains` additionally makes the rule read the same
 way in English as OPA interprets its meaning — a set that contains one or more values given some (optional) conditions.
 
+OPA version 1.0, which is planned for 2024, will make the `contains` keyword mandatory. This rule helps you get ahead of
+the curve and start using it today.
+
 **Note**: don't forget to `import future.keywords.contains`! Or from OPA v0.59.0 and onwards, `import rego.v1`.
 
 **Tip**: When either of the imports mentioned above are found in a Rego file, the `contains` keyword will be inserted

--- a/docs/rules/idiomatic/use-if.md
+++ b/docs/rules/idiomatic/use-if.md
@@ -40,6 +40,9 @@ the rule read the same way in English as it will be interpreted by OPA, i.e:
 rule := "some value" if some_condition
 ```
 
+OPA version 1.0, which is planned for 2024, will make the `if` keyword mandatory. This rule helps you get ahead of the
+curve and start using it today.
+
 **Note**: don't forget to `import future.keywords.if`! Or from OPA v0.59.0 and onwards, `import rego.v1`. 
 
 **Tip**: When either of the imports mentioned above are found in a Rego file, the `if` keyword will be inserted

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -212,7 +212,12 @@ func (config *Config) UnmarshalYAML(value *yaml.Node) error {
 
 // CapabilitiesForThisVersion returns the capabilities for the current OPA version Regal depends on.
 func CapabilitiesForThisVersion() *Capabilities {
-	return fromOPACapabilities(*ast.CapabilitiesForThisVersion())
+	caps, err := ast.LoadCapabilitiesVersion("v0.58.0")
+	if err != nil {
+		panic(fmt.Errorf("loading capabilities failed: %w", err))
+	}
+
+	return fromOPACapabilities(*caps)
 }
 
 func fromOPABuiltin(builtin ast.Builtin) *Builtin {


### PR DESCRIPTION
And not the later commit we're pointing at for rego.v1 functionality. We don't want to promote capabilities that users will need a dev version of OPA to get.

Also, don't run `use-contains` and `use-if` if `rego.v1` is imported, as that's enforced by OPA already.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->