### PR TITLE
lsp: Implement code actions for new fixes

### DIFF
--- a/internal/lsp/command.go
+++ b/internal/lsp/command.go
@@ -14,7 +14,7 @@ func toAnySlice(a []string) []any {
 func FmtCommand(args []string) types.Command {
 	return types.Command{
 		Title:     "Format using opa-fmt",
-		Command:   "regal.fmt",
+		Command:   "regal.fix.opa-fmt",
 		Tooltip:   "Format using opa-fmt",
 		Arguments: toAnySlice(args),
 	}
@@ -23,7 +23,7 @@ func FmtCommand(args []string) types.Command {
 func FmtV1Command(args []string) types.Command {
 	return types.Command{
 		Title:     "Format for Rego v1 using opa-fmt",
-		Command:   "regal.fmt.v1",
+		Command:   "regal.fix.use-rego-v1",
 		Tooltip:   "Format for Rego v1 using opa-fmt",
 		Arguments: toAnySlice(args),
 	}
@@ -32,7 +32,7 @@ func FmtV1Command(args []string) types.Command {
 func UseAssignmentOperatorCommand(args []string) types.Command {
 	return types.Command{
 		Title:     "Replace = with := in assignment",
-		Command:   "regal.use-assignment-operator",
+		Command:   "regal.fix.use-assignment-operator",
 		Tooltip:   "Replace = with := in assignment",
 		Arguments: toAnySlice(args),
 	}
@@ -41,7 +41,7 @@ func UseAssignmentOperatorCommand(args []string) types.Command {
 func NoWhiteSpaceCommentCommand(args []string) types.Command {
 	return types.Command{
 		Title:     "Format comment to have leading whitespace",
-		Command:   "regal.no-whitespace-comment",
+		Command:   "regal.fix.no-whitespace-comment",
 		Tooltip:   "Format comment to have leading whitespace",
 		Arguments: toAnySlice(args),
 	}

--- a/internal/lsp/command.go
+++ b/internal/lsp/command.go
@@ -28,3 +28,21 @@ func FmtV1Command(args []string) types.Command {
 		Arguments: toAnySlice(args),
 	}
 }
+
+func UseAssignmentOperatorCommand(args []string) types.Command {
+	return types.Command{
+		Title:     "Replace = with := in assignment",
+		Command:   "regal.use-assignment-operator",
+		Tooltip:   "Replace = with := in assignment",
+		Arguments: toAnySlice(args),
+	}
+}
+
+func NoWhiteSpaceCommentCommand(args []string) types.Command {
+	return types.Command{
+		Title:     "Format comment to have leading whitespace",
+		Command:   "regal.no-whitespace-comment",
+		Tooltip:   "Format comment to have leading whitespace",
+		Arguments: toAnySlice(args),
+	}
+}

--- a/internal/lsp/commands/parse.go
+++ b/internal/lsp/commands/parse.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+type ParseOptions struct {
+	TargetArgIndex int
+	RowArgIndex    int
+	ColArgIndex    int
+}
+
+type ParseResult struct {
+	Target   string
+	Location *ast.Location
+}
+
+// Parse is responsible for extracting the target and location from the given params command params sent from the client
+// after acting on a Code Action.
+func Parse(params types.ExecuteCommandParams, opts ParseOptions) (*ParseResult, error) {
+	if len(params.Arguments) == 0 {
+		return nil, errors.New("no args supplied")
+	}
+
+	target := ""
+
+	if opts.TargetArgIndex < len(params.Arguments) {
+		target = fmt.Sprintf("%s", params.Arguments[opts.TargetArgIndex])
+	}
+
+	// we can't extract a location from the same location as the target, so location arg positions
+	// must not have been set in the opts.
+	if opts.RowArgIndex == opts.TargetArgIndex {
+		return &ParseResult{
+			Target: target,
+		}, nil
+	}
+
+	var loc *ast.Location
+
+	if opts.RowArgIndex < len(params.Arguments) && opts.ColArgIndex < len(params.Arguments) {
+		var row, col int
+
+		switch v := params.Arguments[opts.RowArgIndex].(type) {
+		case int:
+			row = v
+		case string:
+			var err error
+
+			row, err = strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse row: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("unexpected type for row: %T", params.Arguments[opts.RowArgIndex])
+		}
+
+		switch v := params.Arguments[opts.ColArgIndex].(type) {
+		case int:
+			col = v
+		case string:
+			var err error
+
+			col, err = strconv.Atoi(v)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse col: %w", err)
+			}
+		default:
+			return nil, fmt.Errorf("unexpected type for col: %T", params.Arguments[opts.ColArgIndex])
+		}
+
+		loc = &ast.Location{
+			Row: row,
+			Col: col,
+		}
+	}
+
+	return &ParseResult{
+		Target:   target,
+		Location: loc,
+	}, nil
+}

--- a/internal/lsp/commands/parse_test.go
+++ b/internal/lsp/commands/parse_test.go
@@ -1,0 +1,110 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		ExecuteCommandParams types.ExecuteCommandParams
+		ParseOptions         ParseOptions
+		ExpectedTarget       string
+		ExpectedLocation     *ast.Location
+	}{
+		"extract target only": {
+			ExecuteCommandParams: types.ExecuteCommandParams{
+				Command:   "example",
+				Arguments: []interface{}{"target"},
+			},
+			ParseOptions:     ParseOptions{TargetArgIndex: 0},
+			ExpectedTarget:   "target",
+			ExpectedLocation: nil,
+		},
+		"extract target and location": {
+			ExecuteCommandParams: types.ExecuteCommandParams{
+				Command:   "example",
+				Arguments: []interface{}{"target", "1", 2}, // different types for testing, but should be strings
+			},
+			ParseOptions:     ParseOptions{TargetArgIndex: 0, RowArgIndex: 1, ColArgIndex: 2},
+			ExpectedTarget:   "target",
+			ExpectedLocation: &ast.Location{Row: 1, Col: 2},
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := Parse(tc.ExecuteCommandParams, tc.ParseOptions)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if result.Target != tc.ExpectedTarget {
+				t.Fatalf("expected target %q, got %q", tc.ExpectedTarget, result.Target)
+			}
+
+			if tc.ExpectedLocation == nil && result.Location != nil {
+				t.Fatalf("expected location to be nil, got %v", result.Location)
+			}
+
+			if tc.ExpectedLocation != nil {
+				if result.Location == nil {
+					t.Fatalf("expected location to be %v, got nil", tc.ExpectedLocation)
+				}
+
+				if result.Location.Row != tc.ExpectedLocation.Row {
+					t.Fatalf("expected row %d, got %d", tc.ExpectedLocation.Row, result.Location.Row)
+				}
+
+				if result.Location.Col != tc.ExpectedLocation.Col {
+					t.Fatalf("expected col %d, got %d", tc.ExpectedLocation.Col, result.Location.Col)
+				}
+			}
+		})
+	}
+}
+
+func TestParse_Errors(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		ExecuteCommandParams types.ExecuteCommandParams
+		ParseOptions         ParseOptions
+		ExpectedError        string
+	}{
+		"error extracting target": {
+			ExecuteCommandParams: types.ExecuteCommandParams{
+				Command:   "example",
+				Arguments: []interface{}{}, // empty and so nothing can be extracted
+			},
+			ParseOptions:  ParseOptions{TargetArgIndex: 0},
+			ExpectedError: "no args supplied",
+		},
+	}
+
+	for name, tc := range testCases {
+		tc := tc
+
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Parse(tc.ExecuteCommandParams, tc.ParseOptions)
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tc.ExpectedError)
+			}
+
+			if err.Error() != tc.ExpectedError {
+				t.Fatalf("expected error %q, got %q", tc.ExpectedError, err.Error())
+			}
+		})
+	}
+}

