### PR TITLE
lsp: Support folding ranges

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v4.0.0
         if: matrix.os.name == 'linux'
         with:
-          version: v1.56.1
+          version: v1.57.2
       - uses: actions/upload-artifact@v4
         with:
           name: regal-${{ matrix.os.name }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -61,3 +61,7 @@ linters-settings:
       - prefix(github.com/styrainc/regal)
       - blank
       - dot
+
+issues:
+  exclude-dirs:
+    - internal/lsp/opa

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -746,7 +746,7 @@ allow if {
 	true
 }
 `)
-	err := os.WriteFile(filepath.Join(td, "main.rego"), unformattedContents, 0644)
+	err := os.WriteFile(filepath.Join(td, "main.rego"), unformattedContents, 0o644)
 	if err != nil {
 		t.Fatalf("failed to write main.rego: %v", err)
 	}

--- a/internal/lsp/foldingrange.go
+++ b/internal/lsp/foldingrange.go
@@ -1,0 +1,155 @@
+package lsp
+
+import (
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/opa/scanner"
+	"github.com/styrainc/regal/internal/lsp/opa/tokens"
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+type stack []scanner.Position
+
+func (s stack) Push(p scanner.Position) stack {
+	return append(s, p)
+}
+
+func (s stack) Pop() (stack, scanner.Position) {
+	l := len(s)
+
+	return s[:l-1], s[l-1]
+}
+
+func TokenFoldingRanges(policy string) []types.FoldingRange {
+	scn, err := scanner.New(strings.NewReader(policy))
+	if err != nil {
+		panic(err)
+	}
+
+	var lastPosition scanner.Position
+
+	curlyBraceStack := stack{}
+	bracketStack := stack{}
+	parensStack := stack{}
+
+	foldingRanges := make([]types.FoldingRange, 0)
+
+	for {
+		token, position, _, errors := scn.Scan()
+
+		if token == tokens.EOF || len(errors) > 0 {
+			break
+		}
+
+		switch {
+		case token == tokens.LBrace:
+			curlyBraceStack = curlyBraceStack.Push(position)
+		case token == tokens.RBrace && len(curlyBraceStack) > 0:
+			curlyBraceStack, lastPosition = curlyBraceStack.Pop()
+
+			startChar := uint(lastPosition.Col)
+
+			foldingRanges = append(foldingRanges, types.FoldingRange{
+				StartLine:      uint(lastPosition.Row - 1),
+				StartCharacter: &startChar,
+				// Note that we stop at the line _before_ the closing curly brace
+				// as that shows the end of the object/set in the client, which seems
+				// to be how other implementations do it
+				EndLine: uint(position.Row - 2),
+				Kind:    "region",
+			})
+		case token == tokens.LBrack:
+			bracketStack = bracketStack.Push(position)
+		case token == tokens.RBrack && len(bracketStack) > 0:
+			bracketStack, lastPosition = bracketStack.Pop()
+
+			startChar := uint(lastPosition.Col)
+
+			foldingRanges = append(foldingRanges, types.FoldingRange{
+				StartLine:      uint(lastPosition.Row - 1),
+				StartCharacter: &startChar,
+				// Note that we stop at the line _before_ the closing bracket
+				// as that shows the end of the array in the client, which seems
+				// to be how other implementations do it
+				EndLine: uint(position.Row - 2),
+				Kind:    "region",
+			})
+		case token == tokens.LParen:
+			parensStack = parensStack.Push(position)
+		case token == tokens.RParen && len(parensStack) > 0:
+			parensStack, lastPosition = parensStack.Pop()
+
+			startChar := uint(lastPosition.Col)
+
+			foldingRanges = append(foldingRanges, types.FoldingRange{
+				StartLine:      uint(lastPosition.Row - 1),
+				StartCharacter: &startChar,
+				// Note that we stop at the line _before_ the closing bracket
+				// as that shows the end of the array in the client, which seems
+				// to be how other implementations do it
+				EndLine: uint(position.Row - 2),
+				Kind:    "region",
+			})
+		}
+	}
+
+	return foldingRanges
+}
+
+func findFoldingRanges(text string, module *ast.Module) []types.FoldingRange {
+	uintZero := uint(0)
+
+	ranges := make([]types.FoldingRange, 0)
+
+	// Comments
+
+	numComments := len(module.Comments)
+	isBlock := false
+
+	var startLine uint
+
+	for i, comment := range module.Comments {
+		// the comment following this is on the next line
+		if i+1 < numComments && module.Comments[i+1].Location.Row == comment.Location.Row+1 {
+			isBlock = true
+
+			if i == 0 || module.Comments[i-1].Location.Row != comment.Location.Row-1 {
+				startLine = uint(comment.Location.Row - 1)
+			}
+		} else if isBlock {
+			ranges = append(ranges, types.FoldingRange{
+				StartLine:      startLine,
+				EndLine:        uint(comment.Location.Row - 1),
+				StartCharacter: &uintZero,
+				Kind:           "comment",
+			})
+
+			isBlock = false
+		}
+	}
+
+	// Imports
+
+	if len(module.Imports) > 2 {
+		lastImport := module.Imports[len(module.Imports)-1]
+
+		// note that we treat *all* imports as a single folding range,
+		// as it's likely the user wants to hide all of them... but we
+		// could consider instead folding "blocks" of grouped imports
+
+		ranges = append(ranges, types.FoldingRange{
+			StartLine:      uint(module.Imports[0].Location.Row - 1),
+			EndLine:        uint(lastImport.Location.Row - 1),
+			StartCharacter: &uintZero,
+			Kind:           "imports",
+		})
+	}
+
+	// Tokens — {}, [], ()
+
+	tokenRanges := TokenFoldingRanges(text)
+
+	return append(ranges, tokenRanges...)
+}

--- a/internal/lsp/foldingrange_test.go
+++ b/internal/lsp/foldingrange_test.go
@@ -1,0 +1,76 @@
+package lsp
+
+import (
+	"testing"
+)
+
+func TestTokenFoldingRanges(t *testing.T) {
+	t.Parallel()
+
+	policy := `package p
+
+	import rego.v1
+
+rule if {
+	arr := [
+		1,
+		2,
+		3,
+	]
+	par := (
+		1 +
+		2 -
+		3
+	)
+}`
+
+	foldingRanges := TokenFoldingRanges(policy)
+
+	if len(foldingRanges) != 3 {
+		t.Fatalf("Expected 3 folding ranges, got %d", len(foldingRanges))
+	}
+
+	arr := foldingRanges[0]
+
+	if arr.StartLine != 5 || *arr.StartCharacter != 9 {
+		t.Errorf("Expected start line 5 and start character 9, got %d and %d", arr.StartLine, *arr.StartCharacter)
+	}
+
+	if arr.EndLine != 8 {
+		t.Errorf("Expected end line 8, got %d", arr.EndLine)
+	}
+
+	parens := foldingRanges[1]
+
+	if parens.StartLine != 10 || *parens.StartCharacter != 9 {
+		t.Errorf("Expected start line 10 and start character 9, got %d and %d", parens.StartLine, *parens.StartCharacter)
+	}
+
+	if parens.EndLine != 13 {
+		t.Errorf("Expected end line 13, got %d", parens.EndLine)
+	}
+
+	rule := foldingRanges[2]
+
+	if rule.StartLine != 4 || *rule.StartCharacter != 9 {
+		t.Errorf("Expected start line 4 and start character 9, got %d and %d", rule.StartLine, *rule.StartCharacter)
+	}
+
+	if rule.EndLine != 14 {
+		t.Errorf("Expected end line 7, got %d", rule.EndLine)
+	}
+}
+
+func TestTokenInvalidFoldingRanges(t *testing.T) {
+	t.Parallel()
+
+	policy := `package p
+
+arr := ]]`
+
+	foldingRanges := TokenFoldingRanges(policy)
+
+	if len(foldingRanges) != 0 {
+		t.Fatalf("Expected no folding ranges, got %d", len(foldingRanges))
+	}
+}

--- a/internal/lsp/opa/scanner/scanner.go
+++ b/internal/lsp/opa/scanner/scanner.go
@@ -1,0 +1,446 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Original source at https://github.com/open-policy-agent/opa/blob/main/ast/internal/scanner/scanner.go
+
+package scanner
+
+import (
+	"fmt"
+	"io"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/styrainc/regal/internal/lsp/opa/tokens"
+)
+
+const bom = 0xFEFF
+
+// Scanner is used to tokenize an input stream of
+// Rego source code.
+type Scanner struct {
+	offset           int
+	row              int
+	col              int
+	bs               []byte
+	curr             rune
+	width            int
+	errors           []Error
+	keywords         map[string]tokens.Token
+	regoV1Compatible bool
+}
+
+// Error represents a scanner error.
+type Error struct {
+	Pos     Position
+	Message string
+}
+
+// Position represents a point in the scanned source code.
+type Position struct {
+	Offset int // start offset in bytes
+	End    int // end offset in bytes
+	Row    int // line number computed in bytes
+	Col    int // column number computed in bytes
+}
+
+// New returns an initialized scanner that will scan
+// through the source code provided by the io.Reader.
+func New(r io.Reader) (*Scanner, error) {
+	bs, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Scanner{
+		offset:   0,
+		row:      1,
+		col:      0,
+		bs:       bs,
+		curr:     -1,
+		width:    0,
+		keywords: tokens.Keywords(),
+	}
+
+	s.next()
+
+	if s.curr == bom {
+		s.next()
+	}
+
+	return s, nil
+}
+
+// Bytes returns the raw bytes for the full source
+// which the scanner has read in.
+func (s *Scanner) Bytes() []byte {
+	return s.bs
+}
+
+// String returns a human-readable string of the current scanner state.
+func (s *Scanner) String() string {
+	return fmt.Sprintf("<curr: %q, offset: %d, len: %d>", s.curr, s.offset, len(s.bs))
+}
+
+// Keyword will return a token for the passed in
+// literal value. If the value is a Rego keyword
+// then the appropriate token is returned. Everything
+// else is an Ident.
+func (s *Scanner) Keyword(lit string) tokens.Token {
+	if tok, ok := s.keywords[lit]; ok {
+		return tok
+	}
+	return tokens.Ident
+}
+
+// AddKeyword adds a string -> token mapping to this Scanner instance.
+func (s *Scanner) AddKeyword(kw string, tok tokens.Token) {
+	s.keywords[kw] = tok
+
+	switch tok {
+	case tokens.Every: // importing 'every' means also importing 'in'
+		s.keywords["in"] = tokens.In
+	}
+}
+
+func (s *Scanner) HasKeyword(keywords map[string]tokens.Token) bool {
+	for kw := range s.keywords {
+		if _, ok := keywords[kw]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Scanner) SetRegoV1Compatible() {
+	s.regoV1Compatible = true
+}
+
+func (s *Scanner) RegoV1Compatible() bool {
+	return s.regoV1Compatible
+}
+
+// WithKeywords returns a new copy of the Scanner struct `s`, with the set
+// of known keywords being that of `s` with `kws` added.
+func (s *Scanner) WithKeywords(kws map[string]tokens.Token) *Scanner {
+	cpy := *s
+	cpy.keywords = make(map[string]tokens.Token, len(s.keywords)+len(kws))
+	for kw, tok := range s.keywords {
+		cpy.AddKeyword(kw, tok)
+	}
+	for k, t := range kws {
+		cpy.AddKeyword(k, t)
+	}
+	return &cpy
+}
+
+// WithoutKeywords returns a new copy of the Scanner struct `s`, with the
+// set of known keywords being that of `s` with `kws` removed.
+// The previously known keywords are returned for a convenient reset.
+func (s *Scanner) WithoutKeywords(kws map[string]tokens.Token) (*Scanner, map[string]tokens.Token) {
+	cpy := *s
+	kw := s.keywords
+	cpy.keywords = make(map[string]tokens.Token, len(s.keywords)-len(kws))
+	for kw, tok := range s.keywords {
+		if _, ok := kws[kw]; !ok {
+			cpy.AddKeyword(kw, tok)
+		}
+	}
+	return &cpy, kw
+}
+
+// Scan will increment the scanners position in the source
+// code until the next token is found. The token, starting position
+// of the token, string literal, and any errors encountered are
+// returned. A token will always be returned, the caller must check
+// for any errors before using the other values.
+func (s *Scanner) Scan() (tokens.Token, Position, string, []Error) {
+	pos := Position{Offset: s.offset - s.width, Row: s.row, Col: s.col}
+	var tok tokens.Token
+	var lit string
+
+	if s.isWhitespace() {
+		lit = string(s.curr)
+		s.next()
+		tok = tokens.Whitespace
+	} else if isLetter(s.curr) {
+		lit = s.scanIdentifier()
+		tok = s.Keyword(lit)
+	} else if isDecimal(s.curr) {
+		lit = s.scanNumber()
+		tok = tokens.Number
+	} else {
+		ch := s.curr
+		s.next()
+		switch ch {
+		case -1:
+			tok = tokens.EOF
+		case '#':
+			lit = s.scanComment()
+			tok = tokens.Comment
+		case '"':
+			lit = s.scanString()
+			tok = tokens.String
+		case '`':
+			lit = s.scanRawString()
+			tok = tokens.String
+		case '[':
+			tok = tokens.LBrack
+		case ']':
+			tok = tokens.RBrack
+		case '{':
+			tok = tokens.LBrace
+		case '}':
+			tok = tokens.RBrace
+		case '(':
+			tok = tokens.LParen
+		case ')':
+			tok = tokens.RParen
+		case ',':
+			tok = tokens.Comma
+		case ':':
+			if s.curr == '=' {
+				s.next()
+				tok = tokens.Assign
+			} else {
+				tok = tokens.Colon
+			}
+		case '+':
+			tok = tokens.Add
+		case '-':
+			tok = tokens.Sub
+		case '*':
+			tok = tokens.Mul
+		case '/':
+			tok = tokens.Quo
+		case '%':
+			tok = tokens.Rem
+		case '&':
+			tok = tokens.And
+		case '|':
+			tok = tokens.Or
+		case '=':
+			if s.curr == '=' {
+				s.next()
+				tok = tokens.Equal
+			} else {
+				tok = tokens.Unify
+			}
+		case '>':
+			if s.curr == '=' {
+				s.next()
+				tok = tokens.Gte
+			} else {
+				tok = tokens.Gt
+			}
+		case '<':
+			if s.curr == '=' {
+				s.next()
+				tok = tokens.Lte
+			} else {
+				tok = tokens.Lt
+			}
+		case '!':
+			if s.curr == '=' {
+				s.next()
+				tok = tokens.Neq
+			} else {
+				s.error("illegal ! character")
+			}
+		case ';':
+			tok = tokens.Semicolon
+		case '.':
+			tok = tokens.Dot
+		}
+	}
+
+	pos.End = s.offset - s.width
+	errs := s.errors
+	s.errors = nil
+
+	return tok, pos, lit, errs
+}
+
+func (s *Scanner) scanIdentifier() string {
+	start := s.offset - 1
+	for isLetter(s.curr) || isDigit(s.curr) {
+		s.next()
+	}
+	return string(s.bs[start : s.offset-1])
+}
+
+func (s *Scanner) scanNumber() string {
+	start := s.offset - 1
+
+	if s.curr != '.' {
+		for isDecimal(s.curr) {
+			s.next()
+		}
+	}
+
+	if s.curr == '.' {
+		s.next()
+		var found bool
+		for isDecimal(s.curr) {
+			s.next()
+			found = true
+		}
+		if !found {
+			s.error("expected fraction")
+		}
+	}
+
+	if lower(s.curr) == 'e' {
+		s.next()
+		if s.curr == '+' || s.curr == '-' {
+			s.next()
+		}
+		var found bool
+		for isDecimal(s.curr) {
+			s.next()
+			found = true
+		}
+		if !found {
+			s.error("expected exponent")
+		}
+	}
+
+	// Scan any digits following the decimals to get the
+	// entire invalid number/identifier.
+	// Example: 0a2b should be a single invalid number "0a2b"
+	// rather than a number "0", followed by identifier "a2b".
+	if isLetter(s.curr) {
+		s.error("illegal number format")
+		for isLetter(s.curr) || isDigit(s.curr) {
+			s.next()
+		}
+	}
+
+	return string(s.bs[start : s.offset-1])
+}
+
+func (s *Scanner) scanString() string {
+	start := s.literalStart()
+	for {
+		ch := s.curr
+
+		if ch == '\n' || ch < 0 {
+			s.error("non-terminated string")
+			break
+		}
+
+		s.next()
+
+		if ch == '"' {
+			break
+		}
+
+		if ch == '\\' {
+			switch s.curr {
+			case '\\', '"', '/', 'b', 'f', 'n', 'r', 't':
+				s.next()
+			case 'u':
+				s.next()
+				s.next()
+				s.next()
+				s.next()
+			default:
+				s.error("illegal escape sequence")
+			}
+		}
+	}
+
+	return string(s.bs[start : s.offset-1])
+}
+
+func (s *Scanner) scanRawString() string {
+	start := s.literalStart()
+	for {
+		ch := s.curr
+		s.next()
+		if ch == '`' {
+			break
+		} else if ch < 0 {
+			s.error("non-terminated string")
+			break
+		}
+	}
+	return string(s.bs[start : s.offset-1])
+}
+
+func (s *Scanner) scanComment() string {
+	start := s.literalStart()
+	for s.curr != '\n' && s.curr != -1 {
+		s.next()
+	}
+	end := s.offset - 1
+	// Trim carriage returns that precede the newline
+	if s.offset > 1 && s.bs[s.offset-2] == '\r' {
+		end = end - 1
+	}
+	return string(s.bs[start:end])
+}
+
+func (s *Scanner) next() {
+	if s.offset >= len(s.bs) {
+		s.curr = -1
+		s.offset = len(s.bs) + 1
+		return
+	}
+
+	s.curr = rune(s.bs[s.offset])
+	s.width = 1
+
+	if s.curr == 0 {
+		s.error("illegal null character")
+	} else if s.curr >= utf8.RuneSelf {
+		s.curr, s.width = utf8.DecodeRune(s.bs[s.offset:])
+		if s.curr == utf8.RuneError && s.width == 1 {
+			s.error("illegal utf-8 character")
+		} else if s.curr == bom && s.offset > 0 {
+			s.error("illegal byte-order mark")
+		}
+	}
+
+	s.offset += s.width
+
+	if s.curr == '\n' {
+		s.row++
+		s.col = 0
+	} else {
+		s.col++
+	}
+}
+
+func (s *Scanner) literalStart() int {
+	// The current offset is at the first character past the literal delimiter (#, ", `, etc.)
+	// Need to subtract width of first character (plus one for the delimiter).
+	return s.offset - (s.width + 1)
+}
+
+// From the Go scanner (src/go/scanner/scanner.go)
+
+func isLetter(ch rune) bool {
+	return 'a' <= lower(ch) && lower(ch) <= 'z' || ch == '_'
+}
+
+func isDigit(ch rune) bool {
+	return isDecimal(ch) || ch >= utf8.RuneSelf && unicode.IsDigit(ch)
+}
+
+func isDecimal(ch rune) bool { return '0' <= ch && ch <= '9' }
+
+func lower(ch rune) rune { return ('a' - 'A') | ch } // returns lower-case ch iff ch is ASCII letter
+
+func (s *Scanner) isWhitespace() bool {
+	return s.curr == ' ' || s.curr == '\t' || s.curr == '\n' || s.curr == '\r'
+}
+
+func (s *Scanner) error(reason string) {
+	s.errors = append(s.errors, Error{Pos: Position{
+		Offset: s.offset,
+		Row:    s.row,
+		Col:    s.col,
+	}, Message: reason})
+}

