### PR TITLE
[ast]: Improve all_refs performance

### DIFF
--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -293,22 +293,26 @@ is_output_var(rule, ref, location) if {
 	not ref.value in (find_names_in_scope(rule, location) - find_some_decl_names_in_scope(rule, location))
 }
 
-all_refs contains value if {
-	walk(input.rules, [_, value])
+default is_ref(_) := false
 
+is_ref(value) if {
+	value.type == "ref"
+}
+
+is_ref(value) if {
 	value[0].type == "ref"
 }
 
 all_refs contains value if {
 	walk(input.rules, [_, value])
 
-	value.type == "ref"
+	is_ref(value)
 }
 
 all_refs contains value if {
 	walk(input.imports, [_, value])
 
-	value.type == "ref"
+	is_ref(value)
 }
 
 ref_to_string(ref) := concat(".", [_ref_part_to_string(i, part) | some i, part in ref])

--- a/bundle/regal/ast.rego
+++ b/bundle/regal/ast.rego
@@ -295,13 +295,9 @@ is_output_var(rule, ref, location) if {
 
 default is_ref(_) := false
 
-is_ref(value) if {
-	value.type == "ref"
-}
+is_ref(value) if value.type == "ref"
 
-is_ref(value) if {
-	value[0].type == "ref"
-}
+is_ref(value) if value[0].type == "ref"
 
 all_refs contains value if {
 	walk(input.rules, [_, value])


### PR DESCRIPTION
This avoids a loop over rules twice. Fixes an issue added in https://github.com/StyraInc/regal/pull/512

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->