### PR TITLE
lsp: Show subpackage scope

### DIFF
--- a/internal/lsp/completions/refs/refs.go
+++ b/internal/lsp/completions/refs/refs.go
@@ -103,10 +103,22 @@ to add more detail.`, name)
 }
 
 func findAnnotationForPackage(m *ast.Module) (*ast.Annotations, bool) {
-	for _, a := range m.Annotations {
+	var subPackageIndexes []int
+
+	for i, a := range m.Annotations {
 		if a.Scope == "package" {
 			return a, true
 		}
+
+		if a.Scope == "subpackages" {
+			subPackageIndexes = append(subPackageIndexes, i)
+		}
+	}
+
+	if len(subPackageIndexes) > 0 {
+		// subpackages are also permitted so they can be shown for the top level
+		// package in completions. However, package annotations take precedence.
+		return m.Annotations[subPackageIndexes[0]], true
 	}
 
 	return nil, false


### PR DESCRIPTION
This means that any info at the top level package can still be shown in completion popups.

Fixes: https://github.com/StyraInc/regal/issues/767

<img width="1082" alt="Screenshot 2024-05-29 at 15 41 05" src="https://github.com/StyraInc/regal/assets/1774239/192df841-66fc-4f94-bb9e-66afd76f1a94">

The correct fix, where any package in a module should also have the inherited data from the above package if there is a scope subpackages annotation. Currently, modules are parsed and loaded in any order, when they are, their docs are generated and cached in refs. The issue with this is that if a higher level package is loaded later, then the sub packages metadata is not present in time. We'd need to implement some complicated invalidation and reloading logic to achieve this I think, or make it so that ref docs are generated on the fly.

I think this fix is good enough for now.