### PR TITLE
Fix markdown content rendering for Zed editor

### DIFF
--- a/internal/lsp/hover/hover.go
+++ b/internal/lsp/hover/hover.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/olekukonko/tablewriter"
-
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/types"
 
@@ -83,30 +81,25 @@ func CreateHoverContent(builtin *ast.Builtin) string {
 
 	sb.WriteString("\n\n#### Arguments\n\n")
 
-	table := tablewriter.NewWriter(sb)
-
-	table.SetBorders(tablewriter.Border{Left: true, Top: false, Right: true, Bottom: false})
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
-	table.SetHeader([]string{"Name", "Type", "Description"})
-	table.SetAutoFormatHeaders(false)
-	table.SetAutoWrapText(false)
-	table.SetCenterSeparator("|") // Add Bulk Data
-
-	argsData := make([][]string, 0)
-
 	for _, arg := range builtin.Decl.NamedFuncArgs().Args {
+		sb.WriteString("- ")
+
 		if n, ok := arg.(*types.NamedType); ok {
-			argsData = append(argsData, []string{"`" + n.Name + "`", n.Type.String(), n.Descr})
+			sb.WriteString("`")
+			sb.WriteString(n.Name)
+			sb.WriteString("` ")
+			sb.WriteString(n.Type.String())
+
+			if n.Descr != "" {
+				sb.WriteString(" — ")
+				sb.WriteString(n.Descr)
+			}
 		} else {
-			argsData = append(argsData, []string{"`" + arg.String() + "`", "", ""})
+			sb.WriteString(arg.String())
 		}
+
+		sb.WriteString("\n")
 	}
-
-	table.AppendBulk(argsData)
-	table.Render()
-
-	table.ClearRows()
 
 	sb.WriteString("\n\nReturns ")
 

--- a/internal/lsp/hover/testdata/hover/graphreachable.md
+++ b/internal/lsp/hover/testdata/hover/graphreachable.md
@@ -9,10 +9,8 @@ Computes the set of reachable nodes in the graph from a set of starting nodes.
 
 #### Arguments
 
-| Name      | Type                                   | Description                                              |
-|-----------|----------------------------------------|----------------------------------------------------------|
-| `graph`   | object[any: any<array[any], set[any]>] | object containing a set or array of neighboring vertices |
-| `initial` | any<array[any], set[any]>              | set or array of root vertices                            |
+- `graph` object[any: any<array[any], set[any]>] — object containing a set or array of neighboring vertices
+- `initial` any<array[any], set[any]> — set or array of root vertices
 
 
 Returns `output` of type `set[any]`: set of vertices reachable from the `initial` vertices in the directed `graph`

--- a/internal/lsp/hover/testdata/hover/indexof.md
+++ b/internal/lsp/hover/testdata/hover/indexof.md
@@ -9,10 +9,8 @@ Returns the index of a substring contained inside a string.
 
 #### Arguments
 
-| Name       | Type   | Description           |
-|------------|--------|-----------------------|
-| `haystack` | string | string to search in   |
-| `needle`   | string | substring to look for |
+- `haystack` string — string to search in
+- `needle` string — substring to look for
 
 
 Returns `output` of type `number`: index of first occurrence, `-1` if not found

--- a/internal/lsp/hover/testdata/hover/jsonfilter.md
+++ b/internal/lsp/hover/testdata/hover/jsonfilter.md
@@ -9,10 +9,8 @@ Filters the object. For example: `json.filter({"a": {"b": "x", "c": "y"}}, ["a/b
 
 #### Arguments
 
-| Name     | Type                                                              | Description       |
-|----------|-------------------------------------------------------------------|-------------------|
-| `object` | object[any: any]                                                  |                   |
-| `paths`  | any<array[any<string, array[any]>], set[any<string, array[any]>]> | JSON string paths |
+- `object` object[any: any]
+- `paths` any<array[any<string, array[any]>], set[any<string, array[any]>]> — JSON string paths
 
 
 Returns `filtered` of type `any`: remaining data from `object` with only keys specified in `paths`


### PR DESCRIPTION
Since Zed doesn't render markdown tables yet, we'll just present the arguments as a list instead. We could make an exception for Zed, but I think I prefer having this be consistent across editors, and the table format wasn't a requirement here.

Fixes #827

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->