### PR TITLE
Avoid panic when searching for `.regal/config.yaml`

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -299,7 +299,7 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 		}
 
 		regal = regal.WithUserConfig(userConfig)
-	case err != nil && params.configFile != "":
+	case params.configFile != "":
 		return report.Report{}, fmt.Errorf("user-provided config file not found: %w", err)
 	case params.debug:
 		log.Println("no user-provided config file found, will use the default config")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,6 +133,12 @@ func FindRegalDirectory(path string) (*os.File, error) {
 
 		// Move up one level in the directory tree
 		parts := strings.Split(dir, rio.PathSeparator)
+		if len(parts) == 0 {
+			// See https://github.com/StyraInc/regal/issues/682
+			// Not sure how we could get here, but we need to stop if we do
+			return nil, errors.New("stopping as dir is empty string")
+		}
+
 		parts = parts[:len(parts)-1]
 
 		if parts[0] == volume {


### PR DESCRIPTION
As reported in #682, the server panics when the dir for whatever reason is "". I don't yet know how to trigger this, and the result of this fix is likely that the config file won't be found when this happens. But as a temporary measure I prefer to have Regal run with default configuration compared to crashing.