### PR TITLE
lsp: Use text edit for builtins providers

### DIFF
--- a/internal/lsp/completions/providers/builtins.go
+++ b/internal/lsp/completions/providers/builtins.go
@@ -47,6 +47,19 @@ func (*BuiltIns) Run(c *cache.Cache, params types.CompletionParams, _ *Options) 
 					Kind:  "markdown",
 					Value: hover.CreateHoverContent(builtIn),
 				},
+				TextEdit: &types.TextEdit{
+					Range: types.Range{
+						Start: types.Position{
+							Line:      params.Position.Line,
+							Character: params.Position.Character - uint(len(lastWord)),
+						},
+						End: types.Position{
+							Line:      params.Position.Line,
+							Character: params.Position.Character,
+						},
+					},
+					NewText: key,
+				},
 			})
 		}
 	}


### PR DESCRIPTION
When not supplying a text edit, the editor will just insert the text instead. This is a problem when picking up a suggestion from a word started earlier.

Fixes #808 

before 

https://github.com/StyraInc/regal/assets/1774239/14e48d70-09ed-429c-84ac-28b18e12bf92

after

https://github.com/StyraInc/regal/assets/1774239/bb7b72e4-77d1-45e2-9e99-3bcc84bc5d1e

