### PR TITLE
Language server initialisation adjustments

### DIFF
--- a/internal/lsp/messages.go
+++ b/internal/lsp/messages.go
@@ -15,15 +15,14 @@ type FileEvent struct {
 }
 
 type InitializeParams struct {
-	ProcessID            int                `json:"processId"`
-	ClientInfo           Client             `json:"clientInfo"`
-	Locale               string             `json:"locale"`
-	RootPath             string             `json:"rootPath"`
-	RootURI              string             `json:"rootUri"`
-	Capabilities         ClientCapabilities `json:"capabilities"`
-	InitializationOption string             `json:"initializationOptions"`
-	Trace                string             `json:"trace"`
-	WorkspaceFolders     []WorkspaceFolder  `json:"workspaceFolders"`
+	ProcessID        int                `json:"processId"`
+	ClientInfo       Client             `json:"clientInfo"`
+	Locale           string             `json:"locale"`
+	RootPath         string             `json:"rootPath"`
+	RootURI          string             `json:"rootUri"`
+	Capabilities     ClientCapabilities `json:"capabilities"`
+	Trace            string             `json:"trace"`
+	WorkspaceFolders []WorkspaceFolder  `json:"workspaceFolders"`
 }
 
 type WorkspaceFolder struct {


### PR DESCRIPTION
This PR makes two changes:

- https://github.com/StyraInc/regal/issues/578 raised an issue with the unmarshalling of the initializationOptions field. We don't use this field so it has been dropped.
- We an issue when there is no root URI set in the initialize request. This PR disables workspace functions such as aggregate violations and linting of unopened files when this is the case (when a single file has been opened).