### PR TITLE
Better align with specification based on Zed client testing

### DIFF
--- a/internal/lsp/command.go
+++ b/internal/lsp/command.go
@@ -2,13 +2,13 @@ package lsp
 
 import "github.com/styrainc/regal/internal/lsp/types"
 
-func toAnySlice(a []string) []any {
+func toAnySlice(a []string) *[]any {
 	b := make([]any, len(a))
 	for i := range a {
 		b[i] = a[i]
 	}
 
-	return b
+	return &b
 }
 
 func FmtCommand(args []string) types.Command {

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -103,7 +103,7 @@ func updateParse(cache *cache.Cache, uri string) (bool, error) {
 			Message: astError.Message,
 			Source:  key,
 			Code:    strings.ReplaceAll(astError.Code, "_", "-"),
-			CodeDescription: types.CodeDescription{
+			CodeDescription: &types.CodeDescription{
 				Href: link,
 			},
 		})
@@ -187,7 +187,7 @@ func updateFileDiagnostics(
 			Message: item.Description,
 			Source:  "regal/" + item.Category,
 			Code:    item.Title,
-			CodeDescription: types.CodeDescription{
+			CodeDescription: &types.CodeDescription{
 				Href: fmt.Sprintf(
 					"https://docs.styra.com/regal/rules/%s/%s",
 					item.Category,
@@ -265,7 +265,7 @@ func updateAllDiagnostics(
 			Message: item.Description,
 			Source:  "regal/" + item.Category,
 			Code:    item.Title,
-			CodeDescription: types.CodeDescription{
+			CodeDescription: &types.CodeDescription{
 				Href: fmt.Sprintf(
 					"https://docs.styra.com/regal/rules/%s/%s",
 					item.Category,

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -554,6 +554,7 @@ func (l *LanguageServer) handleTextDocumentCodeAction(
 		return nil, fmt.Errorf("failed to unmarshal params: %w", err)
 	}
 
+	yes := true
 	actions := make([]types.CodeAction, 0)
 
 	for _, diag := range params.Context.Diagnostics {
@@ -563,7 +564,7 @@ func (l *LanguageServer) handleTextDocumentCodeAction(
 				Title:       "Format using opa fmt",
 				Kind:        "quickfix",
 				Diagnostics: []types.Diagnostic{diag},
-				IsPreferred: true,
+				IsPreferred: &yes,
 				Command:     FmtCommand([]string{params.TextDocument.URI}),
 			})
 		case ruleNameUseRegoV1:
@@ -571,7 +572,7 @@ func (l *LanguageServer) handleTextDocumentCodeAction(
 				Title:       "Format for Rego v1 using opa fmt",
 				Kind:        "quickfix",
 				Diagnostics: []types.Diagnostic{diag},
-				IsPreferred: true,
+				IsPreferred: &yes,
 				Command:     FmtV1Command([]string{params.TextDocument.URI}),
 			})
 		case "use-assignment-operator":
@@ -579,7 +580,7 @@ func (l *LanguageServer) handleTextDocumentCodeAction(
 				Title:       "Replace = with := in assignment",
 				Kind:        "quickfix",
 				Diagnostics: []types.Diagnostic{diag},
-				IsPreferred: true,
+				IsPreferred: &yes,
 				Command: UseAssignmentOperatorCommand([]string{
 					params.TextDocument.URI,
 					strconv.FormatUint(uint64(diag.Range.Start.Line+1), 10),
@@ -591,7 +592,7 @@ func (l *LanguageServer) handleTextDocumentCodeAction(
 				Title:       "Format comment to have leading whitespace",
 				Kind:        "quickfix",
 				Diagnostics: []types.Diagnostic{diag},
-				IsPreferred: true,
+				IsPreferred: &yes,
 				Command: NoWhiteSpaceCommentCommand([]string{
 					params.TextDocument.URI,
 					strconv.FormatUint(uint64(diag.Range.Start.Line+1), 10),
@@ -607,12 +608,11 @@ func (l *LanguageServer) handleTextDocumentCodeAction(
 				Title:       txt,
 				Kind:        "quickfix",
 				Diagnostics: []types.Diagnostic{diag},
-				IsPreferred: true,
+				IsPreferred: &yes,
 				Command: types.Command{
 					Title:     txt,
 					Command:   "vscode.open",
-					Tooltip:   txt,
-					Arguments: []any{diag.CodeDescription.Href},
+					Arguments: &[]any{diag.CodeDescription.Href},
 				},
 			})
 		}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -162,7 +162,7 @@ type CodeAction struct {
 	Title       string       `json:"title"`
 	Kind        string       `json:"kind"`
 	Diagnostics []Diagnostic `json:"diagnostics"`
-	IsPreferred bool         `json:"isPreferred"`
+	IsPreferred *bool        `json:"isPreferred,omitempty"`
 	Command     Command      `json:"command"`
 }
 
@@ -170,7 +170,7 @@ type Command struct {
 	Title     string `json:"title"`
 	Tooltip   string `json:"tooltip"`
 	Command   string `json:"command"`
-	Arguments []any  `json:"arguments"`
+	Arguments *[]any `json:"arguments,omitempty"`
 }
 
 type ExecuteCommandOptions struct {
@@ -330,12 +330,12 @@ type TextDocumentContentChangeEvent struct {
 }
 
 type Diagnostic struct {
-	Range           Range           `json:"range"`
-	Message         string          `json:"message"`
-	Severity        uint            `json:"severity"`
-	Source          string          `json:"source"`
-	Code            string          `json:"code"`
-	CodeDescription CodeDescription `json:"codeDescription"`
+	Range           Range            `json:"range"`
+	Message         string           `json:"message"`
+	Severity        uint             `json:"severity"`
+	Source          string           `json:"source"`
+	Code            string           `json:"code"`
+	CodeDescription *CodeDescription `json:"codeDescription,omitempty"`
 }
 
 type CodeDescription struct {


### PR DESCRIPTION
Make optional attributes optional, and omit when empty.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->