### PR TITLE
Fix false positive in `prefer-some-in-iteration`

### DIFF
--- a/bundle/regal/rules/style/prefer_some_in_iteration_test.rego
+++ b/bundle/regal/rules/style/prefer_some_in_iteration_test.rego
@@ -148,6 +148,44 @@ test_fail_ignore_if_subattribute_disabled if {
 	r == with_location({"col": 10, "file": "policy.rego", "row": 4, "text": "\t\tbar := input.foo[_].bar"})
 }
 
+test_success_allow_if_inside_array if {
+	policy := ast.policy(`allow {
+		bar := [input.foo[_] == 1]
+	}`)
+
+	r := rule.report with config.for_rule as {
+		"level": "error",
+		"ignore-if-sub-attribute": true,
+		"ignore-nesting-level": 5,
+	}
+		with input as policy
+	r == set()
+}
+
+test_success_allow_if_inside_set if {
+	policy := ast.policy(`s := {input.foo[_] == 1}`)
+
+	r := rule.report with config.for_rule as {
+		"level": "error",
+		"ignore-if-sub-attribute": true,
+		"ignore-nesting-level": 5,
+	}
+		with input as policy
+	r == set()
+}
+
+test_success_allow_if_inside_object if {
+	policy := ast.policy(`s := {foo: input.foo[_] == 1}`)
+
+	r := rule.report with config.for_rule as {
+		"level": "error",
+		"ignore-if-sub-attribute": true,
+		"ignore-nesting-level": 5,
+	}
+		with input as policy
+	r == set()
+}
+
 allow_nesting(i) := {
 	"level": "error",
 	"ignore-nesting-level": i,


### PR DESCRIPTION
Don't flag iteration inside of arrays, sets or objects as using `some` in that context isn't possible.

Fixes #553

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->