### PR TITLE
Skip nil check for sync.Once

### DIFF
--- a/internal/lsp/completions/refs/used.go
+++ b/internal/lsp/completions/refs/used.go
@@ -73,9 +73,7 @@ func initialize() {
 // See the rego above for more details on what's included and excluded.
 // This function is run when the parse completes for a module.
 func UsedInModule(ctx context.Context, module *ast.Module) ([]string, error) {
-	if pq == nil {
-		pqInitOnce.Do(initialize)
-	}
+	pqInitOnce.Do(initialize)
 
 	rs, err := pq.Eval(ctx, rego.EvalInput(module))
 	if err != nil {


### PR DESCRIPTION
When using sync.Once this is not needed.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->