### PR TITLE
`prefer-package-imports`: except data.regal imports in custom rules

### DIFF
--- a/bundle/regal/rules/imports/prefer_package_imports_test.rego
+++ b/bundle/regal/rules/imports/prefer_package_imports_test.rego
@@ -77,3 +77,25 @@ test_success_aggregate_report_ignored_import_path if {
 
 	r == set()
 }
+
+test_aggregate_ignores_imports_of_regal_in_custom_rule if {
+	r := rule.aggregate with input as regal.parse_module("p.rego", `
+	package custom.regal.rules.foo.bar
+
+	import data.regal.ast
+
+	import data.a.b.c
+	`)
+
+	r == {{
+		"aggregate_data": {
+			"imports": [{
+				"location": {"col": 2, "file": "p.rego", "row": 6, "text": "\timport data.a.b.c"},
+				"path": ["a", "b", "c"],
+			}],
+			"package_path": ["custom", "regal", "rules", "foo", "bar"],
+		},
+		"aggregate_source": {"file": "p.rego", "package_path": ["custom", "regal", "rules", "foo", "bar"]},
+		"rule": {"category": "imports", "title": "prefer-package-imports"},
+	}}
+}


### PR DESCRIPTION
Fixes #497

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->