### PR TITLE
docs: make old rule draft

### DIFF
--- a/docs/rules/bugs/unused-return-value.md
+++ b/docs/rules/bugs/unused-return-value.md
@@ -1,3 +1,7 @@
+---
+draft: true
+--- 
+
 # unused-return-value
 
 ## Please Note


### PR DESCRIPTION
This allows the page to be present in GH, but no appear in docs.styra.com.

Changes already applied to docs repo
see: https://github.com/StyraInc/docs/pull/26

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->