### PR TITLE
docs: fix broken link to ast.rego

### DIFF
--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -275,7 +275,7 @@ everything is displayed on a single line — not so much. This built-in allows m
 but with newlines and spaces added for a more pleasant experience.
 
 In addition to this, Regal provides many helpful functions, rules and utilities in Rego. Browsing the source code of the
-[regal.ast](https://github.com/StyraInc/regal/blob/main/bundle/regal/ast.rego) package to see what's available is
+[regal.ast](https://github.com/StyraInc/regal/blob/main/bundle/regal/ast/ast.rego) package to see what's available is
 recommended!
 
 ## Community


### PR DESCRIPTION
This fixes a broken link I noticed while making a custom rule. Thanks!