### PR TITLE
pkg/version: remove spurious whitespace from String()

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -41,7 +41,7 @@ func (vi Info) String() string {
 			"Version:    " + vi.Version,
 			"Go Version: " + vi.GoVersion,
 			"Platform:   " + vi.Platform,
-			"Commit:        " + vi.Commit,
+			"Commit:     " + vi.Commit,
 			"Timestamp:  " + vi.Timestamp,
 			"Hostname:   " + vi.Hostname,
 		},


### PR DESCRIPTION
```
Version:    0.7.0
Go Version: go1.20.7
Platform:   darwin/amd64
Commit:        unknown
Timestamp:  2023-08-11T08:51:41Z
Hostname:   github.actions.local
```
I found it slightly misaligned there... probably not intentionally so