### PR TITLE
Address `external-reference` missing cases

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -194,6 +194,19 @@ _find_object_comprehension_vars(value) := array.concat(key, val) if {
 	val := [value.value.value | value.value.value.type == "var"]
 }
 
+_find_vars(_, value, last) := find_term_vars(function_ret_args(fn_name, value)) if {
+	last == "terms"
+	value[0].type == "ref"
+	value[0].value[0].type == "var"
+	value[0].value[0].value != "assign"
+
+	fn_name := ref_to_string(value[0].value)
+
+	not contains(fn_name, "$")
+	fn_name in all_function_names # regal ignore:external-reference
+	function_ret_in_args(fn_name, value)
+}
+
 _find_vars(path, value, last) := _find_assign_vars(path, value) if {
 	last == "terms"
 	value[0].type == "ref"
@@ -383,6 +396,8 @@ function_decls(rules) := {rule_name: decl |
 
 	decl := {"decl": {"args": args, "result": {"type": "any"}}}
 }
+
+function_ret_args(fn_name, terms) := array.slice(terms, count(all_functions[fn_name].decl.args) + 1, count(terms))
 
 function_ret_in_args(fn_name, terms) if {
 	rest := array.slice(terms, 1, count(terms))

--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -3,6 +3,7 @@ package regal.ast_test
 import rego.v1
 
 import data.regal.ast
+import data.regal.capabilities
 
 # regal ignore:rule-length
 test_find_vars if {
@@ -79,6 +80,26 @@ test_find_vars_comprehension_lhs if {
 	}
 
 	names == {"a", "b", "c", "d", "e", "f", "g"}
+}
+
+test_find_vars_function_ret_return_args if {
+	policy := `
+	package p
+
+	import rego.v1
+
+	allow if {
+		walk(input, [path, value])
+	}
+	`
+
+	module := regal.parse_module("p.rego", policy)
+
+	vars := ast.find_vars(module.rules) with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with input.rules as []
+
+	names := {var.value | some var in vars; var.type == "var"}
+	names == {"path", "value"}
 }
 
 # https://github.com/StyraInc/regal/issues/168

--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -25,11 +25,13 @@ for_rule(category, title) := _with_level(category, title, "ignore") if {
 } else := _with_level(category, title, "error") if {
 	force_enabled(category, title)
 } else := c if {
+	# regal ignore:external-reference
 	m := merged_config.rules[category][title]
 	c := object.union(m, {"level": rule_level(m)})
 }
 
 _with_level(category, title, level) := c if {
+	# regal ignore:external-reference
 	m := merged_config.rules[category][title]
 	c := object.union(m, {"level": level})
 } else := {"level": level}
@@ -38,30 +40,42 @@ default rule_level(_) := "error"
 
 rule_level(cfg) := cfg.level
 
+# regal ignore:external-reference
 force_disabled(_, title) if title in data.eval.params.disable
 
 force_disabled(category, title) if {
 	# regal ignore:external-reference
-	data.eval.params.disable_all
-	not category in data.eval.params.enable_category
-	not title in data.eval.params.enable
+	params := data.eval.params
+
+	params.disable_all
+	not category in params.enable_category
+	not title in params.enable
 }
 
 force_disabled(category, title) if {
-	category in data.eval.params.disable_category
-	not title in data.eval.params.enable
+	# regal ignore:external-reference
+	params := data.eval.params
+
+	category in params.disable_category
+	not title in params.enable
 }
 
+# regal ignore:external-reference
 force_enabled(_, title) if title in data.eval.params.enable
 
 force_enabled(category, title) if {
 	# regal ignore:external-reference
-	data.eval.params.enable_all
-	not category in data.eval.params.disable_category
-	not title in data.eval.params.disable
+	params := data.eval.params
+
+	params.enable_all
+	not category in params.disable_category
+	not title in params.disable
 }
 
 force_enabled(category, title) if {
-	category in data.eval.params.enable_category
-	not title in data.eval.params.disable
+	# regal ignore:external-reference
+	params := data.eval.params
+
+	category in params.enable_category
+	not title in params.disable
 }

--- a/bundle/regal/result.rego
+++ b/bundle/regal/result.rego
@@ -40,8 +40,10 @@ aggregate(chain, aggregate_data) := entry if {
 			"title": title,
 		},
 		"aggregate_source": {
+			# regal ignore:external-reference
 			"file": input.regal.file.name,
 			"package_path": [part.value |
+				# regal ignore:external-reference
 				some i, part in input["package"].path
 				i > 0
 			],
@@ -115,6 +117,7 @@ _related_resources(annotations, category, title) := rr if {
 	not annotations.related_resources
 	rr := [{
 		"description": "documentation",
+		# regal ignore:external-reference
 		"ref": sprintf("%s/%s/%s", [config.docs.base_url, category, title]),
 	}]
 }

--- a/bundle/regal/rules/custom/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer_value_in_head.rego
@@ -21,7 +21,7 @@ report contains violation if {
 	last.terms[1].type == "var"
 	last.terms[1].value == var
 
-	not configured_exception(cfg, last.terms[2])
+	not configured_exception(cfg, last.terms[2], ast.scalar_types)
 
 	violation := result.fail(rego.metadata.chain(), result.location(last))
 }
@@ -33,7 +33,7 @@ var_in_head(rule) := rule.head.key.value if {
 	rule.head.key.type == "var"
 }
 
-configured_exception(cfg, term) if {
+configured_exception(cfg, term, scalar_types) if {
 	cfg["only-scalars"] == true
-	term.type in ast.scalar_types
+	term.type in scalar_types
 }

--- a/bundle/regal/rules/idiomatic/equals_pattern_matching.rego
+++ b/bundle/regal/rules/idiomatic/equals_pattern_matching.rego
@@ -30,7 +30,7 @@ report contains violation if {
 	val.value[0].value[0].type == "var"
 	val.value[0].value[0].value == "equal"
 
-	terms := normalize_eq_terms(val.value)
+	terms := normalize_eq_terms(val.value, ast.scalar_types)
 	terms[0].value in arg_var_names
 
 	violation := result.fail(rego.metadata.chain(), result.location(fn))
@@ -63,7 +63,7 @@ report contains violation if {
 	expr.terms[0].value[0].type == "var"
 	expr.terms[0].value[0].value == "equal"
 
-	terms := normalize_eq_terms(expr.terms)
+	terms := normalize_eq_terms(expr.terms, ast.scalar_types)
 	terms[0].value in arg_var_names
 
 	violation := result.fail(rego.metadata.chain(), result.location(fn))
@@ -71,14 +71,14 @@ report contains violation if {
 
 # METADATA
 # description: Normalize var to always always be on the left hand side
-normalize_eq_terms(terms) := [terms[1], terms[2]] if {
+normalize_eq_terms(terms, scalar_types) := [terms[1], terms[2]] if {
 	terms[1].type == "var"
 	not startswith(terms[1].value, "$")
-	terms[2].type in ast.scalar_types
+	terms[2].type in scalar_types
 }
 
-normalize_eq_terms(terms) := [terms[2], terms[1]] if {
-	terms[1].type in ast.scalar_types
+normalize_eq_terms(terms, scalar_types) := [terms[2], terms[1]] if {
+	terms[1].type in scalar_types
 	terms[2].type == "var"
 	not startswith(terms[2].value, "$")
 }

--- a/bundle/regal/rules/style/external_reference.rego
+++ b/bundle/regal/rules/style/external_reference.rego
@@ -8,24 +8,49 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
+	fn_namespaces := {split(name, ".")[0] | some name in object.keys(ast.all_functions)}
+
 	some fn in ast.functions
 
 	named_args := {arg.value | some arg in fn.head.args; arg.type == "var"}
 	head_vars := {v.value | some v in ast.find_term_vars(fn.head.value)}
-	own_vars := head_vars | {v.value | some v in ast.find_vars(fn.body)}
+	body_vars := {v.value | some v in ast.find_vars(fn.body)}
+	else_vars := {v.value | some v in ast.find_vars(fn["else"])}
+	own_vars := (head_vars | body_vars) | else_vars
 
-	allowed_refs := named_args | own_vars
+	# note: parens added by opa fmt 🤦
+	allowed_refs := (named_args | own_vars) | fn_namespaces
 
-	some expr in fn.body
-	some term in expr_terms(expr.terms)
+	walk(fn, [path, value])
 
-	term.type == "var"
-	not term.value in allowed_refs
-	not startswith(term.value, "$")
+	value.type == "var"
+	not value.value in allowed_refs
+	not startswith(value.value, "$")
+	not function_call_ctx(fn, path)
 
-	violation := result.fail(rego.metadata.chain(), result.location(term))
+	violation := result.fail(rego.metadata.chain(), result.location(value))
 }
 
-expr_terms(terms) := terms if is_array(terms)
+last_indexof(arr, item) := regal.last([i | some i, x in arr; x == item])
 
-expr_terms(terms) := [terms.value[0]] if is_object(terms)
+# METADATA
+# scope: document
+# description: |
+#   functions should be able to call other functions and this shouldn't
+#   be flagged as there's no way to import other functions via arguments
+#   note: this doesn't check for built-in calls or calls to function
+#   defined in the same package, as those are already covered by
+#   "fn_namespaces" in the report rule
+function_call_ctx(fn, path) if {
+	terms_path := array.slice(path, 0, last_indexof(path, "terms") + 2)
+	next_term_path := array.concat(
+		array.slice(terms_path, 0, count(terms_path) - 1), # ["body", 0, "terms", 0] -> ["body", 0, "terms"]
+		[regal.last(terms_path) + 1], # 0 -> 1
+	)
+
+	# ["body", 0, "terms", 1]
+
+	object.get(fn, next_term_path, null) != null
+}
+
+function_call_ctx(fn, path) if object.get(fn, array.slice(path, 0, count(path) - 4), {}).type == "call"

--- a/bundle/regal/rules/style/external_reference_test.rego
+++ b/bundle/regal/rules/style/external_reference_test.rego
@@ -3,11 +3,13 @@ package regal.rules.style["external-reference_test"]
 import rego.v1
 
 import data.regal.ast
+import data.regal.capabilities
 import data.regal.config
 import data.regal.rules.style["external-reference"] as rule
 
 test_fail_function_references_input if {
 	r := rule.report with input as ast.policy(`f(_) { input.foo }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == {{
 		"category": "style",
 		"description": "Reference to input, data or rule ref in function body",
@@ -23,6 +25,7 @@ test_fail_function_references_input if {
 
 test_fail_function_references_data if {
 	r := rule.report with input as ast.policy(`f(_) { data.foo }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == {{
 		"category": "style",
 		"description": "Reference to input, data or rule ref in function body",
@@ -36,6 +39,24 @@ test_fail_function_references_data if {
 	}}
 }
 
+test_fail_function_references_data_in_expr if {
+	r := rule.report with input as ast.policy(`f(x) {
+		x == data.foo
+	}`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r == {{
+		"category": "style",
+		"description": "Reference to input, data or rule ref in function body",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/external-reference", "style"),
+		}],
+		"title": "external-reference",
+		"location": {"col": 8, "file": "policy.rego", "row": 4, "text": "\t\tx == data.foo"},
+		"level": "error",
+	}}
+}
+
 test_fail_function_references_rule if {
 	r := rule.report with input as ast.policy(`
 foo := "bar"
@@ -45,6 +66,7 @@ f(x, y) {
 	y == foo
 }
 	`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == {{
 		"category": "style",
 		"description": "Reference to input, data or rule ref in function body",
@@ -60,35 +82,54 @@ f(x, y) {
 
 test_success_function_references_no_input_or_data if {
 	r := rule.report with input as ast.policy(`f(x) { x == true }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
 
 test_success_function_references_no_input_or_data_reverse if {
 	r := rule.report with input as ast.policy(`f(x) { true == x }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
 
 test_success_function_references_only_own_vars if {
 	r := rule.report with input as ast.policy(`f(x) { y := x; y == 10 }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
 
 test_success_function_references_only_own_vars_nested if {
 	r := rule.report with input as ast.policy(`f(x, z) { y := x; y == [1, 2, z]}`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
 
 test_success_function_references_only_own_vars_and_wildcard if {
 	r := rule.report with input as ast.policy(`f(x, y) { _ = x + y }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
 
 test_success_function_references_return_var if {
 	r := rule.report with input as ast.policy(`f(x) := y { y = true }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
 
 test_success_function_references_return_vars if {
 	r := rule.report with input as ast.policy(`f(x) := [x, y] { x = false; y = true }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r == set()
+}
+
+test_success_function_references_external_function if {
+	r := rule.report with input as ast.policy(`f(x) { data.foo.bar(x) }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r == set()
+}
+
+test_success_function_references_external_function_in_expr if {
+	r := rule.report with input as ast.policy(`f(x) := y { y := data.foo.bar(x) }`)
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }

--- a/bundle/regal/rules/style/unnecessary_some.rego
+++ b/bundle/regal/rules/style/unnecessary_some.rego
@@ -20,24 +20,24 @@ report contains violation if {
 	symbols[0].type == "call"
 	symbols[0].value[0].type == "ref"
 
-	some_is_unnecessary(symbols)
+	some_is_unnecessary(symbols, ast.scalar_types)
 
 	violation := result.fail(rego.metadata.chain(), result.location(symbols))
 }
 
-some_is_unnecessary(value) if {
+some_is_unnecessary(value, scalar_types) if {
 	ref := value[0].value[0].value
 
 	[ref[0].value, ref[1].value] == ["internal", "member_2"]
 
-	value[0].value[1].type in ast.scalar_types
+	value[0].value[1].type in scalar_types
 }
 
-some_is_unnecessary(value) if {
+some_is_unnecessary(value, scalar_types) if {
 	ref := value[0].value[0].value
 
 	[ref[0].value, ref[1].value] == ["internal", "member_3"]
 
-	value[0].value[1].type in ast.scalar_types
-	value[0].value[2].type in ast.scalar_types
+	value[0].value[1].type in scalar_types
+	value[0].value[2].type in scalar_types
 }

--- a/docs/rules/style/external-reference.md
+++ b/docs/rules/style/external-reference.md
@@ -8,6 +8,8 @@
 ```rego
 package policy
 
+import rego.v1
+
 # Depends on both `input` and `data`
 is_preferred_login_method(method) if {
     preferred_login_methods := {login_method |
@@ -22,6 +24,8 @@ is_preferred_login_method(method) if {
 
 ```rego
 package policy
+
+import rego.v1
 
 # Depends only on function arguments
 is_preferred_login_method(method, user, all_login_methods) if {
@@ -39,6 +43,27 @@ What separates functions from rules is that they accept arguments. While a funct
 `input`, `data` or other rules declared in a policy, these references create dependencies that aren't obvious simply by
 checking the function signature, and it makes it harder to reuse that function in other contexts. Additionally,
 functions that only depend on their arguments are easier to test standalone.
+
+## Exceptions
+
+Rego does not provide first-class functions — functions can't be passed as arguments to other functions. Therefore, this
+rule allows functions to freely reference (i.e. call) _other functions_, whether built-in functions, or custom functions
+defined in the same package or elsewhere, and these do not count as "external references" simply because there is not
+other way to import them into the function body.
+
+```rego
+package policy
+
+import rego.v1
+
+first_name(full_name) := capitalized {
+    first_name := split(full_name, " ")[0]
+
+    # while data.utils.capitalize is an external reference, it's not flagged
+    # as such, since there is no way to import it via function arguments
+    capitalized := data.utils.capitalize(first_name)
+}
+```
 
 ## Configuration Options
 


### PR DESCRIPTION
This took quite some effort as the first iteration of this rule was rather basic. While this makes it a bit annoying with its pedantry, at least it's now **correct**. One benefit of this is that `ast.find_vars` now also takes function arg return value bindings into account, which may have positive impact on other rules as well.

Fixes #191

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->