### PR TITLE
lsp: URI decode workspace URIs

### DIFF
--- a/internal/lsp/uri/uri.go
+++ b/internal/lsp/uri/uri.go
@@ -1,6 +1,7 @@
 package uri
 
 import (
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -32,9 +33,19 @@ func FromPath(client clients.Identifier, path string) string {
 // Some clients represent URIs differently, and so this function exists to convert
 // client URIs into a standard file paths.
 func ToPath(client clients.Identifier, uri string) string {
+	// if the uri appears to be a URI with a file prefix, then remove the prefix
 	path := strings.TrimPrefix(uri, "file://")
 
+	// if it looks like a URI, then try and decode it
+	if strings.HasPrefix(uri, "file://") {
+		decodedPath, err := url.QueryUnescape(path)
+		if err == nil {
+			path = decodedPath
+		}
+	}
+
 	if client == clients.IdentifierVSCode {
+		// handling case for windows when the drive letter is set
 		if strings.Contains(path, ":") || strings.Contains(path, "%3A") {
 			path = strings.Replace(path, "%3A", ":", 1)
 			path = strings.TrimPrefix(path, "/")

--- a/internal/lsp/uri/uri_test.go
+++ b/internal/lsp/uri/uri_test.go
@@ -136,6 +136,10 @@ func TestURIToPath_VSCode(t *testing.T) {
 			uri:  "file:///c%3A/foo/bar",
 			want: "c:/foo/bar",
 		},
+		"unix encoded with space in path": {
+			uri:  "file:///Users/foo/bar%20baz",
+			want: "/Users/foo/bar baz",
+		},
 		// these other examples shouldn't happen, but we should handle them
 		"windows not encoded": {
 			uri:  "file://c:/foo/bar",


### PR DESCRIPTION
This addresses an issue when the URIs used for workspaces contain spaces - for example.

Fixes https://github.com/StyraInc/regal/issues/629
