### PR TITLE
Single file `impossible-not`

### DIFF
--- a/bundle/regal/ast/imports.rego
+++ b/bundle/regal/ast/imports.rego
@@ -20,6 +20,19 @@ imported_identifiers contains imported_identifier(imp) if {
 	imp.path.value[0].value in {"input", "data"}
 }
 
+# METADATA
+# description: |
+#   map of all imported paths in the input module, keyed by their identifier or "namespace"
+resolved_imports[identifier] := path if {
+	some _import in imports
+
+	_import.path.value[0].value == "data"
+	count(_import.path.value) > 1
+
+	identifier := imported_identifier(_import)
+	path := [part.value | some part in _import.path.value]
+}
+
 imported_identifier(imp) := imp.alias
 
 imported_identifier(imp) := regal.last(imp.path.value).value if not imp.alias

--- a/docs/rules/bugs/impossible-not.md
+++ b/docs/rules/bugs/impossible-not.md
@@ -4,7 +4,7 @@
 
 **Category**: Bugs
 
-**Type**: Aggregate - only runs when more than one file is provided for linting
+**Type**: Aggregate - runs both on single files as well as when more than one file is provided for linting
 
 **Avoid**
 ```rego


### PR DESCRIPTION
Improve this new rule to have the `report` rule handle single file violations, while the aggregate report ignores violations where the `not` ref and the partial rule is in the same file.