### PR TITLE
Don't call completion providers inside of comments

### DIFF
--- a/internal/lsp/completions/manager_test.go
+++ b/internal/lsp/completions/manager_test.go
@@ -3,6 +3,8 @@ package completions
 import (
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/completions/providers"
 	"github.com/styrainc/regal/internal/lsp/types"
@@ -42,5 +44,44 @@ func TestManager(t *testing.T) {
 	comp := completions[0]
 	if comp.Label != "package" {
 		t.Fatalf("Expected label to be 'package', got: %v", comp.Label)
+	}
+}
+
+func TestManagerEarlyExitInsideComment(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+	fileURI := "file:///foo/bar/file.rego"
+
+	fileContents := `package p
+
+import rego.v1 # modern rego i
+`
+
+	module := ast.MustParseModule(fileContents)
+
+	c.SetFileContents(fileURI, fileContents)
+	c.SetModule(fileURI, module)
+
+	mgr := NewManager(c, &ManagerOptions{})
+	mgr.RegisterProvider(&providers.Import{})
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: fileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 30,
+		},
+	}
+
+	completions, err := mgr.Run(completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if len(completions) != 0 {
+		t.Errorf("Expected no completions, got: %v", completions)
 	}
 }


### PR DESCRIPTION
It seems like this is handled client side by some editors, but Zed triggered completion requests inside of comments. While we could have each provider handle this, I think an early exit in the manager already is a better solution, as there's unlikely to be any provider that wants to do suggestions in a comment. If that changes in the future, we'll handle it then.

Fixes #826

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->