### PR TITLE
docs: use 4 spaces for indentation in `circular-imports` docs

### DIFF
--- a/docs/rules/imports/circular-import.md
+++ b/docs/rules/imports/circular-import.md
@@ -21,16 +21,16 @@ import rego.v1
 import data.shared
 
 admins := {
-  "anna",
-  "bob",
+    "anna",
+    "bob",
 }
 
 allow if {
-  input.role in shared.roles
+    input.role in shared.roles
 }
 
 allow if {
-  input.user in admins
+    input.user in admins
 }
 ```
 
@@ -43,8 +43,8 @@ import data.authz # circular import!
 roles := { "admin", "editor", "viewer" }
 
 users := authz.admins | {
-  "chloe",
-  "dave",
+    "chloe",
+    "dave",
 }
 ```
 
@@ -68,11 +68,11 @@ import rego.v1
 import data.shared
 
 allow if {
-  input.role in shared.roles
+    input.role in shared.roles
 }
 
 allow if {
-  input.user in shared.users
+    input.user in shared.users
 }
 ```
 
@@ -81,8 +81,8 @@ allow if {
 package admins
 
 admins := {
-  "anna",
-  "bob",
+    "anna",
+    "bob",
 }
 ```
 
@@ -95,8 +95,8 @@ import data.admins
 roles := {"admin", "editor", "viewer"}
 
 users := admins.admins | {
-  "chloe",
-  "david",
+    "chloe",
+    "david",
 }
 ```
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->