### PR TITLE
lint/fix: roll over empty config

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -219,7 +219,10 @@ func fix(args []string, params *fixCommandParams) error {
 			log.Printf("found user config file: %s", userConfigFile.Name())
 		}
 
-		if err := yaml.NewDecoder(userConfigFile).Decode(&userConfig); err != nil {
+		err := yaml.NewDecoder(userConfigFile).Decode(&userConfig)
+		if errors.Is(err, io.EOF) {
+			log.Printf("user config file %q is empty, will use the default config", userConfigFile.Name())
+		} else if err != nil {
 			if regalDir != nil {
 				return fmt.Errorf("failed to decode user config from %s: %w", regalDir.Name(), err)
 			}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -289,7 +289,10 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 			log.Printf("found user config file: %s", userConfigFile.Name())
 		}
 
-		if err := yaml.NewDecoder(userConfigFile).Decode(&userConfig); err != nil {
+		err := yaml.NewDecoder(userConfigFile).Decode(&userConfig)
+		if errors.Is(err, io.EOF) {
+			log.Printf("user config file %q is empty, will use the default config", userConfigFile.Name())
+		} else if err != nil {
 			if regalDir != nil {
 				return report.Report{}, fmt.Errorf("failed to decode user config from %s: %w", regalDir.Name(), err)
 			}


### PR DESCRIPTION
If a config file contains nothing or only comments, then we can roll over it with a more helpful message rather than erroring.

Fixes https://github.com/StyraInc/regal/issues/805