### PR TITLE
Send warning to client on CRLF line endings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -18,6 +18,7 @@ linters:
     - rowserrcheck
     - wastedassign
     # annoying
+    - nestif
     - gocognit
     - goerr113
     - varnamelen

--- a/internal/lsp/documentsymbol.go
+++ b/internal/lsp/documentsymbol.go
@@ -11,7 +11,6 @@ import (
 	"github.com/styrainc/regal/internal/lsp/types/symbols"
 )
 
-//nolint:nestif
 func documentSymbols(
 	contents string,
 	module *ast.Module,
@@ -173,7 +172,6 @@ func refToString(ref ast.Ref) string {
 	return sb.String()
 }
 
-//nolint:nestif
 func getRuleDetail(rule *ast.Rule) string {
 	if rule.Head.Args != nil {
 		return "function" + rule.Head.Args.String()

--- a/internal/lsp/documentsymbol_test.go
+++ b/internal/lsp/documentsymbol_test.go
@@ -83,7 +83,6 @@ func TestRefToString(t *testing.T) {
 	}
 }
 
-//nolint:nestif
 func TestDocumentSymbols(t *testing.T) {
 	t.Parallel()
 

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -69,6 +69,11 @@ type GeneralClientCapabilities struct {
 	StaleRequestSupport StaleRequestSupportClientCapabilities `json:"staleRequestSupport"`
 }
 
+type ShowMessageParams struct {
+	Type    uint   `json:"type"`
+	Message string `json:"message"`
+}
+
 type StaleRequestSupportClientCapabilities struct {
 	Cancel                  bool     `json:"cancel"`
 	RetryOnContentModifieds []string `json:"retryOnContentModified"`
@@ -247,9 +252,19 @@ type TextDocumentInlayHintParams struct {
 	Range        Range                  `json:"range"`
 }
 
+type TextDocumentSaveOptions struct {
+	IncludeText bool `json:"includeText"`
+}
+
+type TextDocumentDidSaveParams struct {
+	TextDocument TextDocumentIdentifier `json:"textDocument"`
+	Text         *string                `json:"text,omitempty"`
+}
+
 type TextDocumentSyncOptions struct {
-	OpenClose bool `json:"openClose"`
-	Change    uint `json:"change"`
+	OpenClose bool                    `json:"openClose"`
+	Change    uint                    `json:"change"`
+	Save      TextDocumentSaveOptions `json:"save"`
 }
 
 type TextDocumentIdentifier struct {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -94,7 +94,7 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 
 	footer := fmt.Sprintf("%d file%s linted.", r.Summary.FilesScanned, pluralScanned)
 
-	if r.Summary.NumViolations == 0 { //nolint:nestif
+	if r.Summary.NumViolations == 0 {
 		footer += " No violations found."
 	} else {
 		pluralViolations := ""
@@ -256,8 +256,6 @@ func (tr JSONReporter) Publish(_ context.Context, r report.Report) error {
 // Publish first prints the pretty formatted report to console for easy access in the logs. It then goes on
 // to print the GitHub Actions annotations for each violation. Finally, it prints a summary of the report suitable
 // for the GitHub Actions UI.
-//
-//nolint:nestif
 func (tr GitHubReporter) Publish(ctx context.Context, r report.Report) error {
 	err := NewPrettyReporter(tr.out).Publish(ctx, r)
 	if err != nil {
@@ -302,7 +300,7 @@ func (tr GitHubReporter) Publish(ctx context.Context, r report.Report) error {
 
 		fmt.Fprintf(summaryFile, "%d file%s linted.", r.Summary.FilesScanned, pluralScanned)
 
-		if r.Summary.NumViolations == 0 { //nolint:nestif
+		if r.Summary.NumViolations == 0 {
 			fmt.Fprintf(summaryFile, " No violations found")
 		} else {
 			pluralViolations := ""


### PR DESCRIPTION
In case either `opa-fmt` or `use-rego-v1` is enabled, we'll send back a warning to the client whenever they save a document containing CRLF line endings. This to avoid confusion when the user tries to fix formatting using `opa fmt`, but the editor adding back CRLF line endings after.

Also disable the nestif linter, as it's annoying.

Fixes #693

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->