### PR TITLE
Fix: false positive with `print` and `unused-return-value`

### DIFF
--- a/bundle/regal/rules/bugs/unused_return_value.rego
+++ b/bundle/regal/rules/bugs/unused_return_value.rego
@@ -17,6 +17,9 @@ report contains violation if {
 	ref_name := expr.terms[0].value[0].value
 	ref_name in ast.builtin_names
 
+	# special case as the "result" of print is ""
+	ref_name != "print"
+
 	config.capabilities.builtins[ref_name].decl.result != "boolean"
 
 	# no violation if the return value is declared as the last function argument

--- a/bundle/regal/rules/bugs/unused_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unused_return_value_test.rego
@@ -44,3 +44,11 @@ test_success_function_arg_return_ignored if {
 	}`)
 	r == set()
 }
+
+test_success_not_triggered_by_print if {
+	r := rule.report with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with input as ast.with_rego_v1(`allow if {
+		print(lower("A"))
+	}`)
+	r == set()
+}


### PR DESCRIPTION
Fixes #474

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->