### PR TITLE
Cache result of `createHoverContent`

### DIFF
--- a/internal/lsp/hover.go
+++ b/internal/lsp/hover.go
@@ -19,6 +19,8 @@ type BuiltinPosition struct {
 
 var builtins = builtinMap() //nolint:gochecknoglobals
 
+var builtinHoverCache = make(map[*ast.Builtin]string) //nolint:gochecknoglobals
+
 func builtinMap() map[string]*ast.Builtin {
 	m := make(map[string]*ast.Builtin)
 	for _, b := range ast.CapabilitiesForThisVersion().Builtins {
@@ -73,6 +75,10 @@ func writeFunctionSnippet(sb *strings.Builder, builtin *ast.Builtin) {
 }
 
 func createHoverContent(builtin *ast.Builtin) string {
+	if content, ok := builtinHoverCache[builtin]; ok {
+		return content
+	}
+
 	title := fmt.Sprintf(
 		"[%s](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-%s-%s)",
 		builtin.Name,
@@ -139,7 +145,11 @@ func createHoverContent(builtin *ast.Builtin) string {
 
 	sb.WriteString("\n")
 
-	return sb.String()
+	result := sb.String()
+
+	builtinHoverCache[builtin] = result
+
+	return result
 }
 
 func updateBuiltinPositions(cache *Cache, uri string) error {


### PR DESCRIPTION
This is a idempotent function, so no need to render the content each time it's called.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->