### PR TITLE
Fix wrong category for `double-negative` rule

### DIFF
--- a/docs/rules/style/double-negative.md
+++ b/docs/rules/style/double-negative.md
@@ -2,7 +2,7 @@
 
 **Summary**: Avoid double negatives
 
-**Category**: Community
+**Category**: Style
 
 **Avoid**
 ```rego
@@ -50,7 +50,7 @@ This linter rule provides the following configuration options:
 
 ```yaml
 rules:
-  community:
+  style:
     double-negative:
       # one of "error", "warning", "ignore"
       level: error


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->