### PR TITLE
lsp: implement `workspace/symbol`

### DIFF
--- a/internal/lsp/documentsymbol.go
+++ b/internal/lsp/documentsymbol.go
@@ -267,3 +267,28 @@ func isConstant(rule *ast.Rule) bool {
 		rule.Body.Equal(ast.NewBody(ast.NewExpr(ast.BooleanTerm(true)))) &&
 		rule.Else == nil
 }
+
+func toWorkspaceSymbol(docSym types.DocumentSymbol, docURL string) types.WorkspaceSymbol {
+	return types.WorkspaceSymbol{
+		Name: docSym.Name,
+		Kind: docSym.Kind,
+		Location: types.Location{
+			URI:   docURL,
+			Range: docSym.Range,
+		},
+	}
+}
+
+func toWorkspaceSymbols(docSym []types.DocumentSymbol, docURL string, symbols *[]types.WorkspaceSymbol) {
+	for _, sym := range docSym {
+		// Only include the "main" symbol for incremental rules and functions
+		// as numeric items isn't very useful in the workspace symbol list.
+		if !strings.HasPrefix(sym.Name, "#") {
+			*symbols = append(*symbols, toWorkspaceSymbol(sym, docURL))
+
+			if sym.Children != nil {
+				toWorkspaceSymbols(*sym.Children, docURL, symbols)
+			}
+		}
+	}
+}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -89,6 +89,7 @@ type ServerCapabilities struct {
 	DocumentFormattingProvider bool                    `json:"documentFormattingProvider"`
 	FoldingRangeProvider       bool                    `json:"foldingRangeProvider"`
 	DocumentSymbolProvider     bool                    `json:"documentSymbolProvider"`
+	WorkspaceSymbolProvider    bool                    `json:"workspaceSymbolProvider"`
 	DefinitionProvider         bool                    `json:"definitionProvider"`
 }
 
@@ -171,6 +172,17 @@ type DocumentSymbol struct {
 	Range          Range              `json:"range"`
 	SelectionRange Range              `json:"selectionRange"`
 	Children       *[]DocumentSymbol  `json:"children,omitempty"`
+}
+
+type WorkspaceSymbolParams struct {
+	Query string `json:"query"`
+}
+
+type WorkspaceSymbol struct {
+	Name          string             `json:"name"`
+	Kind          symbols.SymbolKind `json:"kind"`
+	Location      Location           `json:"location"`
+	ContainerName *string            `json:"containerName,omitempty"`
 }
 
 type FoldingRangeParams struct {


### PR DESCRIPTION
This was rather trivial with document symbols supported. It's now made possible to search for symbols across the whole workspace, which is rather nice!

<img width="633" alt="Screenshot 2024-04-23 at 07 26 20" src="https://github.com/StyraInc/regal/assets/510711/2111abc1-813d-46fe-a6c1-81784423b911">
