### PR TITLE
lsp: Return null when no hover items

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -537,7 +537,10 @@ func (l *LanguageServer) handleTextDocumentHover(
 		}
 	}
 
-	return struct{}{}, nil
+	// As set in the spec here: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover
+	// if no hover is found, we must return a null response.
+	//nolint:nilnil
+	return nil, nil
 }
 
 func (l *LanguageServer) handleTextDocumentCodeAction(


### PR DESCRIPTION
The spec states this value should be null when there are no hover items to show.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->