### PR TITLE
Return `null` in textDocument/diagnostic handler

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1316,7 +1316,7 @@ func (*LanguageServer) handleTextDocumentDiagnostic(
 	// this is a no-op. Because we accept the textDocument/didChange event, which contains the new content,
 	// we don't need to do anything here as once the new content has been parsed, the diagnostics will be sent
 	// on the channel regardless of this request.
-	return struct{}{}, nil
+	return nil, nil
 }
 
 func (l *LanguageServer) handleWorkspaceDidChangeWatchedFiles(


### PR DESCRIPTION
While the specification isn't clear here, Neovim apparently had issues dealing with the empty object response. And since all the other editors seem to handle a null response too, let's just go with that instead.

Fixes #810

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->