### PR TITLE
cmd/fix: Filter files loaded for fixing

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -237,7 +237,13 @@ func fix(args []string, params *fixCommandParams) error {
 	f := fixer.NewFixer()
 	f.RegisterFixes(fixes.NewDefaultFixes()...)
 
-	fileProvider := fileprovider.NewFSFileProvider(args...)
+	ignore := userConfig.Ignore.Files
+
+	if len(params.ignoreFiles.v) > 0 {
+		ignore = params.ignoreFiles.v
+	}
+
+	fileProvider := fileprovider.NewFSFileProvider(ignore, args...)
 
 	fixReport, err := f.Fix(ctx, &l, fileProvider)
 	if err != nil {

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -751,6 +751,12 @@ allow if {
 		t.Fatalf("failed to write main.rego: %v", err)
 	}
 
+	unrelatedFileContents := []byte(`foobar`)
+	err = os.WriteFile(filepath.Join(td, "unrelated.txt"), unrelatedFileContents, 0o644)
+	if err != nil {
+		t.Fatalf("failed to write unrelated.txt: %v", err)
+	}
+
 	err = regal(&stdout, &stderr)("fix", td)
 
 	// 0 exit status is expected as all violations should have been fixed

--- a/pkg/fixer/fixes/useassignmentoperator.go
+++ b/pkg/fixer/fixes/useassignmentoperator.go
@@ -28,6 +28,10 @@ func (*UseAssignmentOperator) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]Fix
 
 		line := lines[loc.Row-1]
 
+		if loc.Col-1 < 0 || loc.Col-1 >= len(line) {
+			continue
+		}
+
 		// unexpected character at location column, skipping
 		if line[loc.Col-1] != byte('=') {
 			continue


### PR DESCRIPTION
This uses the same logic to filter files when loading them for fixing as used in linting.

Fixes: https://github.com/StyraInc/regal/issues/761