### PR TITLE
Fix: `rule-shadows-builtin` to flag shadowed namespaces

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -21,6 +21,11 @@ has_var(value) if {
 
 builtin_names := object.keys(config.capabilities.builtins)
 
+builtin_namespaces contains namespace if {
+	some name in builtin_names
+	namespace := split(name, ".")[0]
+}
+
 # METADATA
 # description: |
 #   provide the package name / path as originally declared in the

--- a/bundle/regal/rules/bugs/rule_shadows_builtin.rego
+++ b/bundle/regal/rules/bugs/rule_shadows_builtin.rego
@@ -9,7 +9,7 @@ import data.regal.result
 
 report contains violation if {
 	some rule in input.rules
-	ast.name(rule) in ast.builtin_names
+	ast.name(rule) in ast.builtin_namespaces
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/bugs/rule_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/rule_shadows_builtin_test.rego
@@ -22,6 +22,22 @@ test_fail_rule_name_shadows_builtin if {
 	}}
 }
 
+test_fail_rule_name_shadows_builtin_namespace if {
+	cfg := {"capabilities": {"builtins": {"http.send": {}}}}
+	r := rule.report with input as ast.policy(`http := "yes"`) with data.internal.combined_config as cfg
+	r == {{
+		"category": "bugs",
+		"description": "Rule name shadows built-in",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/rule-shadows-builtin", "bugs"),
+		}],
+		"title": "rule-shadows-builtin",
+		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "http := \"yes\""},
+		"level": "error",
+	}}
+}
+
 test_success_rule_name_does_not_shadows_builtin if {
 	r := rule.report with input as ast.policy(`foo := 1`)
 	r == set()

--- a/bundle/regal/rules/imports/import_shadows_builtin.rego
+++ b/bundle/regal/rules/imports/import_shadows_builtin.rego
@@ -7,19 +7,13 @@ import rego.v1
 import data.regal.ast
 import data.regal.result
 
-builtin_namespaces contains namespace if {
-	some name in ast.builtin_names
-
-	namespace := split(name, ".")[0]
-}
-
 report contains violation if {
 	some imp in input.imports
 
 	imp.path.value[0].value in {"data", "input"}
 
 	name := significant_name(imp)
-	name in builtin_namespaces
+	name in ast.builtin_namespaces
 
 	# AST quirk: while we'd ideally provide the location of the *path component*,
 	# there is no location data provided for aliases. In order to be consistent,


### PR DESCRIPTION
Fixes #535

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->