### PR TITLE
function-arg-return: fix docs typo

### DIFF
--- a/docs/rules/style/function-arg-return.md
+++ b/docs/rules/style/function-arg-return.md
@@ -32,7 +32,7 @@ has_email(user) if {
 ## Rationale
 
 Older Rego policies sometimes contain an unusual way to declare where the return value of a function call should be
-stored — the last argument of the function. True to it's Datalog roots, return values may be stored either using
+stored — the last argument of the function. True to its Datalog roots, return values may be stored either using
 assignment (i.e. `:=`) or by appending a variable name to the argument list of a function. While both forms are valid,
 using assignment `:=` consistently is preferred.
 


### PR DESCRIPTION
Just inflating my commit count like it mattered something 🙃 Kidding, just can't let that typo slide.