### PR TITLE
fix: Avoid panic in config finder

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -139,6 +139,10 @@ func FindRegalDirectory(path string) (*os.File, error) {
 			return nil, errors.New("stopping as dir is empty string")
 		}
 
+		if len(parts) < 2 {
+			return nil, errors.New("stopping as dir is root directory")
+		}
+
 		parts = parts[:len(parts)-1]
 
 		if parts[0] == volume {


### PR DESCRIPTION
Not sure if it's worth having two different exit conditions, but I guess it doesn't hurt with some granularity?

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->