### PR TITLE
breaking: Remove `regal.json_pretty` built-in function

### DIFF
--- a/build/capabilities.json
+++ b/build/capabilities.json
@@ -6111,23 +6111,6 @@
       }
     },
     {
-      "name": "regal.json_pretty",
-      "decl": {
-        "args": [
-          {
-            "description": "data to marshal to JSON in a pretty format",
-            "name": "data",
-            "type": "any"
-          }
-        ],
-        "result": {
-          "name": "output",
-          "type": "string"
-        },
-        "type": "function"
-      }
-    },
-    {
       "name": "regal.last",
       "decl": {
         "args": [

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -265,11 +265,11 @@ Works just like `rego.parse_module`, but provides an AST including location info
 by Regal, like the text representation of each line in the original policy. This is useful for authoring tests to assert
 linter rules work as expected.
 
-### `regal.json_pretty(data)`
+### `regal.last(array)`
 
-Printing nested objects and arrays is quite helpful for debugging AST nodes, but the standard representation — where
-everything is displayed on a single line — not so much. This built-in allows marshalling JSON similar to `json.marshal`,
-but with newlines and spaces added for a more pleasant experience.
+This built-in function is a much more performant way to express `array[count(array) - 1]`. This performance difference
+is almost always irrelevant in "normal" Rego policies, but can have a significant impact in linter rules where it's
+sometimes called thousands of times as part of traversing the input AST.
 
 In addition to this, Regal provides many helpful functions, rules and utilities in Rego. Browsing the source code of the
 [regal.ast](https://github.com/StyraInc/regal/blob/main/bundle/regal/ast/ast.rego) package to see what's available is

--- a/internal/compile/compile.go
+++ b/internal/compile/compile.go
@@ -17,10 +17,6 @@ func Capabilities() *ast.Capabilities {
 			Decl: builtins.RegalParseModuleMeta.Decl,
 		},
 		&ast.Builtin{
-			Name: builtins.RegalJSONPrettyMeta.Name,
-			Decl: builtins.RegalJSONPrettyMeta.Decl,
-		},
-		&ast.Builtin{
 			Name: builtins.RegalLastMeta.Name,
 			Decl: builtins.RegalLastMeta.Decl,
 		})

--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -27,17 +27,6 @@ var RegalParseModuleMeta = &rego.Function{
 	),
 }
 
-// RegalJSONPrettyMeta metadata for regal.json_pretty.
-var RegalJSONPrettyMeta = &rego.Function{
-	Name: "regal.json_pretty",
-	Decl: types.NewFunction(
-		types.Args(
-			types.Named("data", types.A).Description("data to marshal to JSON in a pretty format"),
-		),
-		types.Named("output", types.S),
-	),
-}
-
 // RegalLastMeta metadata for regal.last.
 var RegalLastMeta = &rego.Function{
 	Name: "regal.last",
@@ -101,16 +90,6 @@ func RegalLast(_ rego.BuiltinContext, arr *ast.Term) (*ast.Term, error) {
 	return arrOp.Elem(arrOp.Len() - 1), nil
 }
 
-// RegalJSONPretty regal.json_pretty, like json.marshal but with pretty formatting.
-func RegalJSONPretty(_ rego.BuiltinContext, data *ast.Term) (*ast.Term, error) {
-	encoded, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
-		return nil, err
-	}
-
-	return ast.StringTerm(string(encoded)), nil
-}
-
 // TestContextBuiltins returns the list of builtins as expected by the test runner.
 func TestContextBuiltins() []*tester.Builtin {
 	return []*tester.Builtin{
@@ -120,13 +99,6 @@ func TestContextBuiltins() []*tester.Builtin {
 				Decl: RegalParseModuleMeta.Decl,
 			},
 			Func: rego.Function2(RegalParseModuleMeta, RegalParseModule),
-		},
-		{
-			Decl: &ast.Builtin{
-				Name: RegalJSONPrettyMeta.Name,
-				Decl: RegalJSONPrettyMeta.Decl,
-			},
-			Func: rego.Function1(RegalJSONPrettyMeta, RegalJSONPretty),
 		},
 		{
 			Decl: &ast.Builtin{

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -563,7 +563,6 @@ func (l Linter) prepareRegoArgs(query ast.Body) ([]func(*rego.Rego), error) {
 		rego.ParsedQuery(query),
 		rego.ParsedBundle("regal_eval_params", &dataBundle),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
-		rego.Function1(builtins.RegalJSONPrettyMeta, builtins.RegalJSONPretty),
 		rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
 	)
 


### PR DESCRIPTION
We never used it ourselves, and now that OPA has a built-in for this there's even less need to keep this around. I doubt anyone relied on it, but let's call it out in the next release notes anyway.