### PR TITLE
Update permissions to allow running actions

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -11,6 +11,8 @@ jobs:
   update-docs:
     name: Update Docs
     runs-on: ubuntu-22.04
+    permissions:
+      actions: write
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
I am not entirely convinced this will allow the workflow to trigger the jobs in another repo, but this is a test as the alternative isn't ideal.