### PR TITLE
Don't suggest `if` or `contains` following import

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,7 @@ linters:
     - varnamelen
     - nonamedreturns
     - testpackage
+    - goconst
     - gochecknoinits
     - gomnd
     - mnd

--- a/internal/lsp/completions/providers/import.go
+++ b/internal/lsp/completions/providers/import.go
@@ -17,12 +17,15 @@ func (*Import) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([
 
 	_, currentLine := completionLineHelper(c, fileURI, params.Position.Line)
 
-	if params.Context.TriggerKind == completion.Invoked && params.Position.Character == 0 {
+	// the user manually invoked completions at the beginning of an empty line
+	if params.Position.Character == 0 && strings.TrimSpace(currentLine) == "" {
 		return importCompletionItem(params), nil
 	}
 
 	// the user must type i before we provide completions
-	if params.Position.Line != 0 && strings.HasPrefix(currentLine, "i") {
+	if params.Position.Character != 0 &&
+		strings.HasPrefix(currentLine, "i") &&
+		!strings.HasPrefix(currentLine, "import ") {
 		return importCompletionItem(params), nil
 	}
 

--- a/internal/lsp/completions/providers/packagerefs.go
+++ b/internal/lsp/completions/providers/packagerefs.go
@@ -47,9 +47,12 @@ func (*PackageRefs) Run(c *cache.Cache, params types.CompletionParams, _ *Option
 				continue
 			}
 
-			// only suggest packages that match the last word
-			// the user has typed.
-			if !strings.HasPrefix(ref.Label, lastWord) {
+			// if the user has not typed in any word, they've triggered
+			// completion suggestions manually
+			if strings.TrimSpace(lastWord) != "" &&
+				// otherwise, only suggest packages that match the last
+				// word the user has typed.
+				!strings.HasPrefix(ref.Label, lastWord) {
 				continue
 			}
 

--- a/internal/lsp/completions/providers/ruleheadkeyword.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword.go
@@ -31,6 +31,11 @@ func (*RuleHeadKeyword) Run(c *cache.Cache, params types.CompletionParams, _ *Op
 		return []types.CompletionItem{}, nil
 	}
 
+	firstWord := strings.TrimSpace(words[0])
+	if firstWord == "package" || firstWord == "import" {
+		return []types.CompletionItem{}, nil
+	}
+
 	lastWord := words[len(words)-1]
 
 	const keyWdContains = "contains"


### PR DESCRIPTION
Also:
- improve handling of manually invoked suggestions
- don't suggest "import" after "import "

Fixes #830

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->