### PR TITLE
Various fixes

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -459,6 +459,14 @@ all_functions := object.union(config.capabilities.builtins, function_decls(input
 
 all_function_names := object.keys(all_functions)
 
+negated_expressions[rule] contains value if {
+	some rule in input.rules
+
+	walk(rule, [_, value])
+
+	value.negated
+}
+
 # METADATA
 # description: |
 #   true if rule head contains no identifier, but is a chained rule body immediately following the previous one:

--- a/bundle/regal/rules/bugs/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible_not.rego
@@ -27,11 +27,8 @@ multivalue_rules contains path if {
 }
 
 negated_refs contains negated_ref if {
-	some i, rule in input.rules
-
-	walk(rule, [_, value])
-
-	value.negated
+	some rule, value
+	ast.negated_expressions[rule][value]
 
 	# if terms is an array, it's a function call, and most likely not "impossible"
 	is_object(value.terms)

--- a/bundle/regal/rules/style/double_negative.rego
+++ b/bundle/regal/rules/style/double_negative.rego
@@ -9,12 +9,12 @@ package regal.rules.style["double-negative"]
 
 import rego.v1
 
+import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	walk(input.rules, [_, node])
-
-	node.negated
+	some node
+	ast.negated_expressions[_][node]
 
 	node.terms.type == "var"
 	strings.any_prefix_match(node.terms.value, negatives)

--- a/docs/rules/style/external-reference.md
+++ b/docs/rules/style/external-reference.md
@@ -1,6 +1,6 @@
 # external-reference
 
-**Summary**: Reference to input, data or rule ref in function body
+**Summary**: External reference in function
 
 **Category**: Style
 
@@ -21,7 +21,6 @@ is_preferred_login_method(method) if {
 ```
 
 **Prefer**
-
 ```rego
 package policy
 
@@ -70,7 +69,7 @@ first_name(full_name) := capitalized {
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   style:
     external-reference:
       # one of "error", "warning", "ignore"

--- a/docs/rules/style/prefer-some-in-iteration.md
+++ b/docs/rules/style/prefer-some-in-iteration.md
@@ -8,9 +8,11 @@
 ```rego
 package policy
 
+import rego.v1
+
 engineering_roles = {"engineer", "dba", "developer"}
 
-engineers[employee] {
+engineers contains employee if {
     employee := data.employees[_]
     employee.role in engineering_roles
 }
@@ -24,7 +26,7 @@ import rego.v1
 
 engineering_roles = {"engineer", "dba", "developer"}
 
-engineers[employee] {
+engineers contains employee if {
     some employee in data.employees
     employee.role in engineering_roles
 }
@@ -83,7 +85,9 @@ one of the variables (including wildcards: `_`) is an output variable bound in i
 ```rego
 package policy
 
-example_users[user] {
+import rego.v1
+
+example_users contains user if {
     domain := "example.com"
     user := input.sites[domain].users[_]
 }


### PR DESCRIPTION
* Only walk negated expressions once
* Update docs on `external-reference` to reflect current message
* Use rego.v1 in `prefer-some-in-iteration` docs

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->