### PR TITLE
lsp: More graceful shutdown

### DIFF
--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -37,9 +37,9 @@ func init() {
 					LogOutbound: verboseLogging,
 				},
 			})
+			defer conn.Close()
 
 			ls.SetConn(conn)
-
 			go ls.StartDiagnosticsWorker(ctx)
 			go ls.StartHoverWorker(ctx)
 			go ls.StartCommandWorker(ctx)
@@ -50,9 +50,9 @@ func init() {
 
 			select {
 			case <-conn.DisconnectNotify():
-				fmt.Fprint(os.Stderr, "Connection closed\n")
+				fmt.Fprintln(os.Stderr, "Connection closed")
 			case sig := <-sigChan:
-				fmt.Fprint(os.Stderr, "signal: ", sig.String(), "\n")
+				fmt.Fprintln(os.Stderr, "signal: ", sig.String())
 			}
 
 			return nil


### PR DESCRIPTION
We have been erroring on shutdown requests as they have no params set. This PR changes that and makes sure the server waits for the exit message before closing the connection.

The client shows:

```
[Error - 18:21:10] Server process exited with code 0.
```

This is an odd one based on the code here:

https://sourcegraph.com/npm/vscode-languageclient@492942af8005ce98cbd47721d4a7790a0310d4e3/-/blob/lib/node/main.js?L474:37-474:68

It would look like we exit ok here, but that seems to be perhaps parsed as "0" the string... One for another day.

Before:


https://github.com/StyraInc/regal/assets/1774239/203792e1-3cb9-447a-a984-b53d167b11f3

After


https://github.com/StyraInc/regal/assets/1774239/dccb6b0e-cdcf-45bd-abd2-2de623b17af5

