### PR TITLE
lsp: ensure completion items is not null

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -691,6 +691,14 @@ func (l *LanguageServer) handleTextDocumentCompletion(
 		return nil, fmt.Errorf("failed to find completions: %w", err)
 	}
 
+	// make sure the items is always [] instead of null as is required by the spec
+	if items == nil {
+		return types.CompletionList{
+			IsIncomplete: false,
+			Items:        make([]types.CompletionItem, 0),
+		}, nil
+	}
+
 	return types.CompletionList{
 		IsIncomplete: false,
 		Items:        items,


### PR DESCRIPTION
In the spec, items is not optional and so must be an empty list if there are none.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->