### PR TITLE
Clear the store when reloading config

### DIFF
--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
@@ -142,5 +142,6 @@ items := [item |
 			},
 			"newText": ref,
 		},
+		"_regal": {"provider": "rulerefs"},
 	}
 ]

--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
@@ -111,6 +111,9 @@ items := [item |
 	line != ""
 	location.in_rule_body(line)
 
+	# \W is used here to match ( in the case of func() := ..., as well as the space in the case of rule := ...
+	first_word := regex.split(`\W+`, trim_space(line))[0]
+
 	last_word := regal.last(regex.split(`\s+`, trim_space(line)))
 
 	prefix := defermine_ref_prefix(last_word)
@@ -121,6 +124,9 @@ items := [item |
 	some ref in sort(grouped_refs[group_size])
 
 	startswith(ref, prefix)
+
+	# this is to avoid suggesting a recursive rule, e.g. rule := rule, or func() := func()
+	ref != first_word
 
 	item := {
 		"label": ref,

--- a/internal/lsp/completions/manager_test.go
+++ b/internal/lsp/completions/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage/inmem"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/completions/providers"
@@ -83,5 +84,83 @@ func TestManagerEarlyExitInsideComment(t *testing.T) {
 
 	if len(completions) != 0 {
 		t.Errorf("Expected no completions, got: %v", completions)
+	}
+}
+
+func TestManagerRankCompletions(t *testing.T) {
+	t.Parallel()
+
+	file1Contents := `package example
+
+import rego.v1
+
+foo := true
+`
+
+	file1 := ast.MustParseModule(file1Contents)
+
+	file2Contents := `package example2
+
+import rego.v1
+
+bar := data.example.foo
+`
+
+	file2 := ast.MustParseModule(file2Contents)
+
+	store := inmem.NewFromObject(map[string]interface{}{
+		"workspace": map[string]interface{}{
+			"parsed": map[string]interface{}{
+				"file:///file1.rego": file1,
+				"file:///file2.rego": file2,
+			},
+		},
+	})
+
+	policyProvider := providers.NewPolicy(store)
+
+	file2ContentsEdited := `package example2
+
+import rego.v1
+
+bar := data.example.foo
+
+baz := data.
+`
+
+	c := cache.NewCache()
+
+	c.SetFileContents("file:///file2.rego", file2ContentsEdited)
+	c.SetUsedRefs("file:///file2.rego", []string{"data.example.foo"})
+
+	mgr := NewManager(c, &ManagerOptions{})
+	mgr.RegisterProvider(&providers.UsedRefs{})
+	mgr.RegisterProvider(policyProvider)
+
+	completionParams := types.CompletionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: "file:///file2.rego",
+		},
+		Position: types.Position{
+			Line:      6,
+			Character: 13,
+		},
+	}
+
+	completions, err := mgr.Run(completionParams, &providers.Options{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	count := 0
+
+	for _, item := range completions {
+		if item.Label == "data.example.foo" {
+			count++
+		}
+	}
+
+	if count != 1 {
+		t.Fatalf("Expected exactly one completion for 'data.example.foo', got: %v", completions)
 	}
 }

--- a/internal/lsp/completions/providers/used_refs.go
+++ b/internal/lsp/completions/providers/used_refs.go
@@ -59,6 +59,9 @@ func (*UsedRefs) Run(c *cache.Cache, params types.CompletionParams, _ *Options) 
 				},
 				NewText: ref,
 			},
+			Regal: &types.CompletionItemRegalMetadata{
+				Provider: "usedrefs",
+			},
 		})
 	}
 

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -139,8 +139,8 @@ allow = true
 		)
 	}
 
-	if ls.clientRootURI != request.RootURI {
-		t.Fatalf("expected client root URI to be %s, got %s", request.RootURI, ls.clientRootURI)
+	if ls.workspaceRootURI != request.RootURI {
+		t.Fatalf("expected client root URI to be %s, got %s", request.RootURI, ls.workspaceRootURI)
 	}
 
 	// validate that the file contents from the workspace are loaded during the initialize request
@@ -429,24 +429,6 @@ ignore:
 		}
 	}
 
-	// validate that the client received empty diagnostics for the ignored file
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case diags := <-ignoredFileMessages:
-			success = testRequestDataCodes(t, diags, ignoredRegoURI, []string{})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for empty ignored file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
 	// 3. Client sends textDocument/didChange notification with new contents for authz.rego
 	// no response to the call is expected
 	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
@@ -632,8 +614,8 @@ allow := true
 		t.Fatalf("failed to send initialize request: %s", err)
 	}
 
-	if ls.clientRootURI != request.RootURI {
-		t.Fatalf("expected client root URI to be %s, got %s", request.RootURI, ls.clientRootURI)
+	if ls.workspaceRootURI != request.RootURI {
+		t.Fatalf("expected client root URI to be %s, got %s", request.RootURI, ls.workspaceRootURI)
 	}
 
 	// Client sends initialized notification
@@ -692,11 +674,11 @@ allow := true
 	}
 }
 
-func testRequestDataCodes(t *testing.T, requestData types.FileDiagnostics, uri string, codes []string) bool {
+func testRequestDataCodes(t *testing.T, requestData types.FileDiagnostics, fileURI string, codes []string) bool {
 	t.Helper()
 
-	if requestData.URI != uri {
-		t.Log("expected diagnostics to be sent for", uri, "got", requestData.URI)
+	if requestData.URI != fileURI {
+		t.Log("expected diagnostics to be sent for", fileURI, "got", requestData.URI)
 
 		return false
 	}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -141,6 +141,15 @@ type CompletionItem struct {
 	// as an exclusive completion. This is not part of the LSP spec, but used in regal providers
 	// to indicate that the completion item is the only valid completion.
 	Mandatory bool `json:"-"`
+
+	// Regal is used to store regal-specific metadata about the completion item.
+	// This is not part of the LSP spec, but used in the manager to post process
+	// items before returning them to the client.
+	Regal *CompletionItemRegalMetadata `json:"_regal,omitempty"`
+}
+
+type CompletionItemRegalMetadata struct {
+	Provider string `json:"provider"`
 }
 
 type CompletionItemLabelDetails struct {


### PR DESCRIPTION
This also ensures that config is loaded before doing the initial load of the workspace. This means that loaded ignored files do not need to then be immediately dropped.

Also

Fixes https://github.com/StyraInc/regal/issues/832

Fixes https://github.com/StyraInc/regal/issues/843
