### PR TITLE
Implement textDocument/formatting

### DIFF
--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -71,3 +71,31 @@ func ComputeEdits(before, after string) []TextEdit {
 
 	return edits
 }
+
+// The opa fmt command does not allow configuration options, so we will have
+// to ignore them if provided by the client. We can however log the warnings
+// so that the caller has some chance to be made aware of why their options
+// aren't applied.
+func validateFormattingOptions(opts FormattingOptions) []string {
+	warnings := make([]string, 0)
+
+	if opts.InsertSpaces {
+		warnings = append(warnings, "opa fmt: only tabs supported for indentation")
+	}
+
+	if !opts.TrimTrailingWhitespace {
+		warnings = append(warnings, "opa fmt: trailing whitespace always trimmed")
+	}
+
+	if !opts.InsertFinalNewline {
+		warnings = append(warnings, "opa fmt: final newline always inserted")
+	}
+
+	if !opts.TrimFinalNewlines {
+		warnings = append(warnings, "opa fmt: final newlines always trimmed")
+	}
+
+	// opts.TabSize ignored as we don't support using spaces
+
+	return warnings
+}

--- a/internal/lsp/messages.go
+++ b/internal/lsp/messages.go
@@ -77,13 +77,14 @@ type InitializeResult struct {
 }
 
 type ServerCapabilities struct {
-	TextDocumentSyncOptions TextDocumentSyncOptions `json:"textDocumentSync"`
-	DiagnosticProvider      DiagnosticOptions       `json:"diagnosticProvider"`
-	Workspace               WorkspaceOptions        `json:"workspace"`
-	InlayHintProvider       InlayHintOptions        `json:"inlayHintProvider"`
-	HoverProvider           bool                    `json:"hoverProvider"`
-	CodeActionProvider      CodeActionOptions       `json:"codeActionProvider"`
-	ExecuteCommandProvider  ExecuteCommandOptions   `json:"executeCommandProvider"`
+	TextDocumentSyncOptions    TextDocumentSyncOptions `json:"textDocumentSync"`
+	DiagnosticProvider         DiagnosticOptions       `json:"diagnosticProvider"`
+	Workspace                  WorkspaceOptions        `json:"workspace"`
+	InlayHintProvider          InlayHintOptions        `json:"inlayHintProvider"`
+	HoverProvider              bool                    `json:"hoverProvider"`
+	CodeActionProvider         CodeActionOptions       `json:"codeActionProvider"`
+	ExecuteCommandProvider     ExecuteCommandOptions   `json:"executeCommandProvider"`
+	DocumentFormattingProvider bool                    `json:"documentFormattingProvider"`
 }
 
 type WorkspaceOptions struct {
@@ -147,6 +148,19 @@ type TextDocumentEdit struct {
 type TextEdit struct {
 	Range   Range  `json:"range"`
 	NewText string `json:"newText"`
+}
+
+type DocumentFormattingParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Options      FormattingOptions      `json:"options"`
+}
+
+type FormattingOptions struct {
+	TabSize                uint `json:"tabSize"`
+	InsertSpaces           bool `json:"insertSpaces"`
+	TrimTrailingWhitespace bool `json:"trimTrailingWhitespace"`
+	InsertFinalNewline     bool `json:"insertFinalNewline"`
+	TrimFinalNewlines      bool `json:"trimFinalNewline"`
 }
 
 type FileOperationsServerCapabilities struct {


### PR DESCRIPTION
Although currently disabled in server capabilities while we work out how this should work with VS Code, where there is already a client-side formatter registered.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->