### PR TITLE
Add support for editing Regal in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@ dist/
 
 /regal
 /regal.exe
-
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+    "opa.env": {
+        "OPA_CHECK_CAPABILITIES": "${workspacePath}/build/capabilities.json",
+        "OPA_EVAL_CAPABILITIES": "${workspacePath}/build/capabilities.json"
+    },
+    "opa.roots": [
+        "${workspaceFolder}/bundle"
+    ],
+    "opa.strictMode": true
+}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Regal
 
 [![Build Status](https://github.com/styrainc/regal/workflows/Build/badge.svg?branch=main)](https://github.com/styrainc/regal/actions)
-![OPA v0.62.0](https://openpolicyagent.org/badge/v0.62.0)
+![OPA v0.62.1](https://openpolicyagent.org/badge/v0.62.1)
 
 Regal is a linter for [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/), with the goal of making your
 Rego magnificent!


### PR DESCRIPTION
Options like `checkOnSave` would previously not work when hacking on Regal, as a custom capabilities file would need to be provided. Using the latest version of the OPA extension, this is now supported via the `opa.env` option.

Note that actually setting `checkOnSave` or similar options is left up to each developer.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->