### PR TITLE
Rule: `leaked-internal-reference`

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The following rules are currently available:
 | bugs        | [impossible-not](https://docs.styra.com/regal/rules/bugs/impossible-not)                              | Impossible `not` condition                                |
 | bugs        | [inconsistent-args](https://docs.styra.com/regal/rules/bugs/inconsistent-args)                        | Inconsistently named function arguments                   |
 | bugs        | [invalid-metadata-attribute](https://docs.styra.com/regal/rules/bugs/invalid-metadata-attribute)      | Invalid attribute in metadata annotation                  |
+| bugs        | [leaked-internal-reference](https://docs.styra.com/regal/rules/bugs/leaked-internal-reference)        | Outside reference to internal rule or function            |
 | bugs        | [not-equals-in-loop](https://docs.styra.com/regal/rules/bugs/not-equals-in-loop)                      | Use of != in loop                                         |
 | bugs        | [redundant-existence-check](https://docs.styra.com/regal/rules/bugs/redundant-existence-check)        | Redundant existence check                                 |
 | bugs        | [rule-named-if](https://docs.styra.com/regal/rules/bugs/rule-named-if)                                | Rule named "if"                                           |

--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -340,6 +340,9 @@ all_rules_refs contains value if {
 	is_ref(value)
 }
 
+# METADATA
+# title: all_refs
+# description: set containing all references found in the input AST
 all_refs contains value if some value in all_rules_refs
 
 all_refs contains value if {
@@ -348,6 +351,9 @@ all_refs contains value if {
 	is_ref(value)
 }
 
+# METADATA
+# title: ref_to_string
+# description:  returns the "path" string of any given ref value
 ref_to_string(ref) := concat(".", [_ref_part_to_string(i, part) | some i, part in ref])
 
 _ref_part_to_string(0, ref) := ref.value

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -14,6 +14,8 @@ rules:
       level: error
     invalid-metadata-attribute:
       level: error
+    leaked-internal-reference:
+      level: error
     not-equals-in-loop:
       level: error
     redundant-existence-check:

--- a/bundle/regal/rules/bugs/leaked_internal_reference.rego
+++ b/bundle/regal/rules/bugs/leaked_internal_reference.rego
@@ -1,0 +1,16 @@
+# METADATA
+# description: Outside reference to internal rule or function
+package regal.rules.bugs["leaked-internal-reference"]
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.result
+
+report contains violation if {
+	some ref in ast.all_refs
+
+	contains(ast.ref_to_string(ref.value), "._")
+
+	violation := result.fail(rego.metadata.chain(), result.location(ref))
+}

--- a/bundle/regal/rules/bugs/leaked_internal_reference_test.rego
+++ b/bundle/regal/rules/bugs/leaked_internal_reference_test.rego
@@ -1,0 +1,51 @@
+package regal.rules.bugs["leaked-internal-reference_test"]
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.bugs["leaked-internal-reference"] as rule
+
+test_fail_leaked_internal_reference_in_import if {
+	r := rule.report with input as ast.with_rego_v1(`import data.foo._bar`)
+	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 5, "text": "import data.foo._bar"})
+}
+
+test_fail_leaked_internal_reference_in_rule_head if {
+	r := rule.report with input as ast.with_rego_v1(`var := data.foo._bar`)
+	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 5, "text": "var := data.foo._bar"})
+}
+
+test_fail_leaked_internal_reference_in_rule_body if {
+	r := rule.report with input as ast.with_rego_v1(`rule if {
+		x := data.foo._bar
+	}`)
+	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 6, "text": "\t\tx := data.foo._bar"})
+}
+
+test_fail_leaked_internal_reference_in_nested_comprehension if {
+	r := rule.report with input as ast.with_rego_v1(`rule if {
+		comp := [x | x := data.foo._bar]
+	}`)
+	r == expected_with_location({
+		"col": 21,
+		"file": "policy.rego",
+		"row": 6,
+		"text": "\t\tcomp := [x | x := data.foo._bar]",
+	})
+}
+
+expected := {
+	"category": "bugs",
+	"description": "Outside reference to internal rule or function",
+	"level": "error",
+	"related_resources": [{
+		"description": "documentation",
+		"ref": config.docs.resolve_url("$baseUrl/$category/leaked-internal-reference", "bugs"),
+	}],
+	"title": "leaked-internal-reference",
+}
+
+# regal ignore:external-reference
+expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -228,7 +228,7 @@ func fix(args []string, params *fixCommandParams) error {
 		}
 
 		l = l.WithUserConfig(userConfig)
-	case err != nil && params.configFile != "":
+	case params.configFile != "":
 		return fmt.Errorf("user-provided config file not found: %w", err)
 	case params.debug:
 		log.Println("no user-provided config file found, will use the default config")

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -315,7 +315,13 @@ func scaffoldBuiltinRule(params newRuleCommandParams) error {
 func createBuiltinDocs(params newRuleCommandParams) error {
 	docsDir := filepath.Join(params.output, "docs", "rules", params.category)
 
-	docTmpl, err := template.ParseFS(embeds.EmbedTemplatesFS, "templates/builtin/builtin.md.tpl")
+	docTmpl := template.New("builtin.md.tpl")
+
+	docTmpl = docTmpl.Funcs(template.FuncMap{
+		"ToUpper": strings.ToUpper,
+	})
+
+	docTmpl, err := docTmpl.ParseFS(embeds.EmbedTemplatesFS, "templates/builtin/builtin.md.tpl")
 	if err != nil {
 		return err
 	}
@@ -331,6 +337,8 @@ func createBuiltinDocs(params newRuleCommandParams) error {
 	if err != nil {
 		return err
 	}
+
+	log.Printf("Created doc template for builtin rule %q in %s\n", params.name, docsDir)
 
 	return nil
 }

--- a/docs/rules/bugs/leaked-internal-reference.md
+++ b/docs/rules/bugs/leaked-internal-reference.md
@@ -1,0 +1,67 @@
+# leaked-internal-reference
+
+**Summary**: Outside reference to internal rule or function
+
+**Category**: Bugs
+
+**Avoid**
+```rego
+package policy
+
+# Import of rule or functions marked as internal
+import data.users._all_users
+
+allow if {
+    # reference to rule or function marked as internal
+    some role in data.permissions._roles
+    # ...some conditions
+}
+```
+
+## Rationale
+
+OPA doesn't have a concept of "internal", or private rules and functions — and all rules can be queried or referenced
+from the outside. Despite this fact, it has become a common convention to use an underscore prefix in the name of
+rules and functions to indicate that they should be considered internal to the package that they're in:
+
+```rego
+# `allow` may be referenced from outside the package
+allow if _user_is_developer
+
+# `_user_is_developer` should not be referenced from outside the package
+_user_is_developer if "developer" in input.users.roles
+```
+
+While this might seem like a pointless convention if it isn't enforced by OPA, it comes with a number of benefits:
+
+- While OPA doesn't enforce it, other tools like linters can help with that. Like this rule does!
+- It clearly communicates intent to other policy authors, and as a simple form of documentation
+- Completion suggestions in editors can be filtered to exclude internal rules and functions
+- Tools that render documentation from Rego policies and metadata annotations can exclude internal rules and functions
+- Checking for unused rules and functions can be done much faster if they're known not to be referenced from outside
+
+Do note that if you disagree with this rule, you don't need to disable it unless you use underscore prefixes to mean
+something else. If you don't use underscore prefixes, nothing will be reported by this rule anyway. It does however
+mean that the benefits listed above won't apply to your project.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  bugs:
+    leaked-internal-reference:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Rego Style Guide: [Optionally, use leading underscore for rules intended for internal use](https://docs.styra.com/opa/rego-style-guide#optionally-use-leading-underscore-for-rules-intended-for-internal-use)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -49,6 +49,8 @@ duplicate_rule if {
 	input.foo
 }
 
+leaked_internal_reference := data.foo._bar
+
 # METADATA
 # invalid-metadata-attribute: true
 should := "fail"

--- a/internal/embeds/templates/builtin/builtin.md.tpl
+++ b/internal/embeds/templates/builtin/builtin.md.tpl
@@ -2,7 +2,7 @@
 
 **Summary**: ADD DESCRIPTION HERE
 
-**Category**: {{.Category}}
+**Category**: {{.Category | ToUpper}}
 
 **Automatically fixable**: Yes/No
 


### PR DESCRIPTION
Help enforce convention of using underscore prefixes for rules and functions to mean internal by flagging references to them from outside the package.

Fixes #94

Also in this PR:
- Fix casing of category in generated rule doc template
- Some more metadata annotations added in the `ast` package
- Fix warning about pointless nil check in fix.go

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
development](https://github.com/StyraInc/regal/blob/main/docs/development.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->