### PR TITLE
Fix broken `only-scalars` config in `prefer-value-in-head` rule

### DIFF
--- a/bundle/regal/rules/custom/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer_value_in_head.rego
@@ -21,7 +21,7 @@ report contains violation if {
 	last.terms[1].type == "var"
 	last.terms[1].value == var
 
-	not configured_exception(cfg, last.terms[2], ast.scalar_types)
+	not scalar_fail(cfg, last.terms[2], ast.scalar_types)
 
 	violation := result.fail(rego.metadata.chain(), result.location(last))
 }
@@ -33,7 +33,7 @@ var_in_head(rule) := rule.head.key.value if {
 	rule.head.key.type == "var"
 }
 
-configured_exception(cfg, term, scalar_types) if {
+scalar_fail(cfg, term, scalar_types) if {
 	cfg["only-scalars"] == true
-	term.type in scalar_types
+	not term.type in scalar_types
 }

--- a/bundle/regal/rules/custom/prefer_value_in_head_test.rego
+++ b/bundle/regal/rules/custom/prefer_value_in_head_test.rego
@@ -51,24 +51,24 @@ test_success_value_is_in_head_eq if {
 	r == set()
 }
 
-test_fail_value_could_be_in_head_but_not_a_required_scalar if {
+test_fail_value_could_be_in_head_but_not_a_scalar if {
 	module := ast.policy(`value := x {
 		input.x
 		x := [i | i := input[_]]
 	}`)
 
 	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := [i | i := input[_]]"})
+	r == set()
 }
 
-test_success_value_could_be_in_head_and_is_a_required_scalar if {
+test_fail_value_could_be_in_head_and_is_a_scalar if {
 	module := ast.policy(`value := x {
 		input.x
 		x := 5
 	}`)
 
 	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
-	r == set()
+	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := 5"})
 }
 
 test_fail_value_could_be_in_head_multivalue_rule if {

--- a/docs/rules/custom/prefer-value-in-head.md
+++ b/docs/rules/custom/prefer-value-in-head.md
@@ -40,13 +40,14 @@ expressed as "one-liners". This is not a general recommendation, but a style pre
 might want to standardize on. As such, it is placed in the custom category, and must be explicitly enabled in
 configuration.
 
-The `only-literals` configuration option may be used to only suggest moving literal values to the head, and not
-expressions or functions returning a value. With this option set to `true`, the following example would be flagged:
+The `only-scalars` configuration option may be used to only suggest moving scalar values (strings, numbers, booleans,
+null) to the head, and not expressions or functions returning a value. With this option set to `true`, the following
+example would be flagged:
 
 ```rego
 deny contains message if {
     not input.user
-    # value is a string literal
+    # value is a scalar
     message := "user attribute missing from input"
 }
 ```
@@ -56,7 +57,7 @@ But not:
 ```rego
 deny contains message if {
     not input.user
-    # value returned from a function call, not suggested if `only-literals` is set to `true`
+    # value returned from a function call, not suggested if `only-scalars` is set to `true`
     message := sprintf("user attribute missing from input: %v", [input])
 }
 ```
@@ -74,9 +75,9 @@ rules:
       #
       # one of "error", "warning", "ignore"
       level: error
-      # whether to only suggest moving literal values to the head, and not
-      # expressions or functions
-      only-literals: false
+      # whether to only suggest moving scalar values (strings, numbers, booleans, null)
+      # to the head, and not expressions or functions
+      only-scalars: false
 ```
 
 ## Community


### PR DESCRIPTION
And rename it in the docs as it was previously called `only-literals`.

Fixes #568
Fixes #567

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->