### PR TITLE
lsp: Missing built-in data is not a hard error

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -327,8 +327,12 @@ func (l *LanguageServer) handleHover(
 	}
 
 	builtinsOnLine, ok := l.cache.GetBuiltinPositions(params.TextDocument.URI)
+	// when no builtins are found, we can't return a useful hover response.
+	// log the error, but return an empty struct to avoid an error being shown in the client.
 	if !ok {
-		return struct{}{}, fmt.Errorf("could not get builtins for uri %q", params.TextDocument.URI)
+		l.logError(fmt.Errorf("could not get builtins for uri %q", params.TextDocument.URI))
+
+		return struct{}{}, nil
 	}
 
 	for _, bp := range builtinsOnLine[params.Position.Line+1] {


### PR DESCRIPTION
Now when built-in state is not known for a file,
the hover response is empty. This is commonly the case when the file that has just been opened has failed to parse and never parsed in the time that the server has been running.

Fixes https://github.com/StyraInc/regal/issues/618