### PR TITLE
Rule: `if-object-literal`

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The following rules are currently available:
 | bugs        | [deprecated-builtin](https://docs.styra.com/regal/rules/bugs/deprecated-builtin)                      | Avoid using deprecated built-in functions                 |
 | bugs        | [duplicate-rule](https://docs.styra.com/regal/rules/bugs/duplicate-rule)                              | Duplicate rule                                            |
 | bugs        | [if-empty-object](https://docs.styra.com/regal/rules/bugs/if-empty-object)                            | Empty object following `if`                               |
+| bugs        | [if-object-literal](https://docs.styra.com/regal/rules/bugs/if-object-literal)                        | Object literal following `if`                             |
 | bugs        | [impossible-not](https://docs.styra.com/regal/rules/bugs/impossible-not)                              | Impossible `not` condition                                |
 | bugs        | [inconsistent-args](https://docs.styra.com/regal/rules/bugs/inconsistent-args)                        | Inconsistently named function arguments                   |
 | bugs        | [internal-entrypoint](https://docs.styra.com/regal/rules/bugs/internal-entrypoint)                    | Entrypoint can't be marked internal                       |

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -10,6 +10,9 @@ rules:
     duplicate-rule:
       level: error
     if-empty-object:
+      # deprecated with the introduction of if-object-literal
+      level: ignore
+    if-object-literal:
       level: error
     impossible-not:
       level: error

--- a/bundle/regal/rules/bugs/if_object_literal.rego
+++ b/bundle/regal/rules/bugs/if_object_literal.rego
@@ -1,10 +1,6 @@
 # METADATA
-# description: Empty object following `if`
-package regal.rules.bugs["if-empty-object"]
-
-# NOTE: this rule has been deprecated and is no longer enabled by default
-# Use the `if-object-literal` rule instead, which checks for any object,
-# non-empty or not
+# description: Object literal following `if`
+package regal.rules.bugs["if-object-literal"]
 
 import rego.v1
 
@@ -23,7 +19,6 @@ report contains violation if {
 	count(rule.body) == 1
 
 	rule.body[0].terms.type == "object"
-	rule.body[0].terms.value == []
 
 	violation := result.fail(rego.metadata.chain(), result.location(rule))
 }

--- a/bundle/regal/rules/bugs/if_object_literal_test.rego
+++ b/bundle/regal/rules/bugs/if_object_literal_test.rego
@@ -1,0 +1,46 @@
+package regal.rules.bugs["if-object-literal_test"]
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.bugs["if-object-literal"] as rule
+
+test_fail_if_empty_object if {
+	module := ast.with_rego_v1("rule if {}")
+	r := rule.report with input as module
+	r == {{
+		"category": "bugs",
+		"description": "Object literal following `if`",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": "rule if {}"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/if-object-literal", "bugs"),
+		}],
+		"title": "if-object-literal",
+	}}
+}
+
+test_fail_non_empty_object if {
+	module := ast.with_rego_v1(`rule if {"x": input.x}`)
+	r := rule.report with input as module
+	r == {{
+		"category": "bugs",
+		"description": "Object literal following `if`",
+		"level": "error",
+		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": `rule if {"x": input.x}`},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/if-object-literal", "bugs"),
+		}],
+		"title": "if-object-literal",
+	}}
+}
+
+test_success_not_an_object if {
+	module := ast.with_rego_v1(`rule if { true }`)
+	r := rule.report with input as module
+	r == set()
+}

--- a/docs/rules/bugs/if-empty-object.md
+++ b/docs/rules/bugs/if-empty-object.md
@@ -1,5 +1,9 @@
 # if-empty-object
 
+**This rule has been deprecated and replaced by the
+[if-object-literal](https://docs.styra.com/regal/rules/bugs/if-object-literal) rule. Documentation kept here only for
+the sake of posterity.**
+
 **Summary**: Empty object following `if`
 
 **Category**: Bugs

--- a/docs/rules/bugs/if-object-literal.md
+++ b/docs/rules/bugs/if-object-literal.md
@@ -1,0 +1,45 @@
+# if-object-literal
+
+**Summary**: Object literal following `if`
+
+**Category**: Bugs
+
+**Avoid**
+```rego
+package policy
+
+import rego.v1
+
+# {} interpreted as object, not a rule body
+allow if {}
+
+allow if {
+    # perhaps meant to be comparison?
+    # but this too is an object
+    input.x: 10
+}
+```
+
+## Rationale
+
+An object literal immediately following an `if` is almost certainly a mistake, and the intention was likely to express
+a rule body in its place. This isn't too common, but can happen when either an empty object `{}` is all that follows the
+`if`, or an expression in the "body" mistakenly is written as a `key: value` pair.
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  bugs:
+    if-object-literal:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!


### PR DESCRIPTION
This replaces `if-empty-object`, and covers any object literal.

Fixes #822

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->