### PR TITLE
[lsp] Add support for ignored files in ls formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,11 @@ rules:
 
 ### Ignoring Files Globally
 
+**Note**: Ignoring files will disable most language server features
+for those files. Only formatting will remain available.
+Ignored files won't be used for completions, linting, or definitions
+in other files.
+
 If you want to ignore certain files for all rules, you can use the global ignore attribute in your configuration file:
 
 ```yaml

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -374,6 +374,10 @@ type TextDocumentDidOpenParams struct {
 	TextDocument TextDocumentItem `json:"textDocument"`
 }
 
+type TextDocumentDidCloseParams struct {
+	TextDocument TextDocumentItem `json:"textDocument"`
+}
+
 type TextDocumentItem struct {
 	LanguageID string `json:"languageId"`
 	Text       string `json:"text"`


### PR DESCRIPTION
Adding functionality to manage the contents of ignored files when formatting documents.

Addresses some issues with ignored files missed in https://github.com/StyraInc/regal/pull/837