### PR TITLE
Add markdownlint for linting docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: open-policy-agent/setup-opa@v2
         with:
           version: edge
+      - run: npm install -g markdownlint-cli
       - run: go install git.sr.ht/~charles/rq/cmd/rq@latest
       - run: build/do.rq pull_request
       - uses: golangci/golangci-lint-action@v3.7.0

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Rego magnificent!
 
 \- [Merriam Webster](https://www.merriam-webster.com/dictionary/regal)
 
-
 ## Goals
 
 - Identify common mistakes, bugs and inefficiencies in Rego policies, and suggest better approaches
@@ -101,7 +100,7 @@ import future.keywords
 default allow = false
 
 deny if {
-	"admin" != input.user.roles[_]
+    "admin" != input.user.roles[_]
 }
 
 allow if not deny
@@ -112,6 +111,8 @@ Next, run `regal lint` pointed at one or more files or directories to have them 
 ```shell
 regal lint policy/
 ```
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable MD010 -->
 ```text
 Rule:         	not-equals-in-loop
 Description:  	Use of != in loop
@@ -136,6 +137,7 @@ Documentation:	https://docs.styra.com/regal/rules/style/use-assignment-operator
 
 1 file linted. 3 violations found.
 ```
+<!-- markdownlint-restore -->
 <br />
 
 > **Note**
@@ -217,7 +219,7 @@ The following rules are currently available:
 | imports   | [prefer-package-imports](https://docs.styra.com/regal/rules/imports/prefer-package-imports)         | Prefer importing packages over rules                      |
 | imports   | [redundant-alias](https://docs.styra.com/regal/rules/imports/redundant-alias)                       | Redundant alias                                           |
 | imports   | [redundant-data-import](https://docs.styra.com/regal/rules/imports/redundant-data-import)           | Redundant import of data                                  |
-| style     | [avoid-get-and-list-prefix](https://docs.styra.com/regal/rules/style/avoid-get-and-list-prefix)     | Avoid get_ and list_ prefix for rules and functions       |
+| style     | [avoid-get-and-list-prefix](https://docs.styra.com/regal/rules/style/avoid-get-and-list-prefix)     | Avoid `get_` and `list_` prefix for rules and functions   |
 | style     | [chained-rule-body](https://docs.styra.com/regal/rules/style/chained-rule-body)                     | Avoid chaining rule bodies                                |
 | style     | [default-over-else](https://docs.styra.com/regal/rules/style/default-over-else)                     | Prefer default assignment over fallback else              |
 | style     | [detached-metadata](https://docs.styra.com/regal/rules/style/detached-metadata)                     | Detached metadata annotation                              |
@@ -247,7 +249,7 @@ The following rules are currently available:
 
 By default, all rules except for those in the `custom` category are currently **enabled**.
 
-#### Aggregate Rules
+**Aggregate Rules**
 
 Most Regal rules will use data only from a single file at a time, with no consideration for other files. A few rules
 however require data from multiple files, and will therefore collect, or aggregate, data from all files provided for
@@ -453,8 +455,8 @@ The format of an ignore directive is `regal ignore:<rule-name>,<rule-name>...`, 
 rule to ignore. Multiple rules may be added to the same ignore directive, separated by commas.
 
 Note that at this point in time, Regal only considers the same line or the line following the ignore directive, i.e. it
-does not apply to entire blocks of code (like rules, functions or even packages). See [configuration](#configuration) if you want
-to ignore certain rules altogether.
+does not apply to entire blocks of code (like rules, functions or even packages). See [configuration](#configuration)
+if you want to ignore certain rules altogether.
 
 ## Output Formats
 
@@ -482,7 +484,7 @@ but also for OPA [strict mode](https://www.openpolicyagent.org/docs/latest/polic
 > of a future OPA 1.0 release, at which point they'd be made immediately obsolete as part of Regal. There are a few
 > strict mode checks that likely will remain optional in OPA, and we may choose to integrate them into Regal in the
 > future.
-
+>
 > Until then, the recommendation is to run both `opa check --strict` and `regal lint` as part of your policy build
 > and test process.
 

--- a/build/do.rq
+++ b/build/do.rq
@@ -118,6 +118,7 @@ job.check_readme {
 build(true) {
 	run("go build")
 }
+
 build(false) {
 	not binary_present
 	run("go build")
@@ -143,11 +144,13 @@ e2e {
 lint {
 	run("opa check --strict --capabilities build/capabilities.json bundle")
 	run("./regal lint --format pretty bundle")
+	run("markdownlint --config docs/.markdownlint.yaml README.md docs/")
 }
 
 lint_ci {
 	run("opa check --strict --capabilities build/capabilities.json bundle")
 	run_quiet("./regal lint --format github bundle")
+	run("markdownlint --config docs/.markdownlint.yaml README.md docs/")
 }
 
 check_readme {

--- a/bundle/regal/rules/style/avoid_get_and_list_prefix.rego
+++ b/bundle/regal/rules/style/avoid_get_and_list_prefix.rego
@@ -1,5 +1,5 @@
 # METADATA
-# description: Avoid get_ and list_ prefix for rules and functions
+# description: Avoid `get_` and `list_` prefix for rules and functions
 package regal.rules.style["avoid-get-and-list-prefix"]
 
 import rego.v1

--- a/bundle/regal/rules/style/avoid_get_and_list_prefix_test.rego
+++ b/bundle/regal/rules/style/avoid_get_and_list_prefix_test.rego
@@ -10,7 +10,7 @@ test_fail_rule_name_starts_with_get if {
 	r := rule.report with input as ast.policy(`get_foo := 1`)
 	r == {{
 		"category": "style",
-		"description": "Avoid get_ and list_ prefix for rules and functions",
+		"description": "Avoid `get_` and `list_` prefix for rules and functions",
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-get-and-list-prefix", "style"),
@@ -25,7 +25,7 @@ test_fail_function_name_starts_with_list if {
 	r := rule.report with input as ast.policy(`list_users(datasource) := ["we", "have", "no", "users"]`)
 	r == {{
 		"category": "style",
-		"description": "Avoid get_ and list_ prefix for rules and functions",
+		"description": "Avoid `get_` and `list_` prefix for rules and functions",
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-get-and-list-prefix", "style"),

--- a/docs/.markdownlint.yaml
+++ b/docs/.markdownlint.yaml
@@ -1,0 +1,39 @@
+default: true
+
+# MD013/line-length
+# https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md013.md
+MD013:
+  line_length: 120
+  heading_line_length: 80
+  code_blocks: false
+  tables: false
+  headings: true
+
+# MD024/no-duplicate-heading
+# https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md024.md
+MD024:
+  siblings_only: true
+
+# MD026/no-trailing-punctuation
+# https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md026.md
+MD026:
+  # Punctuation characters
+  punctuation: ".,;:，；：！"
+
+# MD031/blanks-around-fences
+# https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md031.md
+MD031: false
+
+# MD033/no-inline-html
+# https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md033.md
+MD033:
+  allowed_elements:
+    - br
+    - details
+    - img
+    - strong
+    - summary
+
+# MD036/no-emphasis-as-heading
+# https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md036.md
+MD036: false

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,7 +27,7 @@ When running Regal against a directory, like `regal lint my-policies/`, Regal do
   policy files and tests, the cost may be prohibitive. To alleviate this, Regal is implemented to process files
   concurrently to minimize the impact of IO bound tasks, and to make use of multiple cores when available.
 - The result of linting each file is eventually collected and compiled into a linter report, which is presented to the
-  user in one of the available [output formats](https://docs.styra.com/regal#output-formats). 
+  user in one of the available [output formats](https://docs.styra.com/regal#output-formats).
 
 ## Rego Rules Evaluation
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-If you'd like to contribute to Regal, here are some pointers to help get you started. 
+If you'd like to contribute to Regal, here are some pointers to help get you started.
 
 Before you start, the [architecture](./architecture) guide provides a useful overview of how Regal works, so you might
 want to read that before diving into the code!
@@ -13,6 +13,7 @@ The following tools are required to build, test and lint Regal:
 - The [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) linter
 - The [gci](https://github.com/daixiang0/gci) import formatter
 - The [gofumpt](https://github.com/mvdan/gofumpt) formatter
+- The [markdownlint](https://github.com/DavidAnson/markdownlint) linter
 
 Recommended, but not required:
 
@@ -37,7 +38,7 @@ Regal.
 ### Guiding principles for new built-in rules
 
 - All rules should have succinct, descriptive names which are unique - even across categories
-- A rule that misses a few cases is better than no rule at all, but it's good to document any known edge cases 
+- A rule that misses a few cases is better than no rule at all, but it's good to document any known edge cases
 - False positives should however always be avoided
 - Add tests for as many cases as you can think of
 - Any new rule should have an example violation added in `e2e/testada/violations/most_violations.rego`
@@ -110,6 +111,14 @@ gci write \
   -s dot .
 ```
 
+In order to ensure consistent formatting in our markdown docs, we use the
+[markdownlint](https://github.com/DavidAnson/markdownlint) tool in CI. To run it yourself before submitting a PR,
+install it (`brew install markdownlint-cli`) and run:
+
+```shell
+markdownlint --config docs/.markdownlint.yaml README.md docs/
+```
+
 ## Preparing a pull request
 
 Using `rq`, run all the required steps with:
@@ -133,16 +142,20 @@ go run main.go table --write-to-readme bundle
 
 Build with
 
-    GOOS=wasip1 GOARCH=wasm go build -o regal.wasm .
+```shell
+GOOS=wasip1 GOARCH=wasm go build -o regal.wasm .
+```
 
 Run with wasmtime regal.wasm and the like:
 
-    $ curl https://wasmtime.dev/install.sh -sSf | bash
-    # ...
-    $ wasmtime --version
-    wasmtime-cli 13.0.0
-    $ wasmtime --dir $(pwd) regal -- lint bundle
-    90 files linted. No violations found.
+```shell
+$ curl https://wasmtime.dev/install.sh -sSf | bash
+# ...
+$ wasmtime --version
+wasmtime-cli 13.0.0
+$ wasmtime --dir $(pwd) regal -- lint bundle
+90 files linted. No violations found.
+```
 
 ## Community
 

--- a/docs/editor-support.md
+++ b/docs/editor-support.md
@@ -2,7 +2,8 @@
 
 ## Neovim via none-ls
 
-[none-ls](https://github.com/nvimtools/none-ls.nvim) - Use Neovim as a language server to inject LSP diagnostics, code actions, and more via Lua.
+[none-ls](https://github.com/nvimtools/none-ls.nvim) - Use Neovim as a language server to inject LSP diagnostics,
+code actions, and more via Lua.
 
 Minimal installation via [VimPlug](https://github.com/junegunn/vim-plug)
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -39,7 +39,7 @@ regoText := `package foo...`
 
 input, err := rules.InputFromText("policy.rego", regoText)
 if err != nil {
-	// handle error
+    // handle error
 }
 ```
 

--- a/docs/pre-commit-hooks.md
+++ b/docs/pre-commit-hooks.md
@@ -13,9 +13,9 @@ To use Regal with pre-commit, add this to your `.pre-commit-config.yaml`
   # -   id: ...
 ```
 
-### Hooks Available
+## Hooks Available
 
-#### `regal-lint`
+### `regal-lint`
 
 ![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
 
@@ -25,7 +25,7 @@ Runs Regal against all staged `.rego` files, aborting the commit if any fail.
 - will build and install the tagged version of Regal in an isolated `GOPATH`
 - ensures compatibility between versions
 
-#### `regal-lint-use-path`
+### `regal-lint-use-path`
 
 ![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
 
@@ -33,7 +33,7 @@ Runs Regal against all staged `.rego` files, aborting the commit if any fail.
 
 - requires the `regal` package is already installed and available on `$PATH`.
 
-#### `regal-download`
+### `regal-download`
 
 ![commit-msg hook](https://img.shields.io/badge/hook-pre--commit-informational?logo=git)
 

--- a/docs/rego-style-guide.md
+++ b/docs/rego-style-guide.md
@@ -16,6 +16,7 @@ for Regal to check, and should be targeted by other means.
 - [ ] Consider using JSON schemas for type checking
 
 ### Notes
+
 Both `opa fmt` and `strict mode` checks can be implemented by tapping into
 the corresponding features of OPA, and simply report errors as linter violations.
 Why not just use OPA for that? Mainly because we want a single command (and config)
@@ -37,10 +38,11 @@ certainly have to be configurable to be usable. Same goes for JSON schemas.
 - [ ] Use helper rules and functions
 - [ ] Use negation to handle undefined
 - [x] ~~Consider partial helper rules over comprehensions in rule bodies~~
-- [x] Avoid prefixing rules and functions with get_ or list_
+- [x] Avoid prefixing rules and functions with `get_` or `list_`
 - [x] Prefer unconditional assignment in rule head over rule body
 
 ### Notes
+
 Three quite complex rules in the top here. While it's not going to be very
 scientific, we could try to determine whether helper rules are used to a
 satisfying degree by checking the dependencies of rules vs the number of
@@ -59,6 +61,7 @@ determine whether the author has done, and both have valid use cases.
 - [x] ~~Prefer sets over arrays (where applicable)~~
 
 ### Notes
+
 Almost all of these should be doable, with some possibly being quite challenging.
 One that could be very hard to implement is the `every` rule, as that would
 require us to determine what **other** method was used and that `every` is a
@@ -75,6 +78,7 @@ none of the above rules can be enforced using the AST alone.
 - [x] Use raw strings for regex patterns
 
 ### Notes
+
 Can only be done by scanning the original code, as this is lost in the AST.
 
 ## Imports
@@ -84,6 +88,7 @@ Can only be done by scanning the original code, as this is lost in the AST.
 - [x] Avoid importing input
 
 ### Notes
+
 Checking for package imports requires a view of all modules. We may assume that
 anything not found there are base documents to be provided at runtime.
 

--- a/docs/rules/bugs/not-equals-in-loop.md
+++ b/docs/rules/bugs/not-equals-in-loop.md
@@ -47,7 +47,7 @@ deny if {
 ```
 
 The body of the `deny` rule above roughly translates to "for any item in `input.user.roles`, return true if the item is
-not `admin`". This is almost never what the policy author intended. What the policy author likely intended was 
+not `admin`". This is almost never what the policy author intended. What the policy author likely intended was
 "deny if `admin` is not in `input.user.roles`". The above policy would thus **not** deny a user with the roles
 `["user", "admin"]` since the first item in the array is not "admin". This is almost never what the policy author
 intended.
@@ -61,7 +61,7 @@ currently only checks for wildcard iteration (`[_]`).
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   bugs:
     not-equals-in-loop:
       # one of "error", "warning", "ignore"

--- a/docs/rules/custom/prefer-value-in-head.md
+++ b/docs/rules/custom/prefer-value-in-head.md
@@ -38,7 +38,7 @@ deny contains "user attribute missing from input" if not input.user
 
 Rules that return the value assigned in the last expression of the rule body may have the value, or the function
 returning the value, moved directly to the rule head. This creates more succinct rules, and often allows for rules to be
-expressed as "one-liners". This is not a general recommendation, but a style preference that a team or organization 
+expressed as "one-liners". This is not a general recommendation, but a style preference that a team or organization
 might want to standardize on. As such, it is placed in the custom category, and must be explicitly enabled in
 configuration.
 

--- a/docs/rules/idiomatic/prefer-set-or-object-rule.md
+++ b/docs/rules/idiomatic/prefer-set-or-object-rule.md
@@ -13,7 +13,7 @@ import future.keywords.if
 import future.keywords.in
 
 # top level set comprehension
-developers := {developer | 
+developers := {developer |
     some user in input.users
     "developer" in user.roles
     developer := user.name
@@ -35,7 +35,7 @@ import future.keywords.if
 import future.keywords.in
 
 # set generating rule
-developers contains developer if { 
+developers contains developer if {
     some user in input.users
     "developer" in user.roles
     developer := user.name
@@ -56,7 +56,7 @@ otherwise hard problems. However, when used as the value directly (and unconditi
 always better to use a rule that generates a set or object in the rule body rather than having a comprehension do so in
 the rule head. Why is that?
 
-### Readability 
+### Readability
 
 Rules that generate objects, and sets even more so, read more natural than comprehensions, and are generally more
 descriptive. While both constructs are easy to spot for a seasoned Rego author, anything that helps improve readability
@@ -81,14 +81,14 @@ import future.keywords.in
 developers contains developer if {
     some user in input.users
     "developer" in user.roles
-    developer := user.name 
+    developer := user.name
 }
 
 # *Also* getting developers from data
 developers contains developer if {
     some user in data.users
     "developer" in user.roles
-    developer := user.name 
+    developer := user.name
 }
 
 # Unconditionally adding a developer to the set
@@ -100,7 +100,7 @@ policy file using the same package, and have more rules added there that would c
 great opportunities for extensibility, and collaboration across developers and teams working on policy together.
 
 Objects differ somewhat from sets in that while several rules can be used to generate an object, there cannot be more
-than one rule contributing to a single key-value pair. 
+than one rule contributing to a single key-value pair.
 
 ```rego
 package policy

--- a/docs/rules/idiomatic/use-if.md
+++ b/docs/rules/idiomatic/use-if.md
@@ -34,7 +34,7 @@ is_admin if "admin" in input.user.roles
 ## Rationale
 
 The `if` keyword helps communicate what Rego rules really are — conditional assignments. Using `if` in other words makes
-the rule read the same way in English as it will be interpreted by OPA, i.e: 
+the rule read the same way in English as it will be interpreted by OPA, i.e:
 
 ```rego
 rule := "some value" if some_condition
@@ -43,7 +43,7 @@ rule := "some value" if some_condition
 OPA version 1.0, which is planned for 2024, will make the `if` keyword mandatory. This rule helps you get ahead of the
 curve and start using it today.
 
-**Note**: don't forget to `import future.keywords.if`! Or from OPA v0.59.0 and onwards, `import rego.v1`. 
+**Note**: don't forget to `import future.keywords.if`! Or from OPA v0.59.0 and onwards, `import rego.v1`.
 
 **Tip**: When either of the imports mentioned above are found in a Rego file, the `if` keyword will be inserted
 automatically at any applicable location by the `opa fmt` tool.
@@ -53,7 +53,7 @@ automatically at any applicable location by the `opa fmt` tool.
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   idiomatic:
     use-if:
       # one of "error", "warning", "ignore"

--- a/docs/rules/style/default-over-else.md
+++ b/docs/rules/style/default-over-else.md
@@ -75,7 +75,7 @@ example is **not** guaranteed to return a value of `"Unknown"`:
 fname := first_name(input.name)
 ```
 
-Whether deemed acceptable or not, this differs enough from default assignment of rules to make this preference opt-in 
+Whether deemed acceptable or not, this differs enough from default assignment of rules to make this preference opt-in
 rather than opt-out. Use the `prefer-default-functions` configuration option to control whether `default` assignment
 should be preferred over `else` fallbacks also for custom functions. The default value (no pun intended!) of this config
 option is `false`.

--- a/docs/rules/style/function-arg-return.md
+++ b/docs/rules/style/function-arg-return.md
@@ -32,7 +32,7 @@ has_email(user) if {
 ## Rationale
 
 Older Rego policies sometimes contain an unusual way to declare where the return value of a function call should be
-stored — the last argument of the function. True to it's Datalog roots, return values may be stored either using 
+stored — the last argument of the function. True to it's Datalog roots, return values may be stored either using
 assignment (i.e. `:=`) or by appending a variable name to the argument list of a function. While both forms are valid,
 using assignment `:=` consistently is preferred.
 
@@ -56,7 +56,7 @@ is arguably more idiomatic than:
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   style:
     function-arg-return:
       # one of "error", "warning", "ignore"

--- a/docs/rules/style/line-length.md
+++ b/docs/rules/style/line-length.md
@@ -17,7 +17,7 @@ The default maximum line length is 120 characters.
 
 ## Exceptions
 
-On a few rare occasions, a single word — like a really long URL in a metadata annotation — can't possibly be made any 
+On a few rare occasions, a single word — like a really long URL in a metadata annotation — can't possibly be made any
 shorter. Using an ignore directive isn't an option in that context, and ignoring the whole file is rarely what you'll
 want. The `non-breakable-word-threshold` configuration option allows defining a threshold length for when a single word
 should be considered so long that the line length rule should ignore the line entirely.
@@ -27,7 +27,7 @@ should be considered so long that the line length rule should ignore the line en
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   style:
     line-length:
       # one of "error", "warning", "ignore"

--- a/docs/rules/style/prefer-some-in-iteration.md
+++ b/docs/rules/style/prefer-some-in-iteration.md
@@ -78,7 +78,7 @@ The `ignore-nesting-level` configuration option allows setting the threshold for
 **equal or greater than** the threshold won't be considered a violation. The default setting of `2` allows all _nested_
 iteration, but not e.g. `my_array[x]`.
 
-**Note:** not all nesting is *iteration*! The following example is considered to have a nesting level of `1`, as only
+**Note:** not all nesting is _iteration_! The following example is considered to have a nesting level of `1`, as only
 one of the variables (including wildcards: `_`) is an output variable bound in iteration:
 
 ```rego

--- a/docs/rules/style/todo-comment.md
+++ b/docs/rules/style/todo-comment.md
@@ -31,7 +31,7 @@ To fix the problem, or use an issue tracker to track it.
 
 ## Rationale
 
-While TODO and FIXME comments are occasionally useful, they essentially provide a way to do issue tracking inside of 
+While TODO and FIXME comments are occasionally useful, they essentially provide a way to do issue tracking inside of
 the code rather than where issues belong — in your issue tracker.
 
 ## Configuration Options
@@ -39,7 +39,7 @@ the code rather than where issues belong — in your issue tracker.
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   style:
     todo-comment:
       # one of "error", "warning", "ignore"

--- a/docs/rules/style/use-in-operator.md
+++ b/docs/rules/style/use-in-operator.md
@@ -1,5 +1,5 @@
 # use-in-operator
 
-## Please Note!
+## Please Note
 
 This rule has been moved to *idiomatic* category and can be found [here](../idiomatic/use-in-operator.md).

--- a/docs/rules/testing/metasyntactic-variable.md
+++ b/docs/rules/testing/metasyntactic-variable.md
@@ -27,7 +27,7 @@ roles := ["developer", "admin"]
 ## Rationale
 
 Using "foo", "bar", "baz" and other [metasyntactic variables](https://en.wikipedia.org/wiki/Metasyntactic_variable) is
-occasionally useful in examples, but should be avoided in production policy. 
+occasionally useful in examples, but should be avoided in production policy.
 
 This linter rules forbids any metasyntactic variable names, as listed by Wikipedia:
 
@@ -54,7 +54,7 @@ perhaps code meant to be used in examples. When using a
 simply configure an ignore pattern with the configuration of this rule:
 
 ```yaml
-rules: 
+rules:
   testing:
     metasyntactic-variable:
       level: error
@@ -71,7 +71,7 @@ If you'd rather use your own list of forbidden variable names or patterns, see t
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   testing:
     metasyntactic-variable:
       # one of "error", "warning", "ignore"

--- a/docs/rules/testing/test-outside-test-package.md
+++ b/docs/rules/testing/test-outside-test-package.md
@@ -45,7 +45,7 @@ from production policy. This is easily done by placing tests in a separate packa
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   testing:
     test-outside-test-package:
       # one of "error", "warning", "ignore"

--- a/docs/rules/testing/todo-test.md
+++ b/docs/rules/testing/todo-test.md
@@ -28,7 +28,7 @@ developing policy. They are however not to be committed, and should be removed b
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   testing:
     todo-test:
       # one of "error", "warning", "ignore"


### PR DESCRIPTION
Disable some overly pedantic rules, but good to help keep our docs consistent.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->