### PR TITLE
Precompute refs in file at update

### DIFF
--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
@@ -9,17 +9,8 @@ import data.regal.lsp.completion.location
 ref_is_internal(ref) if contains(ref, "._")
 
 workspace_rule_refs contains ref if {
-	some file, parsed in data.workspace.parsed
-
-	package_name := concat(".", [path.value |
-		some i, path in parsed["package"].path
-	])
-
-	some rule in parsed.rules
-
-	rule_ref := ast.ref_to_string(rule.head.ref)
-
-	ref := concat(".", [package_name, rule_ref])
+	some refs in data.workspace.defined_refs
+	some ref in refs
 }
 
 parsed_current_file := data.workspace.parsed[input.regal.file.uri]
@@ -98,10 +89,10 @@ grouped_refs[size] contains ref if {
 	size := count(indexof_n(ref, "."))
 }
 
-default defermine_ref_prefix(_) := ""
+default determine_ref_prefix(_) := ""
 
-defermine_ref_prefix(word) := word if {
-	not word in {":="}
+determine_ref_prefix(word) := word if {
+	word != ":="
 }
 
 items := [item |
@@ -116,7 +107,7 @@ items := [item |
 
 	last_word := regal.last(regex.split(`\s+`, trim_space(line)))
 
-	prefix := defermine_ref_prefix(last_word)
+	prefix := determine_ref_prefix(last_word)
 
 	sorted_counts := sort(object.keys(grouped_refs))
 

--- a/internal/lsp/completions/providers/policy_test.go
+++ b/internal/lsp/completions/providers/policy_test.go
@@ -93,6 +93,10 @@ import data.example
 				"file:///file1.rego": file1,
 				"file:///file2.rego": file2,
 			},
+			"defined_refs": map[string][]string{
+				"file:///file1.rego": {"example.foo"},
+				"file:///file2.rego": {},
+			},
 		},
 	})
 
@@ -135,7 +139,7 @@ allow if {
 		labels = append(labels, item.Label)
 	}
 
-	expected := []string{"example.foo"}
+	expected := []string{"example", "example.foo"}
 	if !slices.Equal(expected, labels) {
 		t.Fatalf("expected %v, got %v", expected, labels)
 	}

--- a/internal/lsp/store.go
+++ b/internal/lsp/store.go
@@ -1,0 +1,114 @@
+package lsp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+)
+
+func NewRegalStore() storage.Store {
+	return inmem.NewFromObject(map[string]interface{}{
+		"workspace": map[string]interface{}{
+			"parsed":       map[string]interface{}{},
+			"defined_refs": map[string][]string{},
+		},
+	})
+}
+
+func transact(ctx context.Context, store storage.Store, writeMode bool, op func(txn storage.Transaction) error) error {
+	var params storage.TransactionParams
+	if writeMode {
+		params = storage.WriteParams
+	}
+
+	txn, err := store.NewTransaction(ctx, params)
+	if err != nil {
+		return fmt.Errorf("failed to create transaction: %w", err)
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			store.Abort(ctx, txn)
+		}
+	}()
+
+	if err := op(txn); err != nil {
+		return err
+	}
+
+	if err := store.Commit(ctx, txn); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	success = true
+
+	return nil
+}
+
+func PutFileMod(ctx context.Context, store storage.Store, fileURI string, mod *ast.Module) error {
+	return transact(ctx, store, true, func(txn storage.Transaction) error {
+		var stErr *storage.Error
+
+		err := store.Write(ctx, txn, storage.ReplaceOp, storage.Path{"workspace", "parsed", fileURI}, mod)
+		if errors.As(err, &stErr) && stErr.Code == storage.NotFoundErr {
+			err = store.Write(ctx, txn, storage.AddOp, storage.Path{"workspace", "parsed", fileURI}, mod)
+			if err != nil {
+				return fmt.Errorf("failed to init module in store: %w", err)
+			}
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to replace module in store: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func RemoveFileMod(ctx context.Context, store storage.Store, fileURI string) error {
+	return transact(ctx, store, true, func(txn storage.Transaction) error {
+		var stErr *storage.Error
+
+		_, err := store.Read(ctx, txn, storage.Path{"workspace", "parsed", fileURI})
+		if errors.As(err, &stErr) && stErr.Code == storage.NotFoundErr {
+			// nothing to do
+			return nil
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to read module from store: %w", err)
+		}
+
+		err = store.Write(ctx, txn, storage.RemoveOp, storage.Path{"workspace", "parsed", fileURI}, nil)
+		if err != nil {
+			return fmt.Errorf("failed to remove module from store: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func PutFileRefs(ctx context.Context, store storage.Store, fileURI string, refs []string) error {
+	return transact(ctx, store, true, func(txn storage.Transaction) error {
+		var stErr *storage.Error
+
+		err := store.Write(ctx, txn, storage.ReplaceOp, storage.Path{"workspace", "defined_refs", fileURI}, refs)
+		if errors.As(err, &stErr) && stErr.Code == storage.NotFoundErr {
+			err = store.Write(ctx, txn, storage.AddOp, storage.Path{"workspace", "defined_refs", fileURI}, refs)
+			if err != nil {
+				return fmt.Errorf("failed to init refs in store: %w", err)
+			}
+		}
+
+		if err != nil {
+			return fmt.Errorf("failed to replace refs in store: %w", err)
+		}
+
+		return nil
+	})
+}

--- a/internal/lsp/types/internal.go
+++ b/internal/lsp/types/internal.go
@@ -6,13 +6,13 @@ import "github.com/open-policy-agent/opa/ast"
 // Ref is designed to be used in completions and provides information
 // relevant to the object with that operation in mind.
 type Ref struct {
-	Kind RefKind
+	Kind RefKind `json:"kind"`
 	// Label is a identifier for the object. e.g. data.package.rule.
-	Label string
+	Label string `json:"label"`
 	// Detail is a small amount of additional information about the object.
-	Detail string
+	Detail string `json:"detail"`
 	// Description is a longer description of the object and uses Markdown formatting.
-	Description string
+	Description string `json:"description"`
 }
 
 // RefKind represents the kind of object that a Ref represents.


### PR DESCRIPTION
Running `workspace_rule_refs` on each key change was proving to be too slow, so I've used a mechanism more similar to the old provider where the refs are computed ahead of time when the file contents changes.