### PR TITLE
bundle: update all_refs to get more refs

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -293,11 +293,23 @@ is_output_var(rule, ref, location) if {
 	not ref.value in (find_names_in_scope(rule, location) - find_some_decl_names_in_scope(rule, location))
 }
 
-all_refs := [value |
+all_refs contains value if {
 	walk(input.rules, [_, value])
 
 	value[0].type == "ref"
-]
+}
+
+all_refs contains value if {
+	walk(input.rules, [_, value])
+
+	value.type == "ref"
+}
+
+all_refs contains value if {
+	walk(input.imports, [_, value])
+
+	value.type == "ref"
+}
 
 ref_to_string(ref) := concat(".", [_ref_part_to_string(i, part) | some i, part in ref])
 

--- a/bundle/regal/ast_test.rego
+++ b/bundle/regal/ast_test.rego
@@ -270,3 +270,24 @@ test_generated_body_function if {
 
 	ast.generated_body(module.rules[0])
 }
+
+test_all_refs if {
+	policy := `package policy
+
+	import data.foo.bar
+
+    allow := data.foo.baz
+
+    deny[message] {
+		message := data.foo.bax
+    }
+    `
+
+	module := regal.parse_module("p.rego", policy)
+
+	r := ast.all_refs with input as module
+
+	text_refs := {base64.decode(ref.location.text) | some ref in r}
+
+	text_refs == {":=", "data.foo.bar", "data.foo.bax", "data.foo.baz"}
+}


### PR DESCRIPTION
all_refs was missing refs in imports and certain types of rules.

This change updates the all_refs rule to return these refs making them available to rule authors.
