### PR TITLE
lsp: add inlay hint support

### DIFF
--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -150,23 +150,16 @@ func updateBuiltinPositions(cache *Cache, uri string) error {
 
 	builtinsOnLine := map[uint][]BuiltinPosition{}
 
-	ast.WalkTerms(module, func(t *ast.Term) bool {
-		if call, ok := t.Value.(ast.Call); ok {
-			name := call[0].Value.String()
-			line := uint(call[0].Location.Row)
+	for _, call := range AllBuiltinCalls(module) {
+		line := uint(call.Location.Row)
 
-			if b, ok := builtins[name]; ok {
-				builtinsOnLine[line] = append(builtinsOnLine[line], BuiltinPosition{
-					Builtin: b,
-					Line:    line,
-					Start:   uint(call[0].Location.Col),
-					End:     uint(call[0].Location.Col + len(name)),
-				})
-			}
-		}
-
-		return false
-	})
+		builtinsOnLine[line] = append(builtinsOnLine[line], BuiltinPosition{
+			Builtin: call.Builtin,
+			Line:    line,
+			Start:   uint(call.Location.Col),
+			End:     uint(call.Location.Col + len(call.Builtin.Name)),
+		})
+	}
 
 	cache.SetBuiltinPositions(uri, builtinsOnLine)
 

--- a/internal/lsp/inlayhint.go
+++ b/internal/lsp/inlayhint.go
@@ -1,0 +1,46 @@
+package lsp
+
+import (
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
+)
+
+func createInlayTooltip(named *types.NamedType) string {
+	if named.Descr == "" {
+		return fmt.Sprintf("Type: `%s`", named.Type.String())
+	}
+
+	return fmt.Sprintf("%s\n\nType: `%s`", named.Descr, named.Type.String())
+}
+
+func getInlayHints(module *ast.Module) []InlayHint {
+	inlayHints := make([]InlayHint, 0)
+
+	for _, call := range AllBuiltinCalls(module) {
+		for i, arg := range call.Builtin.Decl.NamedFuncArgs().Args {
+			if len(call.Args) <= i {
+				// avoid panic if provided a builtin function where the args
+				// have yet to be provided, like if the user types `split()`
+				continue
+			}
+
+			if named, ok := arg.(*types.NamedType); ok {
+				inlayHints = append(inlayHints, InlayHint{
+					Position:     positionFromLocation(call.Args[i].Location),
+					Label:        named.Name + ":",
+					Kind:         2,
+					PaddingLeft:  false,
+					PaddingRight: true,
+					Tooltip: MarkupContent{
+						Kind:  "markdown",
+						Value: createInlayTooltip(named),
+					},
+				})
+			}
+		}
+	}
+
+	return inlayHints
+}

--- a/internal/lsp/inlayhint_test.go
+++ b/internal/lsp/inlayhint_test.go
@@ -1,0 +1,86 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+)
+
+// A function call may either be represented as an ast.Call.
+func TestGetInlayHintsAstCall(t *testing.T) {
+	t.Parallel()
+
+	policy := `package p
+
+	r := json.filter({}, [])`
+
+	module := ast.MustParseModule(policy)
+
+	inlayHints := getInlayHints(module)
+
+	if len(inlayHints) != 2 {
+		t.Errorf("Expected 2 inlay hints, got %d", len(inlayHints))
+	}
+
+	if inlayHints[0].Label != "object:" {
+		t.Errorf("Expected label to be 'object:', got %s", inlayHints[0].Label)
+	}
+
+	if inlayHints[0].Position.Line != 2 && inlayHints[0].Position.Character != 18 {
+		t.Errorf("Expected line 2, character 18, got %d, %d",
+			inlayHints[0].Position.Line, inlayHints[0].Position.Character)
+	}
+
+	if inlayHints[0].Tooltip.Value != "Type: `object[any: any]`" {
+		t.Errorf("Expected tooltip to be 'Type: `object[any: any]`, got %s", inlayHints[0].Tooltip.Value)
+	}
+
+	if inlayHints[1].Label != "paths:" {
+		t.Errorf("Expected label to be 'paths:', got %s", inlayHints[1].Label)
+	}
+
+	if inlayHints[1].Position.Line != 2 && inlayHints[1].Position.Character != 22 {
+		t.Errorf("Expected line 2, character 22, got %d, %d",
+			inlayHints[1].Position.Line, inlayHints[1].Position.Character)
+	}
+
+	if inlayHints[1].Tooltip.Value != "JSON string paths\n\nType: `any<array[any<string, array[any]>],"+
+		" set[any<string, array[any]>]>`" {
+		t.Errorf("Expected tooltip to be 'JSON string paths\n\nType: `any<array[any<string, array[any]>], "+
+			"set[any<string, array[any]>]>`, got %s", inlayHints[1].Tooltip.Value)
+	}
+}
+
+// Or a function call may be represented as the terms of an ast.Expr.
+func TestGetInlayHintsAstTerms(t *testing.T) {
+	t.Parallel()
+
+	policy := `package p
+
+	import rego.v1
+
+	allow if {
+		is_string("yes")
+	}`
+
+	module := ast.MustParseModule(policy)
+
+	inlayHints := getInlayHints(module)
+
+	if len(inlayHints) != 1 {
+		t.Errorf("Expected 1 inlay hints, got %d", len(inlayHints))
+	}
+
+	if inlayHints[0].Label != "x:" {
+		t.Errorf("Expected label to be 'x:', got %s", inlayHints[0].Label)
+	}
+
+	if inlayHints[0].Position.Line != 5 && inlayHints[0].Position.Character != 12 {
+		t.Errorf("Expected line 5, character 12, got %d, %d",
+			inlayHints[0].Position.Line, inlayHints[0].Position.Character)
+	}
+
+	if inlayHints[0].Tooltip.Value != "Type: `any`" {
+		t.Errorf("Expected tooltip to be 'Type: `any`, got %s", inlayHints[0].Tooltip.Value)
+	}
+}