--- a/internal/lsp/opa/tokens/tokens.go
+++ b/internal/lsp/opa/tokens/tokens.go
@@ -1,0 +1,153 @@
+// Copyright 2020 The OPA Authors.  All rights reserved.
+// Use of this source code is governed by an Apache2
+// license that can be found in the LICENSE file.
+
+// Original source at: https://github.com/open-policy-agent/opa/blob/main/ast/internal/tokens/tokens.go
+
+package tokens
+
+// Token represents a single Rego source code token
+// for use by the Parser.
+type Token int
+
+func (t Token) String() string {
+	if t < 0 || int(t) >= len(strings) {
+		return "unknown"
+	}
+	return strings[t]
+}
+
+// All tokens must be defined here
+const (
+	Illegal Token = iota
+	EOF
+	Whitespace
+	Ident
+	Comment
+
+	Package
+	Import
+	As
+	Default
+	Else
+	Not
+	Some
+	With
+	Null
+	True
+	False
+
+	Number
+	String
+
+	LBrack
+	RBrack
+	LBrace
+	RBrace
+	LParen
+	RParen
+	Comma
+	Colon
+
+	Add
+	Sub
+	Mul
+	Quo
+	Rem
+	And
+	Or
+	Unify
+	Equal
+	Assign
+	In
+	Neq
+	Gt
+	Lt
+	Gte
+	Lte
+	Dot
+	Semicolon
+
+	Every
+	Contains
+	If
+)
+
+var strings = [...]string{
+	Illegal:    "illegal",
+	EOF:        "eof",
+	Whitespace: "whitespace",
+	Comment:    "comment",
+	Ident:      "identifier",
+	Package:    "package",
+	Import:     "import",
+	As:         "as",
+	Default:    "default",
+	Else:       "else",
+	Not:        "not",
+	Some:       "some",
+	With:       "with",
+	Null:       "null",
+	True:       "true",
+	False:      "false",
+	Number:     "number",
+	String:     "string",
+	LBrack:     "[",
+	RBrack:     "]",
+	LBrace:     "{",
+	RBrace:     "}",
+	LParen:     "(",
+	RParen:     ")",
+	Comma:      ",",
+	Colon:      ":",
+	Add:        "plus",
+	Sub:        "minus",
+	Mul:        "mul",
+	Quo:        "div",
+	Rem:        "rem",
+	And:        "and",
+	Or:         "or",
+	Unify:      "eq",
+	Equal:      "equal",
+	Assign:     "assign",
+	In:         "in",
+	Neq:        "neq",
+	Gt:         "gt",
+	Lt:         "lt",
+	Gte:        "gte",
+	Lte:        "lte",
+	Dot:        ".",
+	Semicolon:  ";",
+	Every:      "every",
+	Contains:   "contains",
+	If:         "if",
+}
+
+var keywords = map[string]Token{
+	"package": Package,
+	"import":  Import,
+	"as":      As,
+	"default": Default,
+	"else":    Else,
+	"not":     Not,
+	"some":    Some,
+	"with":    With,
+	"null":    Null,
+	"true":    True,
+	"false":   False,
+}
+
+// Keywords returns a copy of the default string -> Token keyword map.
+func Keywords() map[string]Token {
+	cpy := make(map[string]Token, len(keywords))
+	for k, v := range keywords {
+		cpy[k] = v
+	}
+	return cpy
+}
+
+// IsKeyword returns if a token is a keyword
+func IsKeyword(tok Token) bool {
+	_, ok := keywords[strings[tok]]
+	return ok
+}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -85,6 +85,7 @@ type ServerCapabilities struct {
 	CodeActionProvider         CodeActionOptions       `json:"codeActionProvider"`
 	ExecuteCommandProvider     ExecuteCommandOptions   `json:"executeCommandProvider"`
 	DocumentFormattingProvider bool                    `json:"documentFormattingProvider"`
+	FoldingRangeProvider       bool                    `json:"foldingRangeProvider"`
 }
 
 type WorkspaceOptions struct {
@@ -153,6 +154,18 @@ type TextEdit struct {
 type DocumentFormattingParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Options      FormattingOptions      `json:"options"`
+}
+
+type FoldingRangeParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+type FoldingRange struct {
+	StartLine      uint   `json:"startLine"`
+	StartCharacter *uint  `json:"startCharacter,omitempty"`
+	EndLine        uint   `json:"endLine"`
+	EndCharacter   *uint  `json:"endCharacter,omitempty"`
+	Kind           string `json:"kind"`
 }
 
 type FormattingOptions struct {


### PR DESCRIPTION
Adding [folding range](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_foldingRange) support for:
* Imports
* Comments (when grouped on more than one line)
* Blocks from tokens like `{}`, `[]`, `()`

Scanner stolen from OPA so feel free to review that, but fixes should go into OPA ;)

Fixes #648

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->