### PR TITLE
ci: enable unused-parameters and unused-receivers in revive linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,6 +37,22 @@ linters-settings:
     case:
       rules:
         json: snake
+
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+      - name: unused-parameter
+        severity: warning
+        disabled: false
+        arguments:
+          - allowRegex: "^_"
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+      - name: unused-receiver
+        severity: warning
+        disabled: false
+        arguments:
+          - allowRegex: "^_"
+
   gci:
     sections:
       - standard

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -54,7 +54,7 @@ type repeatedStringFlag struct {
 	isSet bool
 }
 
-func (f *repeatedStringFlag) Type() string {
+func (*repeatedStringFlag) Type() string {
 	return stringType
 }
 

--- a/pkg/rules/fmt.go
+++ b/pkg/rules/fmt.go
@@ -72,19 +72,19 @@ func (f *OpaFmtRule) Run(ctx context.Context, input Input) (*report.Report, erro
 	return result, nil
 }
 
-func (f *OpaFmtRule) Name() string {
+func (*OpaFmtRule) Name() string {
 	return title
 }
 
-func (f *OpaFmtRule) Category() string {
+func (*OpaFmtRule) Category() string {
 	return category
 }
 
-func (f *OpaFmtRule) Description() string {
+func (*OpaFmtRule) Description() string {
 	return description
 }
 
-func (f *OpaFmtRule) Documentation() string {
+func (*OpaFmtRule) Documentation() string {
 	return docs.CreateDocsURL(category, title)
 }
 


### PR DESCRIPTION
See https://golangci-lint.run/usage/linters#revive for config details, and https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md for all descriptions.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->