### PR TITLE
Refactor: remove `name` function in favor of `ref_to_string`

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -35,14 +35,6 @@ package_name := concat(".", [path.value |
 	i > 0
 ])
 
-# METADATA
-# description: |
-#   returns the name of the rule, i.e. "foo" for "foo { ... }"
-#   note that what constitutes the "name" of a ref-head rule is
-#   ambiguous at best, i.e. a["b"][c] { ... } ... in those cases
-#   we currently return the first element of the ref, i.e. "a"
-name(rule) := rule.head.ref[0].value
-
 named_refs(refs) := [ref |
 	some i, ref in refs
 	_is_name(ref, i)
@@ -81,7 +73,8 @@ rules := [rule |
 tests := [rule |
 	some rule in input.rules
 	not rule.head.args
-	startswith(name(rule), "test_")
+
+	startswith(ref_to_string(rule.head.ref), "test_")
 ]
 
 functions := [rule |
@@ -91,11 +84,11 @@ functions := [rule |
 
 function_arg_names(rule) := [arg.value | some arg in rule.head.args]
 
-rule_and_function_names contains name(rule) if some rule in input.rules
+rule_and_function_names contains ref_to_string(rule.head.ref) if some rule in input.rules
 
 identifiers := rule_and_function_names | imported_identifiers
 
-rule_names contains name(rule) if some rule in rules
+rule_names contains ref_to_string(rule.head.ref) if some rule in rules
 
 # METADATA
 # description: parse provided snippet with a generic package declaration added
@@ -412,7 +405,7 @@ function_decls(rules) := {rule_name: decl |
 	# regal ignore:external-reference
 	some rule in functions
 
-	rule_name := name(rule)
+	rule_name := ref_to_string(rule.head.ref)
 
 	# ensure we only get one set of args, or we'll have a conflict
 	args := [[item |
@@ -420,7 +413,7 @@ function_decls(rules) := {rule_name: decl |
 		item := {"type": "any"}
 	] |
 		some rule in rules
-		name(rule) == rule_name
+		ref_to_string(rule.head.ref) == rule_name
 	][0]
 
 	decl := {"decl": {"args": args, "result": {"type": "any"}}}

--- a/bundle/regal/rules/bugs/rule_named_if.rego
+++ b/bundle/regal/rules/bugs/rule_named_if.rego
@@ -14,7 +14,7 @@ report contains violation if {
 	"if" in ast.rule_names
 
 	some rule in input.rules
-	ast.name(rule) == "if"
+	ast.ref_to_string(rule.head.ref) == "if"
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/bugs/rule_shadows_builtin.rego
+++ b/bundle/regal/rules/bugs/rule_shadows_builtin.rego
@@ -9,7 +9,8 @@ import data.regal.result
 
 report contains violation if {
 	some rule in input.rules
-	ast.name(rule) in ast.builtin_namespaces
+
+	ast.ref_to_string(rule.head.ref) in ast.builtin_namespaces
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/custom/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming_convention.rego
@@ -38,13 +38,16 @@ report contains violation if {
 	some rule in input.rules
 
 	not rule.head.args
-	not regex.match(convention.pattern, ast.name(rule))
+
+	name := ast.ref_to_string(rule.head.ref)
+
+	not regex.match(convention.pattern, name)
 
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
 		sprintf(
 			"Naming convention violation: rule name %q does not match pattern '%s'",
-			[ast.name(rule), convention.pattern],
+			[name, convention.pattern],
 		),
 	)
 }
@@ -58,13 +61,15 @@ report contains violation if {
 
 	some rule in ast.functions
 
-	not regex.match(convention.pattern, ast.name(rule))
+	name := ast.ref_to_string(rule.head.ref)
+
+	not regex.match(convention.pattern, name)
 
 	violation := with_description(
 		result.fail(rego.metadata.chain(), result.location(rule.head)),
 		sprintf(
 			"Naming convention violation: function name %q does not match pattern '%s'",
-			[ast.name(rule), convention.pattern],
+			[name, convention.pattern],
 		),
 	)
 }

--- a/bundle/regal/rules/performance/with_outside_test_context.rego
+++ b/bundle/regal/rules/performance/with_outside_test_context.rego
@@ -12,7 +12,7 @@ report contains violation if {
 	some expr in rule.body
 
 	expr["with"]
-	not strings.any_prefix_match(ast.name(rule), {"test_", "todo_test"})
+	not strings.any_prefix_match(ast.ref_to_string(rule.head.ref), {"test_", "todo_test"})
 
 	violation := result.fail(rego.metadata.chain(), result.location(expr["with"][0]))
 }

--- a/bundle/regal/rules/style/avoid_get_and_list_prefix.rego
+++ b/bundle/regal/rules/style/avoid_get_and_list_prefix.rego
@@ -9,7 +9,7 @@ import data.regal.result
 
 report contains violation if {
 	some rule in input.rules
-	strings.any_prefix_match(ast.name(rule), {"get_", "list_"})
+	strings.any_prefix_match(ast.ref_to_string(rule.head.ref), {"get_", "list_"})
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/testing/identically_named_tests.rego
+++ b/bundle/regal/rules/testing/identically_named_tests.rego
@@ -8,7 +8,7 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	test_names := [ast.name(rule) | some rule in ast.tests]
+	test_names := [ast.ref_to_string(rule.head.ref) | some rule in ast.tests]
 
 	some i, name in test_names
 

--- a/bundle/regal/rules/testing/todo_test.rego
+++ b/bundle/regal/rules/testing/todo_test.rego
@@ -10,7 +10,7 @@ import data.regal.result
 report contains violation if {
 	some rule in input.rules
 
-	startswith(ast.name(rule), "todo_test_")
+	startswith(ast.ref_to_string(rule.head.ref), "todo_test_")
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/internal/embeds/templates/builtin/builtin.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin.rego.tpl
@@ -13,7 +13,7 @@ report contains violation if {
 
 	# Deny any rule named foo, bar, or baz. This is just an example!
 	# Add your own rule logic here.
-	ast.name(rule) in {"foo", "bar", "baz"}
+	ast.ref_to_string(rule.head.ref) in {"foo", "bar", "baz"}
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule))
 }

--- a/internal/embeds/templates/custom/custom.rego.tpl
+++ b/internal/embeds/templates/custom/custom.rego.tpl
@@ -15,7 +15,7 @@ report contains violation if {
 
 	# Deny any rule named foo, bar, or baz. This is just an example!
 	# Add your own rule logic here.
-	ast.name(rule) in {"foo", "bar", "baz"}
+	ast.ref_to_string(rule.head.ref) in {"foo", "bar", "baz"}
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule))
 }


### PR DESCRIPTION
As `name` was rather ambiguous, and only gave the first part of the name, and `ref_to_string` is usable on any ref — let's just have that.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->