--- a/internal/lsp/messages.go
+++ b/internal/lsp/messages.go
@@ -1,1 +1,0 @@
-package lsp

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -285,28 +285,28 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) {
 			var fixed bool
 
 			switch params.Command {
-			case "regal.fmt":
+			case "regal.fix.opa-fmt":
 				fixed, editParams, err = l.fixEditParams(
 					"Format using opa fmt",
 					&fixes.Fmt{OPAFmtOpts: format.Opts{}},
 					commands.ParseOptions{TargetArgIndex: 0},
 					params,
 				)
-			case "regal.fmt.v1":
+			case "regal.fix.use-rego-v1":
 				fixed, editParams, err = l.fixEditParams(
 					"Format for Rego v1 using opa-fmt",
 					&fixes.Fmt{OPAFmtOpts: format.Opts{RegoVersion: ast.RegoV0CompatV1}},
 					commands.ParseOptions{TargetArgIndex: 0},
 					params,
 				)
-			case "regal.use-assignment-operator":
+			case "regal.fix.use-assignment-operator":
 				fixed, editParams, err = l.fixEditParams(
 					"Replace = with := in assignment",
 					&fixes.UseAssignmentOperator{},
 					commands.ParseOptions{TargetArgIndex: 0, RowArgIndex: 1, ColArgIndex: 2},
 					params,
 				)
-			case "regal.no-whitespace-comment":
+			case "regal.fix.no-whitespace-comment":
 				fixed, editParams, err = l.fixEditParams(
 					"Format comment to have leading whitespace",
 					&fixes.NoWhitespaceComment{},
@@ -861,10 +861,10 @@ func (l *LanguageServer) handleInitialize(
 			},
 			ExecuteCommandProvider: types.ExecuteCommandOptions{
 				Commands: []string{
-					"regal.fmt",
-					"regal.fmt.v1",
-					"regal.use-assignment-operator",
-					"regal.no-whitespace-comment",
+					"regal.fix.opa-fmt",
+					"regal.fix.use-rego-v1",
+					"regal.fix.use-assignment-operator",
+					"regal.fix.no-whitespace-comment",
 				},
 			},
 			DocumentFormattingProvider: true,

--- a/pkg/fixer/fixes/fmt_test.go
+++ b/pkg/fixer/fixes/fmt_test.go
@@ -57,7 +57,7 @@ allow := true
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			fixResults, err := tc.fmt.Fix(tc.fc, &RuntimeOptions{})
+			fixResults, err := tc.fmt.Fix(tc.fc, nil)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/fixer/fixes/nowhitespacecomment.go
+++ b/pkg/fixer/fixes/nowhitespacecomment.go
@@ -2,6 +2,7 @@ package fixes
 
 import (
 	"bytes"
+	"errors"
 	"slices"
 )
 
@@ -14,9 +15,8 @@ func (*NoWhitespaceComment) Name() string {
 func (*NoWhitespaceComment) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
 	lines := bytes.Split(fc.Contents, []byte("\n"))
 
-	// this fix must have locations
-	if len(opts.Locations) == 0 {
-		return nil, nil
+	if opts == nil {
+		return nil, errors.New("missing runtime options")
 	}
 
 	fixed := false

--- a/pkg/fixer/fixes/nowhitespacecomment_test.go
+++ b/pkg/fixer/fixes/nowhitespacecomment_test.go
@@ -27,23 +27,10 @@ func TestNoWhitespaceComment(t *testing.T) {
 
 # this is a comment
 `),
-			fixExpected:    false,
-			runtimeOptions: &RuntimeOptions{},
-		},
-		"no change made because no location": {
-			fc: &FixCandidate{
-				Filename: "test.rego",
-				Contents: []byte(`package test\n
-
-#this is a comment
-`),
+			fixExpected: false,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []ast.Location{},
 			},
-			contentAfterFix: []byte(`package test\n
-
-#this is a comment
-`),
-			fixExpected:    false,
-			runtimeOptions: &RuntimeOptions{},
 		},
 		"single change": {
 			fc: &FixCandidate{
@@ -63,28 +50,6 @@ func TestNoWhitespaceComment(t *testing.T) {
 					{
 						Row: 3,
 						Col: 1,
-					},
-				},
-			},
-		},
-		"bad change": {
-			fc: &FixCandidate{
-				Filename: "test.rego",
-				Contents: []byte(`package test\n
-
-#this is a comment
-`),
-			},
-			contentAfterFix: []byte(`package test\n
-
-#this is a comment
-`),
-			fixExpected: false,
-			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
-					{
-						Row: 3,
-						Col: 9, // this is wrong and should not be fixed
 					},
 				},
 			},

--- a/pkg/fixer/fixes/useassignmentoperator.go
+++ b/pkg/fixer/fixes/useassignmentoperator.go
@@ -2,6 +2,7 @@ package fixes
 
 import (
 	"bytes"
+	"errors"
 	"slices"
 )
 
@@ -14,9 +15,8 @@ func (*UseAssignmentOperator) Name() string {
 func (*UseAssignmentOperator) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
 	lines := bytes.Split(fc.Contents, []byte("\n"))
 
-	// this fix must have locations
-	if len(opts.Locations) == 0 {
-		return nil, nil
+	if opts == nil {
+		return nil, errors.New("missing runtime options")
 	}
 
 	fixed := false


### PR DESCRIPTION
https://github.com/StyraInc/regal/pull/653 added fixes for no-whitespace-comment and use-assignment-operator. This PR adds code actions for these in the regal lsp.


Fixes https://github.com/StyraInc/regal/issues/659

Fixes https://github.com/StyraInc/regal/issues/649