### PR TITLE
lsp: don't add "constant" to the document symbol description

### DIFF
--- a/internal/lsp/documentsymbol.go
+++ b/internal/lsp/documentsymbol.go
@@ -191,8 +191,6 @@ func getRuleDetail(rule *ast.Rule) string {
 
 	if rule.Head.Key != nil {
 		detail += "map "
-	} else if isConstant(rule) {
-		detail += "constant "
 	}
 
 	detail += "rule"


### PR DESCRIPTION
This is already reported by the document type, and constants aren't special enough to warrant extra description.

Fixes #705

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->