### PR TITLE
lsp: Rule head & input doc completion improvements

### DIFF
--- a/internal/lsp/completions/manager.go
+++ b/internal/lsp/completions/manager.go
@@ -37,7 +37,7 @@ func NewDefaultManager(c *cache.Cache) *Manager {
 	m.RegisterProvider(&providers.RuleRefs{})
 	m.RegisterProvider(&providers.RuleHead{})
 	m.RegisterProvider(&providers.RuleHeadKeyword{})
-	m.RegisterProvider(&providers.CommonRule{})
+	m.RegisterProvider(&providers.Input{})
 
 	return m
 }

--- a/internal/lsp/completions/providers/builtins.go
+++ b/internal/lsp/completions/providers/builtins.go
@@ -20,13 +20,8 @@ func (*BuiltIns) Run(c *cache.Cache, params types.CompletionParams, _ *Options) 
 		return []types.CompletionItem{}, nil
 	}
 
-	// TODO: Share and improve this logic, currently shared with the rulerefs provider
-	if !strings.Contains(currentLine, " if ") && // if after if keyword
-		!strings.Contains(currentLine, " contains ") && // if after contains
-		!strings.Contains(currentLine, " else ") && // if after else
-		!strings.Contains(currentLine, "= ") && // if after assignment
-		!patternRuleBody.MatchString(currentLine) { // if in rule body
-		return nil, nil
+	if !inRuleBody(currentLine) {
+		return []types.CompletionItem{}, nil
 	}
 
 	words := patternWhiteSpace.Split(strings.TrimSpace(currentLine), -1)

--- a/internal/lsp/completions/providers/commonrule.go
+++ b/internal/lsp/completions/providers/commonrule.go
@@ -1,0 +1,90 @@
+//nolint:dupl
+package providers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/lsp/types/completion"
+)
+
+// CommonRule will return completions for new rules based on common Rego rule names.
+type CommonRule struct{}
+
+func (*CommonRule) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+	fileURI := params.TextDocument.URI
+
+	_, currentLine := completionLineHelper(c, fileURI, params.Position.Line)
+
+	if patternRuleBody.MatchString(currentLine) { // if in rule body
+		return []types.CompletionItem{}, nil
+	}
+
+	words := patternWhiteSpace.Split(currentLine, -1)
+	if len(words) != 1 {
+		return []types.CompletionItem{}, nil
+	}
+
+	// if the file already contains a rule with the same name, we do not want to
+	// suggest it again. In order to be able to do this later, we need to record
+	// all the existing rules in the file.
+	existingRules := make(map[string]struct{})
+
+	for _, ref := range c.GetFileRefs(fileURI) {
+		if ref.Kind == types.Rule || ref.Kind == types.ConstantRule || ref.Kind == types.Function {
+			parts := strings.Split(ref.Label, ".")
+			existingRules[parts[len(parts)-1]] = struct{}{}
+		}
+	}
+
+	lastWord := strings.TrimSpace(currentLine)
+
+	var label string
+
+	var newText string
+
+	for _, word := range []string{"allow", "deny"} {
+		if strings.HasPrefix(word, lastWord) {
+			// if the rule is defined, we can skip it as it'll be suggested by
+			// another provider
+			if _, ok := existingRules[word]; ok {
+				return []types.CompletionItem{}, nil
+			}
+
+			label = word
+			newText = word + " "
+
+			break
+		}
+	}
+
+	if label == "" {
+		return []types.CompletionItem{}, nil
+	}
+
+	return []types.CompletionItem{
+		{
+			Label: label,
+			Kind:  completion.Snippet,
+			Documentation: &types.MarkupContent{
+				Kind:  "markdown",
+				Value: fmt.Sprintf("%q is a common rule name", label),
+			},
+			TextEdit: &types.TextEdit{
+				Range: types.Range{
+					Start: types.Position{
+						Line:      params.Position.Line,
+						Character: params.Position.Character - uint(len(lastWord)),
+					},
+					End: types.Position{
+						Line:      params.Position.Line,
+						Character: uint(len(currentLine)),
+					},
+				},
+				NewText: newText,
+			},
+		},
+	}, nil
+}