--- a/internal/lsp/messages.go
+++ b/internal/lsp/messages.go
@@ -80,6 +80,7 @@ type ServerCapabilities struct {
 	TextDocumentSyncOptions TextDocumentSyncOptions `json:"textDocumentSync"`
 	DiagnosticProvider      DiagnosticOptions       `json:"diagnosticProvider"`
 	Workspace               WorkspaceOptions        `json:"workspace"`
+	InlayHintProvider       InlayHintOptions        `json:"inlayHintProvider"`
 	HoverProvider           bool                    `json:"hoverProvider"`
 }
 
@@ -109,6 +110,24 @@ type DiagnosticOptions struct {
 	Identifier            string `json:"identifier"`
 	InterFileDependencies bool   `json:"interFileDependencies"`
 	WorkspaceDiagnostics  bool   `json:"workspaceDiagnostics"`
+}
+
+type InlayHintOptions struct {
+	ResolveProvider bool `json:"resolveProvider"`
+}
+
+type InlayHint struct {
+	Position     Position      `json:"position"`
+	Label        string        `json:"label"`
+	Kind         uint          `json:"kind"`
+	PaddingLeft  bool          `json:"paddingLeft"`
+	PaddingRight bool          `json:"paddingRight"`
+	Tooltip      MarkupContent `json:"tooltip"`
+}
+
+type TextDocumentInlayHintParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Range        Range                  `json:"range"`
 }
 
 type TextDocumentSyncOptions struct {

--- a/internal/lsp/rego.go
+++ b/internal/lsp/rego.go
@@ -1,0 +1,60 @@
+package lsp
+
+import "github.com/open-policy-agent/opa/ast"
+
+type BuiltInCall struct {
+	Builtin  *ast.Builtin
+	Location *ast.Location
+	Args     []*ast.Term
+}
+
+func positionFromLocation(loc *ast.Location) Position {
+	return Position{
+		Line:      uint(loc.Row - 1),
+		Character: uint(loc.Col - 1),
+	}
+}
+
+// AllBuiltinCalls returns all built-in calls in the module, excluding operators
+// and any other function identified by an infix.
+func AllBuiltinCalls(module *ast.Module) []BuiltInCall {
+	builtinCalls := make([]BuiltInCall, 0)
+
+	callVisitor := ast.NewGenericVisitor(func(x interface{}) bool {
+		var terms []*ast.Term
+
+		switch node := x.(type) {
+		case ast.Call:
+			terms = node
+		case *ast.Expr:
+			if call, ok := node.Terms.([]*ast.Term); ok {
+				terms = call
+			}
+		default:
+			return false
+		}
+
+		if len(terms) == 0 {
+			return false
+		}
+
+		if b, ok := builtins[terms[0].Value.String()]; ok {
+			// Exclude operators and similar builtins
+			if b.Infix != "" {
+				return false
+			}
+
+			builtinCalls = append(builtinCalls, BuiltInCall{
+				Builtin:  b,
+				Location: terms[0].Location,
+				Args:     terms[1:],
+			})
+		}
+
+		return false
+	})
+
+	callVisitor.Walk(module)
+
+	return builtinCalls
+}


### PR DESCRIPTION
This PR adds support for inlay hints of function arguments. Similar to the hover feature, only built-in functions are supported at this point.

Also did some minor refactoring in the hover function to have it use the same method for collecting built-in functions from a module as the inlay hint system does.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->