### PR TITLE
lsp: Accept but ignore cancelled requests

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -125,6 +125,11 @@ func (l *LanguageServer) Handle(
 		}
 
 		return struct{}{}, nil
+	case "$/cancelRequest":
+		// TODO: this is a no-op, but is something that we should implement
+		// if we want to support longer running, client-triggered operations
+		// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#dollarRequests
+		return struct{}{}, nil
 	}
 
 	return nil, &jsonrpc2.Error{


### PR DESCRIPTION
I have not been able to work out why these are sent but they don't seem to impact the running functionality of the server and supporting them seems to be optional.

https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#dollarRequests

For now, this updates the server to do nothing when receiving such a request. This avoids some log lines that we don't do anything about.

I would like to come back to this though as it seems like there's more here that we might be missing. So it has been labelled as TODO.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->