### PR TITLE
lsp: handle `textDocument/documentSymbol`

### DIFF
--- a/internal/lsp/documentsymbol.go
+++ b/internal/lsp/documentsymbol.go
@@ -1,0 +1,269 @@
+package lsp
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/lsp/types/symbols"
+)
+
+//nolint:nestif
+func documentSymbols(
+	contents string,
+	module *ast.Module,
+) []types.DocumentSymbol {
+	// Only pkgSymbols would likely suffice, but we're keeping docSymbols around in case
+	// we ever want to add more top-level symbols than the package.
+	docSymbols := make([]types.DocumentSymbol, 0)
+	pkgSymbols := make([]types.DocumentSymbol, 0)
+
+	lines := strings.Split(contents, "\n")
+
+	pkgRange := types.Range{
+		Start: types.Position{Line: 0, Character: 0},
+		End:   types.Position{Line: uint(len(lines) - 1), Character: uint(len(lines[len(lines)-1]))},
+	}
+
+	pkg := types.DocumentSymbol{
+		Name:           module.Package.Path.String(),
+		Kind:           symbols.Package,
+		Range:          pkgRange,
+		SelectionRange: pkgRange,
+	}
+
+	// Create groups of rules and functions sharing the same name
+	ruleGroups := make(map[string][]*ast.Rule, len(module.Rules))
+
+	for _, rule := range module.Rules {
+		name := refToString(rule.Head.Ref())
+		ruleGroups[name] = append(ruleGroups[name], rule)
+	}
+
+	for _, rules := range ruleGroups {
+		if len(rules) == 1 {
+			rule := rules[0]
+
+			kind := symbols.Variable
+			if isConstant(rule) {
+				kind = symbols.Constant
+			} else if rule.Head.Args != nil {
+				kind = symbols.Function
+			}
+
+			ruleRange := locationToRange(rule.Location)
+			ruleSymbol := types.DocumentSymbol{
+				Name:           refToString(rule.Head.Ref()),
+				Kind:           kind,
+				Range:          ruleRange,
+				SelectionRange: ruleRange,
+			}
+
+			if detail := getRuleDetail(rule); detail != "" {
+				ruleSymbol.Detail = &detail
+			}
+
+			pkgSymbols = append(pkgSymbols, ruleSymbol)
+		} else {
+			groupFirstRange := locationToRange(rules[0].Location)
+			groupLastRange := locationToRange(rules[len(rules)-1].Location)
+
+			groupRange := types.Range{
+				Start: groupFirstRange.Start,
+				End:   groupLastRange.End,
+			}
+
+			kind := symbols.Variable
+			if rules[0].Head.Args != nil {
+				kind = symbols.Function
+			}
+
+			groupSymbol := types.DocumentSymbol{
+				Name:           refToString(rules[0].Head.Ref()),
+				Kind:           kind,
+				Range:          groupRange,
+				SelectionRange: groupRange,
+			}
+
+			detail := getRuleDetail(rules[0])
+			if detail != "" {
+				groupSymbol.Detail = &detail
+			}
+
+			children := make([]types.DocumentSymbol, 0, len(rules))
+
+			for i, rule := range rules {
+				childRange := locationToRange(rule.Location)
+				childRule := types.DocumentSymbol{
+					Name:           fmt.Sprintf("#%d", i+1),
+					Kind:           kind,
+					Range:          childRange,
+					SelectionRange: childRange,
+				}
+
+				childDetail := getRuleDetail(rule)
+				if childDetail != "" {
+					childRule.Detail = &childDetail
+				}
+
+				children = append(children, childRule)
+			}
+
+			groupSymbol.Children = &children
+
+			pkgSymbols = append(pkgSymbols, groupSymbol)
+		}
+	}
+
+	if len(pkgSymbols) > 0 {
+		pkg.Children = &pkgSymbols
+	}
+
+	docSymbols = append(docSymbols, pkg)
+
+	return docSymbols
+}
+
+func locationToRange(location *ast.Location) types.Range {
+	lines := bytes.Split(location.Text, []byte("\n"))
+
+	var endLine uint
+	if len(lines) == 1 {
+		endLine = uint(location.Row - 1)
+	} else {
+		endLine = uint(location.Row-1) + uint(len(lines)-1)
+	}
+
+	return types.Range{
+		Start: types.Position{
+			Line:      uint(location.Row - 1),
+			Character: uint(location.Col - 1),
+		},
+		End: types.Position{
+			Line:      endLine,
+			Character: uint(len(lines[len(lines)-1])),
+		},
+	}
+}
+
+func refToString(ref ast.Ref) string {
+	sb := strings.Builder{}
+
+	for i, part := range ref {
+		if part.IsGround() {
+			if i > 0 {
+				sb.WriteString(".")
+			}
+
+			sb.WriteString(strings.Trim(part.Value.String(), `"`))
+		} else {
+			if i == 0 {
+				sb.WriteString(strings.Trim(part.Value.String(), `"`))
+			} else {
+				sb.WriteString("[")
+				sb.WriteString(strings.Trim(part.Value.String(), `"`))
+				sb.WriteString("]")
+			}
+		}
+	}
+
+	return sb.String()
+}
+
+//nolint:nestif
+func getRuleDetail(rule *ast.Rule) string {
+	if rule.Head.Args != nil {
+		return "function" + rule.Head.Args.String()
+	}
+
+	if rule.Head.Key != nil && rule.Head.Value == nil {
+		return "multi-value rule"
+	}
+
+	if rule.Head.Value == nil {
+		return ""
+	}
+
+	detail := "single-value "
+
+	if rule.Head.Key != nil {
+		detail += "map "
+	} else if isConstant(rule) {
+		detail += "constant "
+	}
+
+	detail += "rule"
+
+	switch v := rule.Head.Value.Value.(type) {
+	case ast.Boolean:
+		if strings.HasPrefix(rule.Head.Ref()[0].String(), "test_") {
+			detail += " (test)"
+		} else {
+			detail += " (boolean)"
+		}
+	case ast.Number:
+		detail += " (number)"
+	case ast.String:
+		detail += " (string)"
+	case *ast.Array, *ast.ArrayComprehension:
+		detail += " (array)"
+	case ast.Object, *ast.ObjectComprehension:
+		detail += " (object)"
+	case ast.Set, *ast.SetComprehension:
+		detail += " (set)"
+	case ast.Call:
+		name := v[0].String()
+
+		if builtin, ok := builtins[name]; ok {
+			retType := builtin.Decl.NamedResult().String()
+
+			detail += fmt.Sprintf(" (%s)", simplifyType(retType))
+		}
+	}
+
+	return detail
+}
+
+// simplifyType removes anything but the base type from the type name.
+func simplifyType(name string) string {
+	result := name
+
+	if strings.Contains(result, ":") {
+		result = result[strings.Index(result, ":")+1:]
+	}
+
+	// silence gocritic linter here as strings.Index can in
+	// fact *not* return -1 in these cases
+	if strings.Contains(result, "[") {
+		result = result[:strings.Index(result, "[")] //nolint:gocritic
+	}
+
+	if strings.Contains(result, "<") {
+		result = result[:strings.Index(result, "<")] //nolint:gocritic
+	}
+
+	return strings.TrimSpace(result)
+}
+
+// isConstant returns true if the rule is a "constant" rule, i.e.
+// one without conditions and scalar value in the head.
+func isConstant(rule *ast.Rule) bool {
+	isScalar := false
+
+	if rule.Head.Value == nil {
+		return false
+	}
+
+	switch rule.Head.Value.Value.(type) {
+	case ast.Boolean, ast.Number, ast.String, ast.Null:
+		isScalar = true
+	}
+
+	return isScalar &&
+		rule.Head.Args == nil &&
+		rule.Body.Equal(ast.NewBody(ast.NewExpr(ast.BooleanTerm(true)))) &&
+		rule.Else == nil
+}

