### PR TITLE
lsp/completions: Implement better package items

### DIFF
--- a/internal/lsp/completions/providers/builtins.go
+++ b/internal/lsp/completions/providers/builtins.go
@@ -20,20 +20,16 @@ func (*BuiltIns) Run(c *cache.Cache, params types.CompletionParams, _ *Options) 
 		return []types.CompletionItem{}, nil
 	}
 
-	if len(currentLine) < int(params.Position.Character) || len(currentLine) < 2 {
-		return nil, nil
-	}
-
 	// TODO: Share and improve this logic, currently shared with the rulerefs provider
 	if !strings.Contains(currentLine, " if ") && // if after if keyword
 		!strings.Contains(currentLine, " contains ") && // if after contains
 		!strings.Contains(currentLine, " else ") && // if after else
 		!strings.Contains(currentLine, "= ") && // if after assignment
-		!strings.HasPrefix(currentLine, "  ") { // if in rule body
+		!patternRuleBody.MatchString(currentLine) { // if in rule body
 		return nil, nil
 	}
 
-	words := strings.Split(currentLine, " ")
+	words := patternWhiteSpace.Split(strings.TrimSpace(currentLine), -1)
 	lastWord := words[len(words)-1]
 
 	items := []types.CompletionItem{}

--- a/internal/lsp/completions/providers/packagerefs.go
+++ b/internal/lsp/completions/providers/packagerefs.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -24,15 +25,20 @@ func (*PackageRefs) Run(c *cache.Cache, params types.CompletionParams, _ *Option
 		return nil, nil
 	}
 
+	words := strings.Split(currentLine, " ")
+	lastWord := words[len(words)-1]
+
 	thisFileReferences := c.GetFileRefs(fileURI)
 	otherFilePackages := make(map[string]types.Ref)
 
+	// filter out the packages that have the last word as a prefix.
 	for file, refs := range c.GetAllFileRefs() {
 		if file == fileURI {
 			continue
 		}
 
 		for key, ref := range refs {
+			// this provider is only used to suggest items where a package is suitable.
 			if ref.Kind != types.Package {
 				continue
 			}
@@ -42,42 +48,113 @@ func (*PackageRefs) Run(c *cache.Cache, params types.CompletionParams, _ *Option
 				continue
 			}
 
+			// only suggest packages that match the last word
+			// the user has typed.
+			if !strings.HasPrefix(ref.Label, lastWord) {
+				continue
+			}
+
 			otherFilePackages[key] = ref
 		}
 	}
 
-	words := strings.Split(currentLine, " ")
-	lastWord := words[len(words)-1]
+	// partialRefs is a generated list of package names generated from
+	// longer names. For example, if the packages data.foo.bar and data.foo.baz
+	// are defined, an author should still be able to import data.foo.
+	partialRefs := make(map[string]types.Ref)
 
-	items := make([]types.CompletionItem, 0)
+	for key := range otherFilePackages {
+		parts := strings.Split(key, ".")
+		// starting at 1 to skip 'data'
+		for i := 1; i < len(parts)-1; i++ {
+			partialKey := strings.Join(parts[:i+1], ".")
+			// only insert the new partial key if there is no full package
+			// ref that matches it
+			if _, ok := partialRefs[partialKey]; !ok {
+				partialRefs[partialKey] = types.Ref{
+					Label:       partialKey,
+					Description: "See sub packages for more information",
+				}
+			}
+		}
+	}
+
+	// refs are grouped by 'depth', where depth is the number of dots in the
+	// ref string. This is a simplification, but allows shorted, higher level
+	// refs to be suggested first.
+	byDepth := make(map[int]map[string]types.Ref)
 
 	for _, item := range otherFilePackages {
-		if !strings.HasPrefix(item.Label, lastWord) {
+		depth := strings.Count(item.Label, ".")
+
+		if _, ok := byDepth[depth]; !ok {
+			byDepth[depth] = make(map[string]types.Ref)
+		}
+
+		byDepth[depth][item.Label] = item
+	}
+
+	// add partial refs to the byDepth map in case they are not defined
+	// as full refs in files.
+	for _, item := range partialRefs {
+		depth := strings.Count(item.Label, ".")
+
+		if _, ok := byDepth[depth]; !ok {
+			byDepth[depth] = make(map[string]types.Ref)
+		}
+
+		// only add partial refs where no top level ref exists.
+		if _, ok := byDepth[depth][item.Label]; ok {
 			continue
 		}
 
-		items = append(items, types.CompletionItem{
-			Label:  item.Label,
-			Kind:   completion.Module, // for now, only modules are returned
-			Detail: "Rego package",
-			Documentation: &types.MarkupContent{
-				Kind:  "markdown",
-				Value: item.Description,
-			},
-			TextEdit: &types.TextEdit{
-				Range: types.Range{
-					Start: types.Position{
-						Line:      params.Position.Line,
-						Character: 7,
-					},
-					End: types.Position{
-						Line:      params.Position.Line,
-						Character: uint(len(currentLine)),
-					},
+		byDepth[depth][item.Label] = item
+	}
+
+	// items will be shown in order from shallowest to deepest
+	depths := make([]int, 0)
+	for k := range byDepth {
+		depths = append(depths, k)
+	}
+
+	slices.Sort(depths)
+
+	items := make([]types.CompletionItem, 0)
+	for _, depth := range depths {
+		// items are added in groups of depth until there more then 10 items.
+		if len(items) > 10 {
+			continue
+		}
+
+		itemsForDepth, ok := byDepth[depth]
+		if !ok {
+			continue
+		}
+
+		for _, item := range itemsForDepth {
+			items = append(items, types.CompletionItem{
+				Label:  item.Label,
+				Kind:   completion.Module, // for now, only modules are returned
+				Detail: "Rego package",
+				Documentation: &types.MarkupContent{
+					Kind:  "markdown",
+					Value: item.Description,
 				},
-				NewText: item.Label,
-			},
-		})
+				TextEdit: &types.TextEdit{
+					Range: types.Range{
+						Start: types.Position{
+							Line:      params.Position.Line,
+							Character: 7,
+						},
+						End: types.Position{
+							Line:      params.Position.Line,
+							Character: uint(len(currentLine)),
+						},
+					},
+					NewText: item.Label,
+				},
+			})
+		}
 	}
 
 	return items, nil

--- a/internal/lsp/completions/providers/packagerefs_test.go
+++ b/internal/lsp/completions/providers/packagerefs_test.go
@@ -65,7 +65,9 @@ import
 		t.Fatalf("Unexpected error: %v", err)
 	}
 
-	expectedRefs := []string{"data.foo.bar", "data.foo.baz"}
+	// data.foo is not defined in a file, but it included as a partial ref
+	// as it's still valid for import and might be helpful.
+	expectedRefs := []string{"data.foo", "data.foo.bar", "data.foo.baz"}
 	slices.Sort(expectedRefs)
 
 	foundRefs := make([]string, len(completions))

--- a/internal/lsp/completions/providers/rulerefs.go
+++ b/internal/lsp/completions/providers/rulerefs.go
@@ -29,7 +29,7 @@ func (*RuleFromImportedPackageRefs) Run(
 		!strings.Contains(currentLine, " contains ") && // if after contains
 		!strings.Contains(currentLine, " else ") && // if after else
 		!strings.Contains(currentLine, "= ") && // if after assignment
-		!strings.HasPrefix(currentLine, "  ") { // if in rule body
+		!patternRuleBody.MatchString(currentLine) { // if in rule body
 		return nil, nil
 	}
 

--- a/internal/lsp/completions/providers/utils.go
+++ b/internal/lsp/completions/providers/utils.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -23,3 +24,9 @@ func completionLineHelper(c *cache.Cache, fileURI string, currentLineNumber uint
 
 	return strings.Split(fileContents, "\n"), currentLine
 }
+
+//nolint:gochecknoglobals
+var patternRuleBody = regexp.MustCompile(`^\s+`)
+
+//nolint:gochecknoglobals
+var patternWhiteSpace = regexp.MustCompile(`\s+`)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -701,7 +701,7 @@ func (l *LanguageServer) handleTextDocumentCompletion(
 	}
 
 	return types.CompletionList{
-		IsIncomplete: false,
+		IsIncomplete: true,
 		Items:        items,
 	}, nil
 }


### PR DESCRIPTION
Items for packages will now be sorted by 'depth',
show partial package refs where a package is comprised of many sub packages and continuously trigger completions in order to be able to provide up-to-date suggestions based on file changes.

Fixes https://github.com/StyraInc/regal/issues/752

before


https://github.com/StyraInc/regal/assets/1774239/c2ed40e9-5817-4f6e-8c4f-690233c71154



after


https://github.com/StyraInc/regal/assets/1774239/d754f6d3-1353-4442-aca6-6c1324bdc9ba

