### PR TITLE
Fix `prefer-some-in-iteration` false positive on contains check

### DIFF
--- a/bundle/regal/rules/style/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer_some_in_iteration.rego
@@ -73,3 +73,14 @@ invalid_some_context(rule, path) if {
 impossible_some(node) if node.type in {"array", "object", "set"}
 
 impossible_some(node) if node.key
+
+# technically this is not an _impossible_ some, as we could replace e.g. `"x" == input[_]`
+# with `some "x" in input`, but that'd be an `unnecessary-some` violation as `"x" in input`
+# would be the correct way to express that
+impossible_some(node) if {
+	node.terms[0].value[0].type == "var"
+	node.terms[0].value[0].value in {"eq", "equal"}
+
+	some term in node.terms
+	term.type in ast.scalar_types # regal ignore:external-reference
+}


### PR DESCRIPTION
When scalar values are on one side of e.g. `5 == input[_]` we should not recommending using `some`, but `in`.

Fixes #566

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->