### PR TITLE
Fix false positive in `redundant-existence-check` when `with` is used

### DIFF
--- a/bundle/regal/rules/bugs/redundant_existence_check.rego
+++ b/bundle/regal/rules/bugs/redundant_existence_check.rego
@@ -13,6 +13,8 @@ report contains violation if {
 
 	expr.terms.type == "ref"
 
+	not expr["with"]
+
 	ast.static_ref(expr.terms)
 
 	ref_str := ast.ref_to_string(expr.terms.value)

--- a/bundle/regal/rules/bugs/redundant_existence_check_test.rego
+++ b/bundle/regal/rules/bugs/redundant_existence_check_test.rego
@@ -37,3 +37,13 @@ test_success_not_redundant_existence_check if {
 	r := rule.report with input as module
 	r == set()
 }
+
+test_success_not_redundant_existence_check_with_cancels if {
+	module := ast.with_rego_v1(`
+	not_redundant if {
+		rule.foo with input as {}
+		rule.foo == 1
+	}`)
+	r := rule.report with input as module
+	r == set()
+}


### PR DESCRIPTION
Fixes #733

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->