### PR TITLE
lsp: `textDocument/hover` implementation

### DIFF
--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -38,6 +38,7 @@ func init() {
 
 			ls.SetConn(conn)
 			go ls.StartDiagnosticsWorker(ctx)
+			go ls.StartHoverWorker(ctx)
 
 			sigChan := make(chan os.Signal, 1)
 			signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)

--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -1,0 +1,174 @@
+package lsp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/olekukonko/tablewriter"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+)
+
+type BuiltinPosition struct {
+	Builtin *ast.Builtin
+	Line    uint
+	Start   uint
+	End     uint
+}
+
+var builtins = builtinMap() //nolint:gochecknoglobals
+
+func builtinMap() map[string]*ast.Builtin {
+	m := make(map[string]*ast.Builtin)
+	for _, b := range ast.CapabilitiesForThisVersion().Builtins {
+		m[b.Name] = b
+	}
+
+	return m
+}
+
+func builtinCategory(builtin *ast.Builtin) (category string) {
+	if len(builtin.Categories) == 0 {
+		if s := strings.Split(builtin.Name, "."); len(s) > 1 {
+			category = s[0]
+		} else {
+			category = builtin.Name
+		}
+	} else {
+		category = builtin.Categories[0]
+	}
+
+	return category
+}
+
+func writeFunctionSnippet(sb *strings.Builder, builtin *ast.Builtin) {
+	sb.WriteString("```rego\n")
+
+	resType := builtin.Decl.NamedResult()
+	if n, ok := resType.(*types.NamedType); ok {
+		sb.WriteString(n.Name)
+	} else {
+		sb.WriteString("output")
+	}
+
+	sb.WriteString(" := ")
+
+	sb.WriteString(builtin.Name)
+	sb.WriteString("(")
+
+	for i, arg := range builtin.Decl.NamedFuncArgs().Args {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+
+		if n, ok := arg.(*types.NamedType); ok {
+			sb.WriteString(n.Name)
+		} else {
+			sb.WriteString(arg.String())
+		}
+	}
+
+	sb.WriteString(")\n```")
+}
+
+func createHoverContent(builtin *ast.Builtin) string {
+	title := fmt.Sprintf(
+		"[%s](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-%s-%s)",
+		builtin.Name,
+		builtinCategory(builtin),
+		strings.ReplaceAll(builtin.Name, ".", ""),
+	)
+
+	sb := &strings.Builder{}
+
+	sb.WriteString("### ")
+	sb.WriteString(title)
+	sb.WriteString("\n\n")
+
+	writeFunctionSnippet(sb, builtin)
+
+	sb.WriteString("\n\n")
+	sb.WriteString(builtin.Description)
+	sb.WriteString("\n")
+
+	if len(builtin.Decl.FuncArgs().Args) == 0 {
+		return sb.String()
+	}
+
+	sb.WriteString("\n\n#### Arguments\n\n")
+
+	table := tablewriter.NewWriter(sb)
+
+	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeader([]string{"Name", "Type", "Description"})
+	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
+	table.SetCenterSeparator("|") // Add Bulk Data
+
+	argsData := make([][]string, 0)
+
+	for _, arg := range builtin.Decl.NamedFuncArgs().Args {
+		if n, ok := arg.(*types.NamedType); ok {
+			argsData = append(argsData, []string{"`" + n.Name + "`", n.Type.String(), n.Descr})
+		} else {
+			argsData = append(argsData, []string{"`" + arg.String() + "`", "", ""})
+		}
+	}
+
+	table.AppendBulk(argsData)
+	table.Render()
+
+	table.ClearRows()
+
+	sb.WriteString("\n\nReturns ")
+
+	ret := builtin.Decl.NamedResult()
+	if n, ok := ret.(*types.NamedType); ok {
+		sb.WriteString("`")
+		sb.WriteString(n.Name)
+		sb.WriteString("` of type `")
+		sb.WriteString(n.Type.String())
+		sb.WriteString("`: ")
+		sb.WriteString(n.Descr)
+	} else if ret != nil {
+		sb.WriteString(ret.String())
+	}
+
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+func updateBuiltinPositions(cache *Cache, uri string) error {
+	module, ok := cache.GetModule(uri)
+	if !ok {
+		return fmt.Errorf("failed to get module for uri %q", uri)
+	}
+
+	builtinsOnLine := map[uint][]BuiltinPosition{}
+
+	ast.WalkTerms(module, func(t *ast.Term) bool {
+		if call, ok := t.Value.(ast.Call); ok {
+			name := call[0].Value.String()
+			line := uint(call[0].Location.Row)
+
+			if b, ok := builtins[name]; ok {
+				builtinsOnLine[line] = append(builtinsOnLine[line], BuiltinPosition{
+					Builtin: b,
+					Line:    line,
+					Start:   uint(call[0].Location.Col),
+					End:     uint(call[0].Location.Col + len(name)),
+				})
+			}
+		}
+
+		return false
+	})
+
+	cache.SetBuiltinPositions(uri, builtinsOnLine)
+
+	return nil
+}

--- a/internal/lsp/hover_test.go
+++ b/internal/lsp/hover_test.go
@@ -1,0 +1,43 @@
+package lsp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+func TestCreateHoverContent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		builtin  *ast.Builtin
+		testdata string
+	}{
+		{
+			ast.IndexOf,
+			"testdata/hover/indexof.md",
+		},
+		{
+			ast.ReachableBuiltin,
+			"testdata/hover/graphreachable.md",
+		},
+		{
+			ast.JSONFilter,
+			"testdata/hover/jsonfilter.md",
+		},
+	}
+
+	for _, c := range cases {
+		file, err := os.ReadFile(c.testdata)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		hoverContent := createHoverContent(c.builtin)
+
+		if string(file) != hoverContent {
+			t.Errorf("Expected %s, got %s", string(file), hoverContent)
+		}
+	}
+}

