### PR TITLE
Replace `replace` directive with direct version pinning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,8 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
+	// wasip1 support isn't in a tagged version yet, remove for v1.9.4
+	github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
@@ -58,6 +59,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-// wasip1 support isn't in a tagged version yet, remove for v1.9.4
-replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.9.4-0.20230606125235-dd1b4c2e81af


### PR DESCRIPTION
As noted in #490, by using a `replace` directive, we're unable to then `go
install` this project:

```
% go install github.com/StyraInc/regal@latest
go: downloading github.com/StyraInc/regal v0.13.0
go: github.com/StyraInc/regal@latest (in github.com/StyraInc/regal@v0.13.0):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```

Instead, we can replace this with a direct pinning to the commit we want to pull.

Closes #490.
