### PR TITLE
lsp/completions: Drop period from input new text

### DIFF
--- a/internal/lsp/completions/providers/input.go
+++ b/internal/lsp/completions/providers/input.go
@@ -58,7 +58,7 @@ You can also experiment with input in the [Rego Playground](https://play.openpol
 						Line: params.Position.Line, Character: params.Position.Character,
 					},
 				},
-				NewText: "input.",
+				NewText: "input",
 			},
 		})
 	}

--- a/internal/lsp/completions/providers/input_test.go
+++ b/internal/lsp/completions/providers/input_test.go
@@ -44,4 +44,8 @@ allow if i`
 	if labels[0] != "input" {
 		t.Fatalf("Expected 'input' completion, got: %v", labels[0])
 	}
+
+	if exp, got := "input", completions[0].TextEdit.NewText; exp != got {
+		t.Fatalf("Expected '%s' as new text, got: %s", exp, got)
+	}
 }


### PR DESCRIPTION
This is not consistent with other completions

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->