--- a/internal/lsp/messages.go
+++ b/internal/lsp/messages.go
@@ -80,6 +80,7 @@ type ServerCapabilities struct {
 	TextDocumentSyncOptions TextDocumentSyncOptions `json:"textDocumentSync"`
 	DiagnosticProvider      DiagnosticOptions       `json:"diagnosticProvider"`
 	Workspace               WorkspaceOptions        `json:"workspace"`
+	HoverProvider           bool                    `json:"hoverProvider"`
 }
 
 type WorkspaceOptions struct {
@@ -156,6 +157,11 @@ type Position struct {
 	Character uint `json:"character"`
 }
 
+type MarkupContent struct {
+	Kind  string `json:"kind"`
+	Value string `json:"value"`
+}
+
 type TextDocumentDidOpenParams struct {
 	TextDocument TextDocumentItem `json:"textDocument"`
 }
@@ -166,6 +172,12 @@ type TextDocumentItem struct {
 	URI        string `json:"uri"`
 	Version    uint   `json:"version"`
 }
+
+type TextDocumentHoverParams struct {
+	Position     Position               `json:"position"`
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
 type WorkspaceDidCreateFilesParams struct {
 	Files []WorkspaceDidCreateFilesParamsCreatedFile `json:"files"`
 }

--- a/internal/lsp/testdata/hover/graphreachable.md
+++ b/internal/lsp/testdata/hover/graphreachable.md
@@ -1,0 +1,18 @@
+### [graph.reachable](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-graph-graphreachable)
+
+```rego
+output := graph.reachable(graph, initial)
+```
+
+Computes the set of reachable nodes in the graph from a set of starting nodes.
+
+
+#### Arguments
+
+| Name      | Type                                   | Description                                              |
+|-----------|----------------------------------------|----------------------------------------------------------|
+| `graph`   | object[any: any<array[any], set[any]>] | object containing a set or array of neighboring vertices |
+| `initial` | any<array[any], set[any]>              | set or array of root vertices                            |
+
+
+Returns `output` of type `set[any]`: set of vertices reachable from the `initial` vertices in the directed `graph`

--- a/internal/lsp/testdata/hover/indexof.md
+++ b/internal/lsp/testdata/hover/indexof.md
@@ -1,0 +1,18 @@
+### [indexof](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-strings-indexof)
+
+```rego
+output := indexof(haystack, needle)
+```
+
+Returns the index of a substring contained inside a string.
+
+
+#### Arguments
+
+| Name       | Type   | Description           |
+|------------|--------|-----------------------|
+| `haystack` | string | string to search in   |
+| `needle`   | string | substring to look for |
+
+
+Returns `output` of type `number`: index of first occurrence, `-1` if not found

--- a/internal/lsp/testdata/hover/jsonfilter.md
+++ b/internal/lsp/testdata/hover/jsonfilter.md
@@ -1,0 +1,18 @@
+### [json.filter](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-object-jsonfilter)
+
+```rego
+filtered := json.filter(object, paths)
+```
+
+Filters the object. For example: `json.filter({"a": {"b": "x", "c": "y"}}, ["a/b"])` will result in `{"a": {"b": "x"}}`). Paths are not filtered in-order and are deduplicated before being evaluated.
+
+
+#### Arguments
+
+| Name     | Type                                                              | Description       |
+|----------|-------------------------------------------------------------------|-------------------|
+| `object` | object[any: any]                                                  |                   |
+| `paths`  | any<array[any<string, array[any]>], set[any<string, array[any]>]> | JSON string paths |
+
+
+Returns `filtered` of type `any`: remaining data from `object` with only keys specified in `paths`


### PR DESCRIPTION
This PR adds support for the `textDocument/hover` feature of the language server protocol. Currently, only the built-in functions of OPA are supported, which likely satisfies the most common requirement. In the future, we could extend this to cover also user defined functions or rules, where annotations are used to provide data for the hover response.

Screenshot from VS Code with Regal running from this branch.

![Screenshot 2024-04-02 at 13 38 56](https://github.com/StyraInc/regal/assets/510711/c21a5954-abd2-4ea6-a758-bec233687491)