### PR TITLE
Add Stacklok to the list of companies that have adopted Regal

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -38,6 +38,7 @@ Companies and organizations using Regal (not counting organizations behind the o
 - [Atlassian](https://www.atlassian.com)
 - [Bankdata](https://www.bankdata.dk)
 - [Miro](https://miro.com)
+- [Stacklok](https://stacklok.com)
 - [Styra](https://www.styra.com)
 
 ## Community


### PR DESCRIPTION
This adds minder to docs/adopters.md. For more info on Stacklok's Regal
adoption, see: https://stacklok.com/blog/writing-minder-rule-types-with-open-policy-agent-and-rego
