### PR TITLE
lsp: Support file ignore config

### DIFF
--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -100,7 +100,7 @@ func updateParse(cache *Cache, uri string) (bool, error) {
 	return false, nil
 }
 
-func updateFileDiagnostics(ctx context.Context, cache *Cache, regalConfig *config.Config, uri string) error {
+func updateFileDiagnostics(ctx context.Context, cache *Cache, regalConfig *config.Config, uri, rootDir string) error {
 	module, ok := cache.GetModule(uri)
 	if !ok {
 		// then there must have been a parse error
@@ -114,7 +114,9 @@ func updateFileDiagnostics(ctx context.Context, cache *Cache, regalConfig *confi
 
 	input := rules.NewInput(map[string]string{uri: contents}, map[string]*ast.Module{uri: module})
 
-	regalInstance := linter.NewLinter().WithInputModules(&input)
+	regalInstance := linter.NewLinter().
+		WithInputModules(&input).
+		WithRootDir(rootDir)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)
@@ -186,7 +188,7 @@ func updateAllDiagnostics(ctx context.Context, cache *Cache, regalConfig *config
 
 	input := rules.NewInput(files, modules)
 
-	regalInstance := linter.NewLinter().WithInputModules(&input)
+	regalInstance := linter.NewLinter().WithInputModules(&input).WithRootDir(detachedURI)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -150,7 +150,7 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 			}
 
 			// otherwise, lint the file and send the diagnostics
-			err = updateFileDiagnostics(ctx, l.cache, l.loadedConfig, evt.URI)
+			err = updateFileDiagnostics(ctx, l.cache, l.loadedConfig, evt.URI, l.clientRootURI)
 			if err != nil {
 				l.logError(fmt.Errorf("failed to update file diagnostics: %w", err))
 			}

--- a/pkg/config/filter_test.go
+++ b/pkg/config/filter_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestFilterIgnoredPaths(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		paths           []string
+		ignore          []string
+		checkFileExists bool
+		rootDir         string
+		expected        []string
+	}{
+		"no paths": {
+			paths:    []string{},
+			ignore:   []string{},
+			expected: []string{},
+		},
+		"no ignore": {
+			paths:    []string{"foo/bar.rego"},
+			ignore:   []string{},
+			expected: []string{"foo/bar.rego"},
+		},
+		"explicit ignore": {
+			paths:    []string{"foo/bar.rego", "foo/baz.rego"},
+			ignore:   []string{"foo/bar.rego"},
+			expected: []string{"foo/baz.rego"},
+		},
+		"wildcard ignore": {
+			paths:    []string{"foo/bar.rego", "foo/baz.rego", "bar/foo.rego"},
+			ignore:   []string{"foo/*"},
+			expected: []string{"bar/foo.rego"},
+		},
+		"wildcard ignore, with ext": {
+			paths:    []string{"foo/bar.rego", "foo/baz.rego", "bar/foo.rego"},
+			ignore:   []string{"foo/*.rego"},
+			expected: []string{"bar/foo.rego"},
+		},
+		"double wildcard ignore": {
+			paths:    []string{"foo/bar/baz/bax.rego", "foo/baz/bar/bax.rego", "bar/foo.rego"},
+			ignore:   []string{"foo/bar/**"},
+			expected: []string{"bar/foo.rego", "foo/baz/bar/bax.rego"},
+		},
+		"rootDir, explicit ignore": {
+			paths:    []string{"wow/foo/bar.rego", "wow/foo/baz.rego"},
+			ignore:   []string{"foo/bar.rego"},
+			expected: []string{"wow/foo/baz.rego"},
+			rootDir:  "wow/",
+		},
+		"rootDir, no slash, explicit ignore": {
+			paths:    []string{"wow/foo/bar.rego", "wow/foo/baz.rego"},
+			ignore:   []string{"foo/bar.rego"},
+			expected: []string{"wow/foo/baz.rego"},
+			rootDir:  "wow",
+		},
+		"rootDir, wildcard ignore, with ext": {
+			paths:    []string{"wow/foo/bar.rego", "wow/foo/baz.rego", "wow/bar/foo.rego"},
+			ignore:   []string{"foo/*.rego"},
+			expected: []string{"wow/bar/foo.rego"},
+			rootDir:  "wow/",
+		},
+		"rootDir, double wildcard ignore": {
+			paths: []string{
+				"wow/foo/bar/baz/bax.rego",
+				"wow/foo/baz/bar/bax.rego",
+				"wow/bar/foo.rego",
+			},
+			ignore:   []string{"foo/bar/**"},
+			expected: []string{"wow/bar/foo.rego", "wow/foo/baz/bar/bax.rego"},
+			rootDir:  "wow",
+		},
+		"rootDir URI": {
+			paths: []string{
+				"file:///wow/foo/bar.rego",
+				"file:///wow/foo/baz.rego",
+				"file:///wow/bar/foo.rego",
+			},
+			ignore:   []string{"foo/*.rego"},
+			expected: []string{"file:///wow/bar/foo.rego"},
+			rootDir:  "file:///wow",
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			filtered, err := FilterIgnoredPaths(tc.paths, tc.ignore, tc.checkFileExists, tc.rootDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(filtered) != len(tc.expected) {
+				t.Fatalf("expected %d paths, got %d", len(tc.expected), len(filtered))
+			}
+
+			sort.Strings(filtered)
+			sort.Strings(tc.expected)
+
+			for i, path := range filtered {
+				if path != tc.expected[i] {
+					t.Errorf("expected path %s, got %s", tc.expected[i], path)
+				}
+			}
+		})
+	}
+}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -124,6 +124,7 @@ or := 1
 		expViolations   []string
 		expLevels       []string
 		ignoreFilesFlag []string
+		rootDir         string
 	}{
 		{
 			name:          "baseline",
@@ -232,6 +233,28 @@ or := 1
 			expViolations: []string{},
 		},
 		{
+			name: "user config global ignore files with rootDir",
+			userConfig: &config.Config{
+				Ignore: config.Ignore{
+					Files: []string{"foo/*"},
+				},
+			},
+			filename:      "file:///wow/foo/p.rego",
+			expViolations: []string{},
+			rootDir:       "file:///wow",
+		},
+		{
+			name: "user config global ignore files with rootDir, not ignored",
+			userConfig: &config.Config{
+				Ignore: config.Ignore{
+					Files: []string{"bar/*"},
+				},
+			},
+			filename:      "file:///wow/foo/p.rego",
+			expViolations: []string{"opa-fmt", "top-level-iteration", "rule-shadows-builtin"},
+			rootDir:       "file:///wow",
+		},
+		{
 			name:            "CLI flag ignore files",
 			filename:        "p.rego",
 			expViolations:   []string{},
@@ -245,6 +268,8 @@ or := 1
 			t.Parallel()
 
 			linter := NewLinter()
+
+			linter = linter.WithRootDir(tt.rootDir)
 
 			if tt.userConfig != nil {
 				linter = linter.WithUserConfig(*tt.userConfig)


### PR DESCRIPTION
Fixes: https://github.com/StyraInc/regal/issues/589

This PR makes the filtering logic support a new rootDir prefix. When set, this will be stripped from file paths before testing their ignore status. 


https://github.com/StyraInc/regal/assets/1774239/e2234823-6c27-4df7-b546-062ee13afc60
