### PR TITLE
Fix false positive in rules not counting imports in scope

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -93,6 +93,8 @@ function_arg_names(rule) := [arg.value | some arg in rule.head.args]
 
 rule_and_function_names contains name(rule) if some rule in input.rules
 
+identifiers := rule_and_function_names | imported_identifiers
+
 rule_names contains name(rule) if some rule in rules
 
 # METADATA
@@ -294,7 +296,7 @@ find_names_in_scope(rule, location) := names if {
 	var_names := {var.value | some var in find_vars_in_local_scope(rule, location)}
 
 	# parens below added by opa-fmt :)
-	names := (rule_names | fn_arg_names) | var_names
+	names := ((rule_names | imported_identifiers) | fn_arg_names) | var_names
 }
 
 # METADATA

--- a/bundle/regal/ast/imports.rego
+++ b/bundle/regal/ast/imports.rego
@@ -10,6 +10,20 @@ default imports := []
 #   it safe to refer to without risk of halting evaluation
 imports := input.imports
 
+# METADATA
+# description: |
+#   set of all names imported in the input module, meaning commonly the last part of any
+#   imported ref, like "bar" in "data.foo.bar", or an alias like "baz" in "data.foo.bar as baz".
+imported_identifiers contains imported_identifier(imp) if {
+	some imp in imports
+
+	imp.path.value[0].value in {"input", "data"}
+}
+
+imported_identifier(imp) := imp.alias
+
+imported_identifier(imp) := regal.last(imp.path.value).value if not imp.alias
+
 imports_has_path(imports, path) if {
 	some imp in imports
 

--- a/bundle/regal/rules/bugs/top_level_iteration.rego
+++ b/bundle/regal/rules/bugs/top_level_iteration.rego
@@ -15,16 +15,15 @@ report contains violation if {
 	last := regal.last(rule.head.value.value)
 
 	last.type == "var"
-	illegal_value_ref(last.value, rule)
+	illegal_value_ref(last.value, rule, ast.identifiers)
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }
 
 _path(loc) := concat(".", {l.value | some l in loc})
 
-illegal_value_ref(value, rule) if {
-	# regal ignore:external-reference
-	not value in ast.rule_and_function_names
+illegal_value_ref(value, rule, identifiers) if {
+	not value in identifiers
 	not is_arg_or_input(value, rule)
 }
 
@@ -32,9 +31,4 @@ is_arg_or_input(value, rule) if value in ast.function_arg_names(rule)
 
 is_arg_or_input(value, _) if startswith(_path(value), "input.")
 
-# ideally would be able to just say
-# is_arg_or_input("input", _)
-# but the formatter rewrites that to
-# is_arg_or_input("input", _) = true
-# ...meh
-is_arg_or_input("input", _) := true
+is_arg_or_input("input", _)

--- a/bundle/regal/rules/bugs/top_level_iteration_test.rego
+++ b/bundle/regal/rules/bugs/top_level_iteration_test.rego
@@ -64,3 +64,11 @@ test_success_top_level_param if {
 	r := rule.report with input as ast.with_rego_v1(`x(y) := input.foo.bar[y]`)
 	r == set()
 }
+
+test_success_top_level_import if {
+	r := rule.report with input as ast.with_rego_v1(`
+	import data.x
+
+	y := input[x]`)
+	r == set()
+}


### PR DESCRIPTION
Fixes #590

That issue only mentions `top-level-iteration`, but I found the same behavior in `use-some-for-output-vars`, so this fixes that too.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->