### PR TITLE
Correct unassigned-return-value link

### DIFF
--- a/docs/rules/bugs/unused-return-value.md
+++ b/docs/rules/bugs/unused-return-value.md
@@ -2,4 +2,5 @@
 
 ## Please Note
 
-This rule has been renamed to *unassigned-return-value* and can be found [here](../unassigned-return-value.md).
+This rule has been renamed to *unassigned-return-value* and can be found
+[here](https://docs.styra.com/regal/rules/bugs/unassigned-return-value).


### PR DESCRIPTION
This md ref link was working on GH, but didn't work on docs.styra.com.