### PR TITLE
lsp: Fix ast error line index bug

### DIFF
--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -67,15 +67,14 @@ func updateParse(cache *cache.Cache, uri string) (bool, error) {
 	diags := make([]types.Diagnostic, 0)
 
 	for _, astError := range astErrors {
-		lineLength := 1
-
-		if astError.Location.Row-1 < len(lines) {
-			lineLength = len(lines[astError.Location.Row-1])
-		}
-
 		line := astError.Location.Row - 1
 		if line < 0 {
 			line = 0
+		}
+
+		lineLength := 1
+		if line < len(lines) {
+			lineLength = len(lines[line])
 		}
 
 		key := "regal/parse"


### PR DESCRIPTION
When a new file is created, it is empty. We need to address this since I think we are sent the contents. However, this is a fix for an index bug when processing these errors.




Before

https://github.com/StyraInc/regal/assets/1774239/5fbcb712-05ca-4f65-ad6b-8ee867256aa1

After

https://github.com/StyraInc/regal/assets/1774239/82c00e25-8613-4f90-87cf-ad24dc7d10b4



