### PR TITLE
Better support rule head keyword completions

### DIFF
--- a/internal/lsp/completions/providers/ruleheadkeyword_test.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword_test.go
@@ -8,6 +8,57 @@ import (
 	"github.com/styrainc/regal/internal/lsp/types"
 )
 
+func TestRuleHeadKeyword_ManualTriggerAfterRuleName(t *testing.T) {
+	t.Parallel()
+
+	c := cache.NewCache()
+
+	fileContents := `package policy
+
+deny` + " "
+
+	c.SetFileContents(testCaseFileURI, fileContents)
+
+	p := &RuleHeadKeyword{}
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: testCaseFileURI,
+		},
+		Position: types.Position{
+			Line:      2,
+			Character: 4,
+		},
+	}
+
+	completions, err := p.Run(c, completionParams, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	expectedLabels := []string{"contains", "if", ":="}
+
+	if len(completions) != len(expectedLabels) {
+		t.Fatalf("Expected %v completions, got: %v", len(expectedLabels), len(completions))
+	}
+
+	for _, comp := range completions {
+		found := false
+
+		for _, label := range expectedLabels {
+			if comp.Label == label {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			t.Fatalf("Expected label to be one of %v, got: %v", expectedLabels, comp.Label)
+		}
+	}
+}
+
 func TestRuleHeadKeyword_TypedIAfterRuleName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This handles the manual trigger case better.

Fixes https://github.com/StyraInc/regal/issues/811

https://github.com/StyraInc/regal/assets/1774239/e6d7bb88-ca6f-4781-aa8b-71d371e0f7a1


<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->