### PR TITLE
Calculate correct column of `=` in `use-assignment-operator`

### DIFF
--- a/bundle/regal/rules/style/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use_assignment_operator.rego
@@ -18,7 +18,9 @@ report contains violation if {
 	not ast.implicit_boolean_assignment(rule)
 	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule))
+	loc := result.location(rule)
+
+	violation := result.fail(rego.metadata.chain(), object.union(loc, {"location": {"col": eq_col(loc)}}))
 }
 
 report contains violation if {
@@ -28,7 +30,9 @@ report contains violation if {
 	rule.head.value
 	not rule.head.assign
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule.head.ref[0]))
+	loc := result.location(result.location(rule.head.ref[0]))
+
+	violation := result.fail(rego.metadata.chain(), object.union(loc, {"location": {"col": eq_col(loc)}}))
 }
 
 report contains violation if {
@@ -51,5 +55,14 @@ report contains violation if {
 	text := base64.decode(value["else"].head.location.text)
 	regex.match(`^else\s*=`, text)
 
-	violation := result.fail(rego.metadata.chain(), result.location(value["else"].head))
+	loc := result.location(value["else"].head)
+
+	violation := result.fail(rego.metadata.chain(), object.union(loc, {"location": {"col": eq_col(loc)}}))
+}
+
+default eq_col(_) := 1
+
+eq_col(loc) := pos if {
+	pos := indexof(loc.location.text, "=")
+	pos != -1
 }

--- a/bundle/regal/rules/style/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use_assignment_operator_test.rego
@@ -16,7 +16,7 @@ test_fail_unification_in_regular_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo = false"},
+		"location": {"col": 4, "file": "policy.rego", "row": 3, "text": "foo = false"},
 		"level": "error",
 	}}
 }
@@ -31,7 +31,7 @@ test_fail_not_implicit_boolean_assignment_with_body if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "allow = true { true }"},
+		"location": {"col": 6, "file": "policy.rego", "row": 3, "text": "allow = true { true }"},
 		"level": "error",
 	}}
 }
@@ -46,7 +46,7 @@ test_fail_not_implicit_boolean_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo = true"},
+		"location": {"col": 4, "file": "policy.rego", "row": 3, "text": "foo = true"},
 		"level": "error",
 	}}
 }
@@ -66,7 +66,7 @@ test_fail_unification_in_default_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "default x = false"},
+		"location": {"col": 10, "file": "policy.rego", "row": 3, "text": "default x = false"},
 		"level": "error",
 	}}
 }
@@ -81,7 +81,7 @@ test_fail_unification_in_default_function_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "default x(_) = false"},
+		"location": {"col": 13, "file": "policy.rego", "row": 3, "text": "default x(_) = false"},
 		"level": "error",
 	}}
 }
@@ -106,7 +106,7 @@ test_fail_unification_in_object_rule_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": `x["a"] = 1`},
+		"location": {"col": 7, "file": "policy.rego", "row": 3, "text": `x["a"] = 1`},
 		"level": "error",
 	}}
 }
@@ -126,7 +126,7 @@ test_fail_unification_in_function_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": `foo(bar) = "baz"`},
+		"location": {"col": 9, "file": "policy.rego", "row": 3, "text": `foo(bar) = "baz"`},
 		"level": "error",
 	}}
 }
@@ -174,7 +174,7 @@ test_fail_unification_in_else if {
 				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 			}],
 			"title": "use-assignment-operator",
-			"location": {"col": 4, "file": "policy.rego", "row": 8, "text": "\t} else = true if {"},
+			"location": {"col": 8, "file": "policy.rego", "row": 8, "text": "\t} else = true if {"},
 			"level": "error",
 		},
 		{
@@ -185,7 +185,7 @@ test_fail_unification_in_else if {
 				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 			}],
 			"title": "use-assignment-operator",
-			"location": {"col": 4, "file": "policy.rego", "row": 10, "text": "\t} else = false"},
+			"location": {"col": 8, "file": "policy.rego", "row": 10, "text": "\t} else = false"},
 			"level": "error",
 		},
 	}


### PR DESCRIPTION
We previously just reported this as 1 regardless of where it was. Now we try to extract the correct column from the text in the location, or fall back to 1 if we can't find it.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->