### PR TITLE
Fix false positive in `external-reference`

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -175,7 +175,11 @@ _find_every_vars(_, value) := var if {
 	var := array.concat(key_var, val_var)
 }
 
-_find_term_vars(term) := [value |
+# METADATA
+# description: |
+#   traverses all nodes in provided term (using `walk`), and returns an array with
+#   all variables declared in term, i,e [x, y] or {x: y}, etc.
+find_term_vars(term) := [value |
 	walk(term, [_, value])
 
 	value.type == "var"
@@ -183,7 +187,7 @@ _find_term_vars(term) := [value |
 
 _find_set_or_array_comprehension_vars(value) := [value.value.term] if {
 	value.value.term.type == "var"
-} else := _find_term_vars(value.value.term)
+} else := find_term_vars(value.value.term)
 
 _find_object_comprehension_vars(value) := array.concat(key, val) if {
 	key := [value.value.key | value.value.key.type == "var"]

--- a/bundle/regal/rules/style/external_reference.rego
+++ b/bundle/regal/rules/style/external_reference.rego
@@ -11,7 +11,8 @@ report contains violation if {
 	some fn in ast.functions
 
 	named_args := {arg.value | some arg in fn.head.args; arg.type == "var"}
-	own_vars := {v.value | some v in ast.find_vars(fn.body)}
+	head_vars := {v.value | some v in ast.find_term_vars(fn.head.value)}
+	own_vars := head_vars | {v.value | some v in ast.find_vars(fn.body)}
 
 	allowed_refs := named_args | own_vars
 

--- a/bundle/regal/rules/style/external_reference_test.rego
+++ b/bundle/regal/rules/style/external_reference_test.rego
@@ -82,3 +82,13 @@ test_success_function_references_only_own_vars_and_wildcard if {
 	r := rule.report with input as ast.policy(`f(x, y) { _ = x + y }`)
 	r == set()
 }
+
+test_success_function_references_return_var if {
+	r := rule.report with input as ast.policy(`f(x) := y { y = true }`)
+	r == set()
+}
+
+test_success_function_references_return_vars if {
+	r := rule.report with input as ast.policy(`f(x) := [x, y] { x = false; y = true }`)
+	r == set()
+}


### PR DESCRIPTION
By taking variables declared in the return value into account when counting vars in scope.

Fixes #560

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->