### PR TITLE
SARIF: Use `none` for `level` in notices

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -360,6 +360,12 @@ func (tr SarifReporter) Publish(_ context.Context, r report.Report) error {
 	}
 
 	for _, notice := range r.Notices {
+		if notice.Severity == "none" {
+			// no need to report on notices like rules skipped due to
+			// having been deprecated or made obsolete
+			continue
+		}
+
 		pb := sarif.NewPropertyBag()
 		pb.Add("category", notice.Category)
 
@@ -369,7 +375,7 @@ func (tr SarifReporter) Publish(_ context.Context, r report.Report) error {
 
 		run.CreateResultForRule(notice.Title).
 			WithKind("informational").
-			WithLevel(notice.Level).
+			WithLevel("none").
 			WithMessage(sarif.NewTextMessage(notice.Description))
 	}
 

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -375,15 +375,6 @@ func TestSarifReporterPublish(t *testing.T) {
               }
             },
             {
-              "id": "rule-made-obsolete",
-              "shortDescription": {
-                "text": "Rule made obsolete by capability foo"
-              },
-              "properties": {
-                "category": "some-category"
-              }
-            },
-            {
               "id": "rule-missing-capability",
               "shortDescription": {
                 "text": "Rule missing capability bar"
@@ -453,19 +444,10 @@ func TestSarifReporterPublish(t *testing.T) {
           ]
         },
         {
-          "ruleId": "rule-made-obsolete",
+          "ruleId": "rule-missing-capability",
           "ruleIndex": 2,
           "kind": "informational",
-          "level": "notice",
-          "message": {
-            "text": "Rule made obsolete by capability foo"
-          }
-        },
-        {
-          "ruleId": "rule-missing-capability",
-          "ruleIndex": 3,
-          "kind": "informational",
-          "level": "notice",
+          "level": "none",
           "message": {
             "text": "Rule missing capability bar"
           }


### PR DESCRIPTION
And don't include notices on deprecated/obsolete rules at all in report.

Fixes #513

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->