--- a/internal/lsp/documentsymbol_test.go
+++ b/internal/lsp/documentsymbol_test.go
@@ -1,0 +1,234 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/lsp/types/symbols"
+)
+
+func toStrPtr(s string) *string {
+	return &s
+}
+
+func TestRefToString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		title    string
+		ref      ast.Ref
+		expected string
+	}{
+		{
+			"single var",
+			ast.Ref{
+				ast.VarTerm("foo"),
+			},
+			"foo",
+		},
+		{
+			"var in middle",
+			ast.Ref{
+				ast.StringTerm("foo"),
+				ast.VarTerm("bar"),
+				ast.StringTerm("baz"),
+			},
+			"foo[bar].baz",
+		},
+		{
+			"strings",
+			ast.Ref{
+				ast.DefaultRootDocument,
+				ast.StringTerm("foo"),
+				ast.StringTerm("bar"),
+				ast.StringTerm("baz"),
+			},
+			"data.foo.bar.baz",
+		},
+		{
+			"consecutive vars",
+			ast.Ref{
+				ast.VarTerm("foo"),
+				ast.VarTerm("bar"),
+				ast.VarTerm("baz"),
+			},
+			"foo[bar][baz]",
+		},
+		{
+			"mixed",
+			ast.Ref{
+				ast.VarTerm("foo"),
+				ast.VarTerm("bar"),
+				ast.StringTerm("baz"),
+				ast.VarTerm("qux"),
+				ast.StringTerm("quux"),
+			},
+			"foo[bar].baz[qux].quux",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			result := refToString(tc.ref)
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
+//nolint:gocognit,nestif
+func TestDocumentSymbols(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		title    string
+		policy   string
+		expected types.DocumentSymbol
+	}{
+		{
+			"only package",
+			`package foo`,
+			types.DocumentSymbol{
+				Name: "data.foo",
+				Kind: symbols.Package,
+				Range: types.Range{
+					Start: types.Position{Line: 0, Character: 0},
+					End:   types.Position{Line: 0, Character: 11},
+				},
+			},
+		},
+		{
+			"call",
+			`package p
+
+			i := indexof("a", "a")`,
+			types.DocumentSymbol{
+				Name: "data.p",
+				Kind: symbols.Package,
+				Range: types.Range{
+					Start: types.Position{Line: 0, Character: 0},
+					End:   types.Position{Line: 2, Character: 25},
+				},
+				Children: &[]types.DocumentSymbol{
+					{
+						Name:   "i",
+						Kind:   symbols.Variable,
+						Detail: toStrPtr("single-value rule (number)"),
+						Range: types.Range{
+							Start: types.Position{Line: 2, Character: 3},
+							End:   types.Position{Line: 2, Character: 22},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			module, err := ast.ParseModule("test.rego", tc.policy)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			syms := documentSymbols(tc.policy, module)
+
+			pkg := syms[0]
+			if pkg.Name != tc.expected.Name {
+				t.Errorf("Expected %s, got %s", tc.expected.Name, pkg.Name)
+			}
+
+			if pkg.Kind != tc.expected.Kind {
+				t.Errorf("Expected %d, got %d", tc.expected.Kind, pkg.Kind)
+			}
+
+			if pkg.Range != tc.expected.Range {
+				t.Errorf("Expected %v, got %v", tc.expected.Range, pkg.Range)
+			}
+
+			if pkg.Detail != tc.expected.Detail {
+				t.Errorf("Expected %v, got %v", tc.expected.Detail, pkg.Detail)
+			}
+
+			if pkg.Children != nil {
+				if tc.expected.Children == nil {
+					t.Fatalf("Expected no children, got %v", pkg.Children)
+				}
+
+				for i, child := range *pkg.Children {
+					expectedChild := (*tc.expected.Children)[i]
+
+					if child.Name != expectedChild.Name {
+						t.Errorf("Expected %s, got %s", child.Name, expectedChild.Name)
+					}
+
+					if child.Kind != expectedChild.Kind {
+						t.Errorf("Expected %d, got %d", expectedChild.Kind, child.Kind)
+					}
+
+					if child.Range != expectedChild.Range {
+						t.Errorf("Expected %v, got %v", expectedChild.Range, child.Range)
+					}
+
+					if child.Detail != expectedChild.Detail {
+						if expectedChild.Detail == nil && child.Detail != nil {
+							t.Errorf("Expected detail to be nilgot %v", child.Detail)
+						} else if *child.Detail != *expectedChild.Detail {
+							t.Errorf("Expected %s, got %s", *expectedChild.Detail, *child.Detail)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSimplifyType(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input    string
+		expected string
+	}{
+		{
+			"set",
+			"set",
+		},
+		{
+			"set[any]",
+			"set",
+		},
+		{
+			"any<set, object>",
+			"any",
+		},
+		{
+			"output: any<set[any], object>",
+			"any",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			result := simplifyType(tc.input)
+			if result != tc.expected {
+				t.Errorf("Expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}

--- a/internal/lsp/types/symbols/symbols.go
+++ b/internal/lsp/types/symbols/symbols.go
@@ -1,0 +1,32 @@
+package symbols
+
+type SymbolKind int
+
+const (
+	File SymbolKind = iota + 1
+	Module
+	Namespace
+	Package
+	Class
+	Method
+	Property
+	Field
+	Constructor
+	Enum
+	Interface
+	Function
+	Variable
+	Constant
+	String
+	Number
+	Boolean
+	Array
+	Object
+	Key
+	Null
+	EnumMember
+	Struct
+	Event
+	Operator
+	TypeParameter
+)

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/styrainc/regal/internal/lsp/types/symbols"
+
 type FileDiagnostics struct {
 	URI   string       `json:"uri"`
 	Items []Diagnostic `json:"diagnostics"`
@@ -86,6 +88,7 @@ type ServerCapabilities struct {
 	ExecuteCommandProvider     ExecuteCommandOptions   `json:"executeCommandProvider"`
 	DocumentFormattingProvider bool                    `json:"documentFormattingProvider"`
 	FoldingRangeProvider       bool                    `json:"foldingRangeProvider"`
+	DocumentSymbolProvider     bool                    `json:"documentSymbolProvider"`
 }
 
 type WorkspaceOptions struct {
@@ -154,6 +157,19 @@ type TextEdit struct {
 type DocumentFormattingParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Options      FormattingOptions      `json:"options"`
+}
+
+type DocumentSymbolParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+}
+
+type DocumentSymbol struct {
+	Name           string             `json:"name"`
+	Detail         *string            `json:"detail,omitempty"`
+	Kind           symbols.SymbolKind `json:"kind"`
+	Range          Range              `json:"range"`
+	SelectionRange Range              `json:"selectionRange"`
+	Children       *[]DocumentSymbol  `json:"children,omitempty"`
 }
 
 type FoldingRangeParams struct {


### PR DESCRIPTION
More weekend fun! This provides a basic implementation of `textDocument/documentSymbol`. I say basic because we currently scan for nested symbols, but only package, rules and functions, with some nice touches like providing details on what kind of rule it is, and the type it returns, and so on. I think this covers what most actually need, but we can certainly refine this later and add things like variables inside of rule bodies, and so on.

<img width="1229" alt="Screenshot 2024-04-22 at 12 21 07" src="https://github.com/StyraInc/regal/assets/510711/f061b434-ac93-41c5-99ce-ea711d13450b">
