### PR TITLE
docs: abs link for do.rq

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Recommended, but not required:
 
 - The [rq](https://git.sr.ht/~charles/rq) tool. This is used for automating and simplifying many of the tasks outlined
   in this document, and is (ab)used as a Rego-based replacement for Make in this project. Check out the
-  [do.rq](../build/do.rq) file to see what that looks like, and for documentation on the available tasks.
+  [do.rq](https://github.com/StyraInc/regal/blob/main/build/do.rq) file to see what that looks like, and for documentation on the available tasks.
 
 ## Contributing New Rules
 


### PR DESCRIPTION
This is needed as the file is not present on docs.styra.com

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->