--- a/internal/lsp/completions/providers/commonrule_test.go
+++ b/internal/lsp/completions/providers/commonrule_test.go
@@ -1,0 +1,132 @@
+//nolint:dupl
+package providers
+
+import (
+	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/completions/refs"
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/parse"
+)
+
+func TestCommonRule_TypedA(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package policy
+
+a
+`
+
+	c.SetFileContents(testCaseFileURI, fileContents)
+
+	p := &CommonRule{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 1,
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(completions) != 1 {
+		t.Fatalf("Expected exactly one completion, got: %v", completions)
+	}
+
+	comp := completions[0]
+	if comp.Label != "allow" {
+		t.Fatalf("Expected label to be 'allow', got: %v", comp.Label)
+	}
+}
+
+func TestCommonRule_TypedD(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package policy
+
+d
+`
+
+	c.SetFileContents(testCaseFileURI, fileContents)
+
+	p := &CommonRule{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 1,
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(completions) != 1 {
+		t.Fatalf("Expected exactly one completion, got: %v", completions)
+	}
+
+	comp := completions[0]
+	if comp.Label != "deny" {
+		t.Fatalf("Expected label to be 'deny', got: %v", comp.Label)
+	}
+}
+
+func TestCommonRule_TypedDAlreadyDefined(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package policy
+
+deny := false
+
+`
+
+	c.SetFileContents(testCaseFileURI, fileContents+"d")
+
+	mod, err := parse.Module(testCaseFileURI, fileContents)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	c.SetModule(testCaseFileURI, mod)
+	c.SetFileRefs(testCaseFileURI, refs.ForModule(mod))
+
+	p := &CommonRule{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      4,
+			Character: 1,
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(completions) != 0 {
+		t.Fatalf("Expected no completions, got: %v", completions)
+	}
+}

--- a/internal/lsp/completions/providers/input.go
+++ b/internal/lsp/completions/providers/input.go
@@ -20,13 +20,8 @@ func (*Input) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]
 		return []types.CompletionItem{}, nil
 	}
 
-	// TODO: Share and improve this logic, currently shared with the rulerefs provider
-	if !strings.Contains(currentLine, " if ") && // if after if keyword
-		!strings.Contains(currentLine, " contains ") && // if after contains
-		!strings.Contains(currentLine, " else ") && // if after else
-		!strings.Contains(currentLine, "= ") && // if after assignment
-		!patternRuleBody.MatchString(currentLine) { // if in rule body
-		return nil, nil
+	if !inRuleBody(currentLine) {
+		return []types.CompletionItem{}, nil
 	}
 
 	words := patternWhiteSpace.Split(strings.TrimSpace(currentLine), -1)

--- a/internal/lsp/completions/providers/input.go
+++ b/internal/lsp/completions/providers/input.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"strings"
+
+	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/lsp/types/completion"
+)
+
+// Input is a simple completion provider that returns the input keyword as a completion item
+// at suitable times.
+type Input struct{}
+
+func (*Input) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+	fileURI := params.TextDocument.URI
+
+	lines, currentLine := completionLineHelper(c, fileURI, params.Position.Line)
+	if len(lines) < 1 || currentLine == "" {
+		return []types.CompletionItem{}, nil
+	}
+
+	// TODO: Share and improve this logic, currently shared with the rulerefs provider
+	if !strings.Contains(currentLine, " if ") && // if after if keyword
+		!strings.Contains(currentLine, " contains ") && // if after contains
+		!strings.Contains(currentLine, " else ") && // if after else
+		!strings.Contains(currentLine, "= ") && // if after assignment
+		!patternRuleBody.MatchString(currentLine) { // if in rule body
+		return nil, nil
+	}
+
+	words := patternWhiteSpace.Split(strings.TrimSpace(currentLine), -1)
+	lastWord := words[len(words)-1]
+
+	items := []types.CompletionItem{}
+
+	//nolint:gocritic
+	if strings.HasPrefix("input", lastWord) {
+		items = append(items, types.CompletionItem{
+			Label:  "input",
+			Kind:   completion.Keyword,
+			Detail: "document",
+			Documentation: &types.MarkupContent{
+				Kind: "markdown",
+				Value: `# input
+
+'input' refers to the input document being evaluated.
+It is a special keyword that allows you to access the data sent to OPA at evaluation time.
+
+To see more examples of how to use 'input', check out the
+[policy language documentation](https://www.openpolicyagent.org/docs/latest/policy-language/).
+
+You can also experiment with input in the [Rego Playground](https://play.openpolicyagent.org/).
+`,
+			},
+			TextEdit: &types.TextEdit{
+				Range: types.Range{
+					Start: types.Position{
+						Line:      params.Position.Line,
+						Character: params.Position.Character - uint(len(lastWord)),
+					},
+					End: types.Position{
+						Line: params.Position.Line, Character: params.Position.Character,
+					},
+				},
+				NewText: "input.",
+			},
+		})
+	}
+
+	return items, nil
+}

--- a/internal/lsp/completions/providers/input_test.go
+++ b/internal/lsp/completions/providers/input_test.go
@@ -1,0 +1,47 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+func TestInput_if(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package foo
+
+allow if i`
+
+	c.SetFileContents(testCaseFileURI, fileContents)
+
+	p := &Input{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 10, // is the c char that triggered the request
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	labels := completionLabels(completions)
+
+	if len(labels) != 1 {
+		t.Fatalf("Expected one completion, got: %v", labels)
+	}
+
+	if labels[0] != "input" {
+		t.Fatalf("Expected 'input' completion, got: %v", labels[0])
+	}
+}

--- a/internal/lsp/completions/providers/ruleheadkeyword.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword.go
@@ -1,0 +1,80 @@
+//nolint:dupl
+package providers
+
+import (
+	"strings"
+
+	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/lsp/types/completion"
+)
+
+// RuleHeadKeyword will return completions for the keywords when starting a new rule.
+// The current cases are supported:
+// - [rule-name] if
+// - [rule-name] contains
+// - [rule-name] contains if
+// These completions are mandatory, that means they are the only ones to be shown.
+type RuleHeadKeyword struct{}
+
+func (*RuleHeadKeyword) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+	fileURI := params.TextDocument.URI
+
+	_, currentLine := completionLineHelper(c, fileURI, params.Position.Line)
+
+	if patternRuleBody.MatchString(currentLine) { // if in rule body
+		return []types.CompletionItem{}, nil
+	}
+
+	words := patternWhiteSpace.Split(currentLine, -1)
+	if len(words) < 2 {
+		return []types.CompletionItem{}, nil
+	}
+
+	lastWord := words[len(words)-1]
+
+	const keyWdContains = "contains"
+
+	const keyWdIf = "if"
+
+	var label string
+
+	switch {
+	// suggest contains after the name of the rule in the rule head
+	//nolint:gocritic
+	case len(words) == 2 && strings.HasPrefix(keyWdContains, lastWord):
+		label = "contains"
+	// suggest if at the end of the rule head
+	case len(words) == 4 && words[1] == keyWdContains:
+		label = keyWdIf
+	// suggest if after the rule name
+	//nolint:gocritic
+	case len(words) == 2 && strings.HasPrefix(keyWdIf, lastWord):
+		label = keyWdIf
+	}
+
+	if label == "" {
+		return []types.CompletionItem{}, nil
+	}
+
+	return []types.CompletionItem{
+		{
+			Label: label,
+			Kind:  completion.Keyword,
+			TextEdit: &types.TextEdit{
+				Range: types.Range{
+					Start: types.Position{
+						Line:      params.Position.Line,
+						Character: params.Position.Character - uint(len(lastWord)),
+					},
+					End: types.Position{
+						Line:      params.Position.Line,
+						Character: uint(len(currentLine)),
+					},
+				},
+				NewText: label + " ",
+			},
+			Mandatory: true,
+		},
+	}, nil
+}

--- a/internal/lsp/completions/providers/ruleheadkeyword_test.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword_test.go
@@ -1,0 +1,138 @@
+//nolint:dupl
+package providers
+
+import (
+	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+func TestRuleHeadKeyword_TypedIAfterRuleName(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package policy
+
+deny i
+`
+
+	c.SetFileContents(testCaseFileURI, fileContents)
+
+	p := &RuleHeadKeyword{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 5,
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(completions) != 1 {
+		t.Fatalf("Expected exactly one completion, got: %v", completions)
+	}
+
+	comp := completions[0]
+	if comp.Label != "if" {
+		t.Fatalf("Expected label to be 'if', got: %v", comp.Label)
+	}
+
+	if comp.Mandatory != true {
+		t.Fatalf("Expected mandatory to be true, got: %v", comp.Mandatory)
+	}
+}
+
+func TestRuleHeadKeyword_TypedC(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package policy
+
+deny c
+`
+
+	c.SetFileContents(testCaseFileURI, fileContents)
+
+	p := &RuleHeadKeyword{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 5,
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(completions) != 1 {
+		t.Fatalf("Expected exactly one completion, got: %v", completions)
+	}
+
+	comp := completions[0]
+	if comp.Label != "contains" {
+		t.Fatalf("Expected label to be 'contains', got: %v", comp.Label)
+	}
+
+	if comp.Mandatory != true {
+		t.Fatalf("Expected mandatory to be true, got: %v", comp.Mandatory)
+	}
+}
+
+func TestRuleHeadKeyword_TypedI(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package policy
+
+deny contains message i
+`
+
+	c.SetFileContents(testCaseFileURI, fileContents)
+
+	p := &RuleHeadKeyword{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 23,
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(completions) != 1 {
+		t.Fatalf("Expected exactly one completion, got: %v", completions)
+	}
+
+	comp := completions[0]
+	if comp.Label != "if" {
+		t.Fatalf("Expected label to be 'if' got: %v", comp.Label)
+	}
+
+	if comp.Mandatory != true {
+		t.Fatalf("Expected mandatory to be true, got: %v", comp.Mandatory)
+	}
+}

--- a/internal/lsp/completions/providers/rulerefs.go
+++ b/internal/lsp/completions/providers/rulerefs.go
@@ -27,13 +27,8 @@ func (*RuleRefs) Run(
 		return []types.CompletionItem{}, nil
 	}
 
-	// TODO: Share and improve this logic, currently shared with the builtins provider
-	if !strings.Contains(currentLine, " if ") && // if after if keyword
-		!strings.Contains(currentLine, " contains ") && // if after contains
-		!strings.Contains(currentLine, " else ") && // if after else
-		!strings.Contains(currentLine, "= ") && // if after assignment
-		!patternRuleBody.MatchString(currentLine) { // if in rule body
-		return nil, nil
+	if !inRuleBody(currentLine) {
+		return []types.CompletionItem{}, nil
 	}
 
 	words := patternWhiteSpace.Split(currentLine, -1)

--- a/internal/lsp/completions/providers/utils.go
+++ b/internal/lsp/completions/providers/utils.go
@@ -58,3 +58,21 @@ func groupKeyedRefsByDepth(refs map[string]types.Ref) ([]int, map[int]map[string
 
 	return depths, byDepth
 }
+
+// inRuleBody returns is a best-effort helper to determine if the current line is in a rule body.
+func inRuleBody(currentLine string) bool {
+	switch {
+	case strings.Contains(currentLine, " if "):
+		return true
+	case strings.Contains(currentLine, " contains "):
+		return true
+	case strings.Contains(currentLine, " else "):
+		return true
+	case strings.Contains(currentLine, "= "):
+		return true
+	case patternRuleBody.MatchString(currentLine):
+		return true
+	}
+
+	return false
+}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -136,6 +136,11 @@ type CompletionItem struct {
 	Documentation *MarkupContent      `json:"documentation,omitempty"`
 	Preselect     bool                `json:"preselect"`
 	TextEdit      *TextEdit           `json:"textEdit,omitempty"`
+
+	// Mandatory is used to indicate that the completion item is mandatory and should be offered
+	// as an exclusive completion. This is not part of the LSP spec, but used in regal providers
+	// to indicate that the completion item is the only valid completion.
+	Mandatory bool `json:"-"`
 }
 
 type CompletionItemLabelDetails struct {


### PR DESCRIPTION
These new completion providers will complete keywords and common rule names in a limited number of but common scenarios.

https://github.com/StyraInc/regal/assets/1774239/670db180-b494-4ad8-a225-82aed14feb8d

also

Fixes https://github.com/StyraInc/regal/issues/768


https://github.com/StyraInc/regal/assets/1774239/c92ba19b-19c8-493f-814b-e0f8ab235b77

