### PR TITLE
report: Fix profile count aggregation

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -91,12 +91,11 @@ func (r *Report) AddProfileEntries(prof map[string]ProfileEntry) {
 		if _, ok := r.AggregateProfile[loc]; !ok {
 			r.AggregateProfile[loc] = entry
 		} else {
-			profCopy := prof[loc]
+			profCopy := r.AggregateProfile[loc]
 			profCopy.NumEval += entry.NumEval
 			profCopy.NumRedo += entry.NumRedo
 			profCopy.NumGenExpr += entry.NumGenExpr
 			profCopy.TotalTimeNs += entry.TotalTimeNs
-			profCopy.Location = entry.Location
 			r.AggregateProfile[loc] = profCopy
 		}
 	}


### PR DESCRIPTION
AddProfileEntries was creating a copy from the supplied update rather than the global store of counts.

Fixes https://github.com/StyraInc/regal/issues/457