### PR TITLE
Check Regal version at start-up

### DIFF
--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -1,3 +1,6 @@
+features:
+  remote:
+    check_version: true
 rules:
   bugs:
     constant-condition:

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -1,6 +1,6 @@
 features:
   remote:
-    check_version: true
+    check-version: true
 rules:
   bugs:
     constant-condition:

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -282,8 +282,6 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 
 	var userConfig config.Config
 
-	userConfig.SetDefaults()
-
 	userConfigFile, err := readUserConfig(params, regalDir)
 
 	switch {
@@ -322,7 +320,7 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 			dir = regalDir.Name()
 		}
 
-		if userConfig.Features.RemoteFeatures.CheckVersion &&
+		if userConfig.Features.Remote.CheckVersion &&
 			os.Getenv(update.CheckAndWarnIgnoreVariable) != "false" {
 			update.CheckAndWarn(update.Options{
 				CurrentVersion: version.Version,

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -321,7 +321,7 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 		}
 
 		if userConfig.Features.Remote.CheckVersion &&
-			os.Getenv(update.CheckAndWarnIgnoreVariable) != "false" {
+			os.Getenv(update.CheckVersionDisableEnvVar) != "false" {
 			update.CheckAndWarn(update.Options{
 				CurrentVersion: version.Version,
 				CurrentTime:    time.Now().UTC(),

--- a/docs/remote-features.md
+++ b/docs/remote-features.md
@@ -9,7 +9,7 @@ Regal will notify you by writing a message in stderr.
 
 An example of such a message is:
 
-```
+```txt
 A new version of Regal is available (v0.23.1). You are running v0.23.0.
 See https://github.com/StyraInc/regal/releases/tag/v0.23.1 for the latest release.
 ```

--- a/docs/remote-features.md
+++ b/docs/remote-features.md
@@ -1,0 +1,27 @@
+# Remote Features
+
+This page outlines the features of Regal that need internet access to function.
+
+## Checking for Updates
+
+Regal will check for updates on startup. If a new version is available,
+Regal will notify you by writing a message in stderr.
+
+An example of such a message is:
+
+```
+A new version of Regal is available (v0.23.1). You are running v0.23.0.
+See https://github.com/StyraInc/regal/releases/tag/v0.23.1 for the latest release.
+```
+
+This message is based on the local version set in the Regal binary, and **no
+user data is sent** to GitHub where the releases are hosted.
+
+This same function will also write to the file at: `$HOME/.config/regal/latest_version.json`,
+this is used as a cache of the latest version to avoid consuming excessive
+GitHub API rate limits when using Regal.
+
+This functionality can be disabled in two ways:
+
+* Using `.regal/config.yaml`: set `features.remote.check-version` to `false`.
+* Using an environment variable: set `REGAL_DISABLE_CHECK_VERSION` to `true`.

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -335,7 +335,7 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 						CurrentVersion: version.Version,
 						CurrentTime:    time.Now().UTC(),
 						Debug:          false,
-						StateDir:       filepath.Dir(configFile.Name()),
+						StateDir:       config.GlobalDir(),
 					}, os.Stderr)
 				}
 			}()

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -330,7 +330,7 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 			//nolint:contextcheck
 			go func() {
 				if l.loadedConfig.Features.Remote.CheckVersion &&
-					os.Getenv(update.CheckAndWarnIgnoreVariable) != "false" {
+					os.Getenv(update.CheckVersionDisableEnvVar) != "false" {
 					update.CheckAndWarn(update.Options{
 						CurrentVersion: version.Version,
 						CurrentTime:    time.Now().UTC(),

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -330,7 +330,7 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 			//nolint:contextcheck
 			go func() {
 				if l.loadedConfig.Features.Remote.CheckVersion &&
-					os.Getenv(update.CheckVersionDisableEnvVar) != "false" {
+					os.Getenv(update.CheckVersionDisableEnvVar) != "" {
 					update.CheckAndWarn(update.Options{
 						CurrentVersion: version.Version,
 						CurrentTime:    time.Now().UTC(),

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -21,7 +21,7 @@ import (
 //go:embed update.rego
 var updateModule string
 
-const CheckVersionDisableEnvVar = "REGAL_FEATURES_REMOTE_CHECK_VERSION_DISABLE"
+const CheckVersionDisableEnvVar = "REGAL_DISABLE_VERSION_CHECK"
 
 type Options struct {
 	CurrentVersion string

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,186 @@
+//nolint:errcheck
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/open-policy-agent/opa/rego"
+
+	_ "embed"
+)
+
+//go:embed update.rego
+var updateModule string
+
+const CheckAndWarnIgnoreVariable = "REGAL_FEATURES_REMOTE_CHECK_VERSION"
+
+type Options struct {
+	CurrentVersion string
+	CurrentTime    time.Time
+
+	StateDir string
+
+	ReleaseServerHost string
+	ReleaseServerPath string
+
+	CTAURLPrefix string
+
+	Debug bool
+}
+
+type latestVersionFileContents struct {
+	LatestVersion string    `json:"latest_version"`
+	CheckedAt     time.Time `json:"checked_at"`
+}
+
+func CheckAndWarn(opts Options, w io.Writer) {
+	// this is a shortcut heuristic to avoid and version checking
+	// when in dev/test etc.
+	if !strings.HasPrefix(opts.CurrentVersion, "v") {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	latestVersion, err := getLatestVersion(ctx, opts)
+	if err != nil {
+		if opts.Debug {
+			w.Write([]byte(err.Error()))
+		}
+
+		return
+	}
+
+	regoArgs := []func(*rego.Rego){
+		rego.Module("update.rego", updateModule),
+		rego.Query(`data.update.needs_update`),
+		rego.Input(map[string]interface{}{
+			"current_version": opts.CurrentVersion,
+			"latest_version":  latestVersion,
+		}),
+	}
+
+	rs, err := rego.New(regoArgs...).Eval(context.Background())
+	if err != nil {
+		if opts.Debug {
+			w.Write([]byte(err.Error()))
+		}
+
+		return
+	}
+
+	if !rs.Allowed() {
+		if opts.Debug {
+			w.Write([]byte("Regal is up to date"))
+		}
+
+		return
+	}
+
+	ctaURLPrefix := "https://github.com/StyraInc/regal/releases/tag/"
+	if opts.CTAURLPrefix != "" {
+		ctaURLPrefix = opts.CTAURLPrefix
+	}
+
+	ctaURL := ctaURLPrefix + latestVersion
+
+	tmpl := `A new version of Regal is available (%s). You are running %s.
+See %s for the latest release.
+`
+
+	w.Write([]byte(fmt.Sprintf(tmpl, latestVersion, opts.CurrentVersion, ctaURL)))
+}
+
+func getLatestVersion(ctx context.Context, opts Options) (string, error) {
+	if opts.StateDir != "" {
+		// first, attempt to get the file from previous invocations to save on remote calls
+		latestVersionFilePath := filepath.Join(opts.StateDir, "latest_version.json")
+
+		_, err := os.Stat(latestVersionFilePath)
+		if err == nil {
+			var preExistingState latestVersionFileContents
+
+			file, err := os.Open(latestVersionFilePath)
+			if err != nil {
+				return "", fmt.Errorf("failed to open file: %w", err)
+			}
+
+			err = json.NewDecoder(file).Decode(&preExistingState)
+			if err != nil {
+				return "", fmt.Errorf("failed to decode existing version state file: %w", err)
+			}
+
+			if opts.CurrentTime.Sub(preExistingState.CheckedAt) < 3*24*time.Hour {
+				return preExistingState.LatestVersion, nil
+			}
+		}
+	}
+
+	client := http.Client{}
+
+	releaseServerHost := "https://api.github.com"
+	if opts.ReleaseServerHost != "" {
+		releaseServerHost = strings.TrimSuffix(opts.ReleaseServerHost, "/")
+
+		if !strings.HasPrefix(releaseServerHost, "http") {
+			releaseServerHost = "https://" + releaseServerHost
+		}
+	}
+
+	releaseServerURL, err := url.Parse(releaseServerHost)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse release server URL: %w", err)
+	}
+
+	releaseServerPath := "/repos/styrainc/regal/releases/latest"
+	if opts.ReleaseServerPath != "" {
+		releaseServerPath = opts.ReleaseServerPath
+	}
+
+	releaseServerURL.Path = releaseServerPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releaseServerURL.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var responseData struct {
+		TagName string `json:"tag_name"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&responseData)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	stateBs, err := json.MarshalIndent(latestVersionFileContents{
+		LatestVersion: responseData.TagName,
+		CheckedAt:     opts.CurrentTime,
+	}, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal state file: %w", err)
+	}
+
+	err = os.WriteFile(opts.StateDir+"/latest_version.json", stateBs, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	return responseData.TagName, nil
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -21,7 +21,7 @@ import (
 //go:embed update.rego
 var updateModule string
 
-const CheckAndWarnIgnoreVariable = "REGAL_FEATURES_REMOTE_CHECK_VERSION"
+const CheckVersionDisableEnvVar = "REGAL_FEATURES_REMOTE_CHECK_VERSION_DISABLE"
 
 type Options struct {
 	CurrentVersion string

--- a/internal/update/update.rego
+++ b/internal/update/update.rego
@@ -1,0 +1,14 @@
+package update
+
+import rego.v1
+
+current_version := trim(input.current_version, "v")
+
+latest_version := trim(input.latest_version, "v")
+
+default needs_update := false
+
+needs_update if {
+	semver.is_valid(current_version)
+	semver.compare(current_version, latest_version) == -1
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,127 @@
+package update
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCheckAndWarn(t *testing.T) {
+	t.Parallel()
+
+	remoteCalls := 0
+
+	localReleasesServer := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, err := w.Write([]byte(`{"tag_name": "v0.2.0"}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			remoteCalls++
+		}),
+	)
+
+	w := bytes.NewBuffer(nil)
+
+	tempStateDir := t.TempDir()
+
+	opts := Options{
+		CurrentVersion: "v0.1.0",
+		CurrentTime:    time.Now().UTC(),
+		StateDir:       tempStateDir,
+
+		ReleaseServerHost: localReleasesServer.URL,
+		ReleaseServerPath: "/repos/styrainc/regal/releases/latest",
+
+		CTAURLPrefix: "https://github.com/StyraInc/regal/releases/tag/",
+
+		Debug: true,
+	}
+
+	CheckAndWarn(opts, w)
+
+	output := w.String()
+
+	if remoteCalls != 1 {
+		t.Errorf("expected 1 remote call, got %d", remoteCalls)
+	}
+
+	expectedOutput := `A new version of Regal is available (v0.2.0). You are running v0.1.0.
+See https://github.com/StyraInc/regal/releases/tag/v0.2.0 for the latest release.`
+
+	if !strings.Contains(output, expectedOutput) {
+		t.Fatalf("expected output to contain\n%s,\ngot\n%s", expectedOutput, output)
+	}
+
+	// run the function again and check that the state is loaded from disk
+	w = bytes.NewBuffer(nil)
+	CheckAndWarn(opts, w)
+
+	if remoteCalls != 1 {
+		t.Errorf("expected remote to only be called once, got %d", remoteCalls)
+	}
+
+	output = w.String()
+
+	// the same output is expected based on the data on disk
+	if !strings.Contains(output, expectedOutput) {
+		t.Fatalf("expected output to contain\n%s,\ngot\n%s", expectedOutput, output)
+	}
+
+	// update the time to sometime in the future
+	opts.CurrentTime = opts.CurrentTime.Add(4 * 24 * time.Hour)
+
+	// run the function again and check that the state is loaded from the remote again
+	w = bytes.NewBuffer(nil)
+	CheckAndWarn(opts, w)
+
+	if remoteCalls != 2 {
+		t.Errorf("expected remote to be called again, got %d", remoteCalls)
+	}
+
+	// the same output is expected again
+	if !strings.Contains(output, expectedOutput) {
+		t.Fatalf("expected output to contain\n%s,\ngot\n%s", expectedOutput, output)
+	}
+
+	// if the version is not a semver, then there should be no output
+	opts.CurrentVersion = "not-semver"
+
+	w = bytes.NewBuffer(nil)
+	CheckAndWarn(opts, w)
+
+	output = w.String()
+
+	if output != "" {
+		t.Fatalf("expected no output, got\n%s", output)
+	}
+
+	// if the version is greater than the latest version, then there should be no output
+	opts.CurrentVersion = "v0.3.0"
+	opts.Debug = false
+
+	w = bytes.NewBuffer(nil)
+	CheckAndWarn(opts, w)
+
+	output = w.String()
+
+	if output != "" {
+		t.Fatalf("expected no output, got\n%s", output)
+	}
+
+	// if the version is the same as the latest version, then there should be no output
+	opts.CurrentVersion = "v0.2.0"
+
+	w = bytes.NewBuffer(nil)
+	CheckAndWarn(opts, w)
+
+	output = w.String()
+
+	if output != "" {
+		t.Fatalf("expected no output, got\n%s", output)
+	}
+}

--- a/pkg/config/bundle.go
+++ b/pkg/config/bundle.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 
 	"dario.cat/mergo"
+
 	"github.com/open-policy-agent/opa/bundle"
+
 	"github.com/styrainc/regal/internal/util"
 )
 
@@ -28,11 +30,9 @@ func LoadConfigWithDefaultsFromBundle(regalBundle *bundle.Bundle, userConfig *Co
 		return Config{}, fmt.Errorf("failed to convert config from map: %w", err)
 	}
 
-	if defaultConfig.Capabilities == nil {
-		defaultConfig.Capabilities = CapabilitiesForThisVersion()
-	}
-
 	if userConfig == nil {
+		defaultConfig.Capabilities = CapabilitiesForThisVersion()
+
 		return defaultConfig, nil
 	}
 
@@ -41,6 +41,10 @@ func LoadConfigWithDefaultsFromBundle(regalBundle *bundle.Bundle, userConfig *Co
 	err = mergo.Merge(&defaultConfig, userConfig, mergo.WithOverride)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to merge user config: %w", err)
+	}
+
+	if defaultConfig.Capabilities == nil {
+		defaultConfig.Capabilities = CapabilitiesForThisVersion()
 	}
 
 	// adopt user rule levels based on config and defaults

--- a/pkg/config/bundle.go
+++ b/pkg/config/bundle.go
@@ -1,0 +1,107 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"dario.cat/mergo"
+	"github.com/open-policy-agent/opa/bundle"
+	"github.com/styrainc/regal/internal/util"
+)
+
+func LoadConfigWithDefaultsFromBundle(regalBundle *bundle.Bundle, userConfig *Config) (Config, error) {
+	path := []string{"regal", "config", "provided"}
+
+	bundled, err := util.SearchMap(regalBundle.Data, path)
+	if err != nil {
+		return Config{}, fmt.Errorf("config path not found %s: %w", strings.Join(path, "."), err)
+	}
+
+	bundledConf, ok := bundled.(map[string]any)
+	if !ok {
+		return Config{}, errors.New("expected 'rules' of object type")
+	}
+
+	defaultConfig, err := FromMap(bundledConf)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to convert config from map: %w", err)
+	}
+
+	if defaultConfig.Capabilities == nil {
+		defaultConfig.Capabilities = CapabilitiesForThisVersion()
+	}
+
+	if userConfig == nil {
+		return defaultConfig, nil
+	}
+
+	providedRuleLevels := providedConfLevels(&defaultConfig)
+
+	err = mergo.Merge(&defaultConfig, userConfig, mergo.WithOverride)
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to merge user config: %w", err)
+	}
+
+	// adopt user rule levels based on config and defaults
+	// If the user configuration contains rules with the level unset, copy the level from the provided configuration
+	extractUserRuleLevels(userConfig, &defaultConfig, providedRuleLevels)
+
+	return defaultConfig, nil
+}
+
+// extractUserRuleLevels uses defaulting config and per-rule levels from user configuration to set the level for each
+// rule.
+func extractUserRuleLevels(userConfig *Config, mergedConf *Config, providedRuleLevels map[string]string) {
+	for categoryName, rulesByCategory := range mergedConf.Rules {
+		for ruleName, rule := range rulesByCategory {
+			var providedLevel string
+
+			var ok bool
+
+			if providedLevel, ok = providedRuleLevels[ruleName]; !ok {
+				continue
+			}
+
+			// use the level from the provided configuration as the fallback
+			selectedRuleLevel := providedLevel
+
+			var userHasConfiguredRule bool
+
+			if _, ok := userConfig.Rules[categoryName]; ok {
+				_, userHasConfiguredRule = userConfig.Rules[categoryName][ruleName]
+			}
+
+			if userHasConfiguredRule && userConfig.Rules[categoryName][ruleName].Level != "" {
+				// if the user config has a level for the rule, use that
+				selectedRuleLevel = userConfig.Rules[categoryName][ruleName].Level
+			} else if categoryDefault, ok := mergedConf.Defaults.Categories[categoryName]; ok {
+				// if the config has a default level for the category, use that
+				if categoryDefault.Level != "" {
+					selectedRuleLevel = categoryDefault.Level
+				}
+			} else if mergedConf.Defaults.Global.Level != "" {
+				// if the config has a global default level, use that
+				selectedRuleLevel = mergedConf.Defaults.Global.Level
+			}
+
+			rule.Level = selectedRuleLevel
+			mergedConf.Rules[categoryName][ruleName] = rule
+		}
+	}
+}
+
+// Copy the level of each rule from the provided configuration.
+func providedConfLevels(conf *Config) map[string]string {
+	ruleLevels := make(map[string]string)
+
+	for categoryName, rulesByCategory := range conf.Rules {
+		for ruleName := range rulesByCategory {
+			// Note that this assumes all rules have unique names,
+			// which we'll likely always want for provided rules
+			ruleLevels[ruleName] = conf.Rules[categoryName][ruleName].Level
+		}
+	}
+
+	return ruleLevels
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ type Features struct {
 }
 
 type RemoteFeatures struct {
-	CheckVersion bool `json:"check_version,omitempty" yaml:"check_version,omitempty"`
+	CheckVersion bool `json:"check-version,omitempty" yaml:"check-version,omitempty"`
 }
 
 func (d *Default) mapToConfig(result any) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,7 +49,7 @@ type Default struct {
 }
 
 type Features struct {
-	RemoteFeatures *RemoteFeatures `json:"remote_features,omitempty" yaml:"remote_features,omitempty"`
+	Remote *RemoteFeatures `json:"remote,omitempty" yaml:"remote,omitempty"`
 }
 
 type RemoteFeatures struct {
@@ -177,14 +177,6 @@ func FromMap(confMap map[string]any) (Config, error) {
 	return conf, nil
 }
 
-func (config *Config) SetDefaults() {
-	config.Features = &Features{
-		RemoteFeatures: &RemoteFeatures{
-			CheckVersion: true,
-		},
-	}
-}
-
 func (config Config) MarshalYAML() (any, error) {
 	var unstructuredConfig map[string]any
 
@@ -250,7 +242,7 @@ type marshallingIntermediary struct {
 	Features struct {
 		RemoteFeatures struct {
 			CheckVersion bool `yaml:"check_version"`
-		} `yaml:"remote_features"`
+		} `yaml:"remote"`
 	} `yaml:"features"`
 }
 
@@ -329,7 +321,7 @@ func (config *Config) UnmarshalYAML(value *yaml.Node) error {
 	// feature defaults
 	if result.Features.RemoteFeatures.CheckVersion {
 		config.Features = &Features{
-			RemoteFeatures: &RemoteFeatures{
+			Remote: &RemoteFeatures{
 				CheckVersion: true,
 			},
 		}

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Dir is the config directory that will be used for user-wide configuration.
+// This is different from the .regal directories that are searched for when
+// linting.
+func GlobalDir() string {
+	cfgDir, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	regalDir := filepath.Join(cfgDir, ".config", "regal")
+	if _, err := os.Stat(regalDir); os.IsNotExist(err) {
+		if err := os.Mkdir(regalDir, os.ModePerm); err != nil {
+			return ""
+		}
+	}
+
+	return regalDir
+}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -80,7 +80,7 @@ func NewLinter() Linter {
 	}
 }
 
-// NewEmptyLinter creates a linter with no rule bundles
+// NewEmptyLinter creates a linter with no rule bundles.
 func NewEmptyLinter() Linter {
 	return Linter{}
 }

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 
-	"dario.cat/mergo"
 	"github.com/gobwas/glob"
 	"gopkg.in/yaml.v3"
 
@@ -42,7 +41,7 @@ type Linter struct {
 	rootDir              string
 	ruleBundles          []*bundle.Bundle
 	userConfig           *config.Config
-	combinedConfig       *config.Config
+	combinedCfg          *config.Config
 	dataBundle           *bundle.Bundle
 	customRulesPaths     []string
 	customRuleFS         fs.FS
@@ -222,12 +221,10 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 		return report.Report{}, errors.New("nothing provided to lint")
 	}
 
-	conf, err := l.mergedConfig()
+	conf, err := l.combinedConfig()
 	if err != nil {
 		return report.Report{}, fmt.Errorf("failed to merge config: %w", err)
 	}
-
-	l.combinedConfig = &conf
 
 	l.dataBundle = &bundle.Bundle{
 		Manifest: bundle.Manifest{
@@ -236,7 +233,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 		},
 		Data: map[string]any{
 			"internal": map[string]any{
-				"combined_config": config.ToMap(*l.combinedConfig),
+				"combined_config": config.ToMap(*conf),
 				"capabilities":    rio.ToMap(config.CapabilitiesForThisVersion()),
 			},
 		},
@@ -860,121 +857,34 @@ func resultSetToReport(resultSet rego.ResultSet) (report.Report, error) {
 	return r, nil
 }
 
-func (l Linter) readProvidedConfig() (config.Config, error) {
+func (l Linter) combinedConfig() (*config.Config, error) {
+	if l.combinedCfg != nil {
+		return l.combinedCfg, nil
+	}
+
 	regalBundle, err := l.getBundleByName("regal")
 	if err != nil {
-		return config.Config{}, fmt.Errorf("failed to get regal bundle: %w", err)
+		return &config.Config{}, fmt.Errorf("failed to get regal bundle: %w", err)
 	}
 
-	path := []string{"regal", "config", "provided"}
-
-	bundled, err := util.SearchMap(regalBundle.Data, path)
+	mergedConf, err := config.LoadConfigWithDefaultsFromBundle(regalBundle, l.userConfig)
 	if err != nil {
-		return config.Config{}, fmt.Errorf("config path not found %s: %w", strings.Join(path, "."), err)
-	}
-
-	bundledConf, ok := bundled.(map[string]any)
-	if !ok {
-		return config.Config{}, errors.New("expected 'rules' of object type")
-	}
-
-	return config.FromMap(bundledConf) //nolint:wrapcheck
-}
-
-func (l Linter) mergedConfig() (config.Config, error) {
-	if l.combinedConfig != nil {
-		return *l.combinedConfig, nil
-	}
-
-	mergedConf, err := l.readProvidedConfig()
-	if err != nil {
-		return config.Config{}, fmt.Errorf("failed to read provided config: %w", err)
-	}
-
-	providedRuleLevels := providedConfLevels(mergedConf)
-
-	if l.userConfig != nil {
-		err = mergo.Merge(&mergedConf, l.userConfig, mergo.WithOverride)
-		if err != nil {
-			return config.Config{}, fmt.Errorf("failed to merge config: %w", err)
-		}
-
-		// adopt user rule levels based on config and defaults
-		// If the user configuration contains rules with the level unset, copy the level from the provided configuration
-		extractUserRuleLevels(l.userConfig, &mergedConf, providedRuleLevels)
-	}
-
-	if mergedConf.Capabilities == nil {
-		mergedConf.Capabilities = config.CapabilitiesForThisVersion()
+		return &config.Config{}, fmt.Errorf("failed to read provided config: %w", err)
 	}
 
 	if l.debugMode {
 		bs, err := yaml.Marshal(mergedConf)
 		if err != nil {
-			return config.Config{}, fmt.Errorf("failed to marshal config: %w", err)
+			return &config.Config{}, fmt.Errorf("failed to marshal config: %w", err)
 		}
 
 		log.Println("merged provided and user config:")
 		log.Println(string(bs))
 	}
 
-	return mergedConf, nil
-}
+	l.combinedCfg = &mergedConf
 
-// extractUserRuleLevels uses defaulting config and per-rule levels from user configuration to set the level for each
-// rule.
-func extractUserRuleLevels(userConfig *config.Config, mergedConf *config.Config, providedRuleLevels map[string]string) {
-	for categoryName, rulesByCategory := range mergedConf.Rules {
-		for ruleName, rule := range rulesByCategory {
-			var providedLevel string
-
-			var ok bool
-
-			if providedLevel, ok = providedRuleLevels[ruleName]; !ok {
-				continue
-			}
-
-			// use the level from the provided configuration as the fallback
-			selectedRuleLevel := providedLevel
-
-			var userHasConfiguredRule bool
-
-			if _, ok := userConfig.Rules[categoryName]; ok {
-				_, userHasConfiguredRule = userConfig.Rules[categoryName][ruleName]
-			}
-
-			if userHasConfiguredRule && userConfig.Rules[categoryName][ruleName].Level != "" {
-				// if the user config has a level for the rule, use that
-				selectedRuleLevel = userConfig.Rules[categoryName][ruleName].Level
-			} else if categoryDefault, ok := mergedConf.Defaults.Categories[categoryName]; ok {
-				// if the config has a default level for the category, use that
-				if categoryDefault.Level != "" {
-					selectedRuleLevel = categoryDefault.Level
-				}
-			} else if mergedConf.Defaults.Global.Level != "" {
-				// if the config has a global default level, use that
-				selectedRuleLevel = mergedConf.Defaults.Global.Level
-			}
-
-			rule.Level = selectedRuleLevel
-			mergedConf.Rules[categoryName][ruleName] = rule
-		}
-	}
-}
-
-// Copy the level of each rule from the provided configuration.
-func providedConfLevels(conf config.Config) map[string]string {
-	ruleLevels := make(map[string]string)
-
-	for categoryName, rulesByCategory := range conf.Rules {
-		for ruleName := range rulesByCategory {
-			// Note that this assumes all rules have unique names,
-			// which we'll likely always want for provided rules
-			ruleLevels[ruleName] = conf.Rules[categoryName][ruleName].Level
-		}
-	}
-
-	return ruleLevels
+	return l.combinedCfg, nil
 }
 
 func (l Linter) enabledGoRules() ([]rules.Rule, error) {
@@ -1003,12 +913,12 @@ func (l Linter) enabledGoRules() ([]rules.Rule, error) {
 		return enabledGoRules, nil
 	}
 
-	conf, err := l.mergedConfig()
+	conf, err := l.combinedConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create merged config: %w", err)
 	}
 
-	for _, rule := range rules.AllGoRules(conf) {
+	for _, rule := range rules.AllGoRules(*conf) {
 		// disabling specific rule has the highest precedence
 		if util.Contains(l.disable, rule.Name()) {
 			continue

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -80,6 +80,11 @@ func NewLinter() Linter {
 	}
 }
 
+// NewEmptyLinter creates a linter with no rule bundles
+func NewEmptyLinter() Linter {
+	return Linter{}
+}
+
 // WithInputPaths sets the inputPaths to lint. Note that these will be
 // filtered according to the ignore options.
 func (l Linter) WithInputPaths(paths []string) Linter {

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -438,7 +438,7 @@ func TestLintMergedConfigInheritsLevelFromProvided(t *testing.T) {
 		WithUserConfig(userConfig).
 		WithInputModules(&input)
 
-	mergedConfig := testutil.Must(linter.mergedConfig())(t)
+	mergedConfig := testutil.Must(linter.combinedConfig())(t)
 
 	// Since no level was provided, "error" should be inherited from the provided configuration for the rule
 	if mergedConfig.Rules["style"]["file-length"].Level != "error" {
@@ -477,7 +477,7 @@ func TestLintMergedConfigUsesProvidedDefaults(t *testing.T) {
 		WithUserConfig(userConfig).
 		WithInputModules(&input)
 
-	mergedConfig := testutil.Must(linter.mergedConfig())(t)
+	mergedConfig := testutil.Must(linter.combinedConfig())(t)
 
 	// specifically configured rule should not be affected by the default
 	if mergedConfig.Rules["style"]["opa-fmt"].Level != "warning" {


### PR DESCRIPTION
This adds functionality to the regal LS and lint commands what will check the current version against the latest release in GH.

In order to keep the number of requests down, the version is cached to disk in the .regal dir. The task runs in another goroutine to keep things fast too.

Config has been updated with a features key, and
REGAL_FEATURES_REMOTE_CHECK_VERSION can also be set to disable to functionality.

Sharing for review, if we think it looks good, I'll add some docs and we can get this in.

Fixes #802 