### PR TITLE
Use config.docs.resolve_url consistently

### DIFF
--- a/bundle/regal/rules/bugs/impossible_not_test.rego
+++ b/bundle/regal/rules/bugs/impossible_not_test.rego
@@ -2,6 +2,8 @@ package regal.rules.bugs["impossible-not_test"]
 
 import rego.v1
 
+import data.regal.config
+
 import data.regal.rules.bugs["impossible-not"] as rule
 
 test_fail_multivalue_not_reference_same_package if {
@@ -156,7 +158,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": "https://docs.styra.com/regal/rules/bugs/impossible-not",
+		"ref": config.docs.resolve_url("$baseUrl/$category/impossible-not", "bugs"),
 	}],
 	"title": "impossible-not",
 }

--- a/bundle/regal/rules/bugs/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent_args_test.rego
@@ -3,6 +3,7 @@ package regal.rules.bugs["inconsistent-args_test"]
 import rego.v1
 
 import data.regal.ast
+import data.regal.config
 
 import data.regal.rules.bugs["inconsistent-args"] as rule
 
@@ -68,7 +69,7 @@ expected := {
 	"level": "error",
 	"related_resources": [{
 		"description": "documentation",
-		"ref": "https://docs.styra.com/regal/rules/bugs/inconsistent-args",
+		"ref": config.docs.resolve_url("$baseUrl/$category/inconsistent-args", "bugs"),
 	}],
 	"title": "inconsistent-args",
 }

--- a/bundle/regal/rules/imports/circular_import_test.rego
+++ b/bundle/regal/rules/imports/circular_import_test.rego
@@ -2,6 +2,8 @@ package regal.rules.imports["circular-import_test"]
 
 import rego.v1
 
+import data.regal.config
+
 import data.regal.rules.imports["circular-import"] as rule
 
 test_aggregate_rule_empty_if_no_refs if {
@@ -203,7 +205,7 @@ test_aggregate_report_fails_when_cycle_present if {
 		"location": {"col": 0, "file": "b.rego", "row": 2},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/imports/circular-import",
+			"ref": config.docs.resolve_url("$baseUrl/$category/circular-import", "imports"),
 		}],
 		"title": "circular-import",
 	}}
@@ -226,7 +228,7 @@ test_aggregate_report_fails_when_cycle_present_in_1_package if {
 		"location": {"col": 12, "file": "a.rego", "row": 3},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/imports/circular-import",
+			"ref": config.docs.resolve_url("$baseUrl/$category/circular-import", "imports"),
 		}],
 		"title": "circular-import",
 	}}
@@ -258,7 +260,7 @@ test_aggregate_report_fails_when_cycle_present_in_n_packages if {
 		"location": {"col": 12, "file": "c.rego", "row": 3},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/imports/circular-import",
+			"ref": config.docs.resolve_url("$baseUrl/$category/circular-import", "imports"),
 		}],
 		"title": "circular-import",
 	}}

--- a/bundle/regal/rules/style/double_negative_test.rego
+++ b/bundle/regal/rules/style/double_negative_test.rego
@@ -3,6 +3,7 @@ package regal.rules.style["double-negative_test"]
 import rego.v1
 
 import data.regal.ast
+import data.regal.config
 
 import data.regal.rules.style["double-negative"] as rule
 
@@ -20,7 +21,7 @@ test_fail_double_negative if {
 		"location": {"col": 13, "file": "policy.rego", "row": 8, "text": "    fine if not not_fine"},
 		"related_resources": [{
 			"description": "documentation",
-			"ref": "https://docs.styra.com/regal/rules/style/double-negative",
+			"ref": config.docs.resolve_url("$baseUrl/$category/double-negative", "style"),
 		}],
 		"title": "double-negative",
 		"level": "error",

--- a/bundle/regal/rules/style/rule_name_repeats_package_test.rego
+++ b/bundle/regal/rules/style/rule_name_repeats_package_test.rego
@@ -2,11 +2,13 @@ package regal.rules.style["rule-name-repeats-package_test"]
 
 import rego.v1
 
+import data.regal.config
+
 import data.regal.rules.style["rule-name-repeats-package"] as rule
 
 related_resources := [{
 	"description": "documentation",
-	"ref": "https://docs.styra.com/regal/rules/style/rule-name-repeats-package",
+	"ref": config.docs.resolve_url("$baseUrl/$category/rule-name-repeats-package", "style"),
 }]
 
 base_result := {


### PR DESCRIPTION
Instead of hard-coding doc URLs.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->