### PR TITLE
Add snippet suggestion for metadata annotation

### DIFF
--- a/bundle/regal/lsp/completion/providers/commonrule/commonrule.rego
+++ b/bundle/regal/lsp/completion/providers/commonrule/commonrule.rego
@@ -17,7 +17,7 @@ items contains item if {
 
 	some label in suggested_names
 
-	invoke_suggestion(line, label)
+	startswith(label, line)
 
 	item := {
 		"label": label,
@@ -33,8 +33,3 @@ items contains item if {
 		},
 	}
 }
-
-invoke_suggestion("", _)
-
-# regal ignore:external-reference
-invoke_suggestion(line, label) if startswith(label, line)

--- a/bundle/regal/lsp/completion/providers/default/default.rego
+++ b/bundle/regal/lsp/completion/providers/default/default.rego
@@ -11,7 +11,7 @@ items contains item if {
 	position := location.to_position(input.regal.context.location)
 	line := input.regal.file.lines[position.line]
 
-	invoke_suggestion(line)
+	startswith("default", line)
 
 	item := {
 		"label": "default",
@@ -28,7 +28,7 @@ items contains item if {
 	position := location.to_position(input.regal.context.location)
 	line := input.regal.file.lines[position.line]
 
-	invoke_suggestion(line)
+	startswith("default", line)
 
 	some name in ast.rule_and_function_names
 
@@ -42,7 +42,3 @@ items contains item if {
 		},
 	}
 }
-
-invoke_suggestion("")
-
-invoke_suggestion(line) if startswith("default", line)

--- a/bundle/regal/lsp/completion/providers/import/import.rego
+++ b/bundle/regal/lsp/completion/providers/import/import.rego
@@ -10,7 +10,7 @@ items contains item if {
 	line := input.regal.file.lines[position.line]
 	word := location.word_at(line, input.regal.context.location.col)
 
-	invoke_suggestion(line)
+	startswith("import", line)
 
 	item := {
 		"label": "import",
@@ -22,7 +22,3 @@ items contains item if {
 		},
 	}
 }
-
-invoke_suggestion("")
-
-invoke_suggestion(line) if startswith("import", line)

--- a/bundle/regal/lsp/completion/providers/package/package.rego
+++ b/bundle/regal/lsp/completion/providers/package/package.rego
@@ -11,7 +11,7 @@ items contains item if {
 	position := location.to_position(input.regal.context.location)
 	line := input.regal.file.lines[position.line]
 
-	invoke_suggestion(line)
+	startswith("package", line)
 
 	item := {
 		"label": "package",
@@ -23,8 +23,3 @@ items contains item if {
 		},
 	}
 }
-
-invoke_suggestion("")
-
-# regal ignore:external-reference
-invoke_suggestion(line) if startswith("package", line)

--- a/bundle/regal/lsp/completion/providers/packagename/packagename.rego
+++ b/bundle/regal/lsp/completion/providers/packagename/packagename.rego
@@ -9,7 +9,8 @@ items contains item if {
 	position := location.to_position(input.regal.context.location)
 	line := input.regal.file.lines[position.line]
 
-	invoke_suggestion(line, position)
+	startswith(line, "package ")
+	position.character > 7
 
 	ps := input.regal.context.path_separator
 
@@ -30,11 +31,6 @@ items contains item if {
 			"newText": sprintf("%s\n\n", [suggestion]),
 		},
 	}
-}
-
-invoke_suggestion(line, position) if {
-	startswith(line, "package ")
-	position.character > 7
 }
 
 base(path) := substring(path, 0, regal.last(indexof_n(path, "/")))

--- a/bundle/regal/lsp/completion/providers/regov1/regov1.rego
+++ b/bundle/regal/lsp/completion/providers/regov1/regov1.rego
@@ -15,7 +15,7 @@ items contains item if {
 
 	word := location.ref_at(line, input.regal.context.location.col)
 
-	invoke_suggestion(word)
+	startswith("rego.v1", word.text)
 
 	item := {
 		"label": "rego.v1",
@@ -26,8 +26,4 @@ items contains item if {
 			"newText": "rego.v1\n\n",
 		},
 	}
-}
-
-invoke_suggestion(word) if {
-	startswith("rego.v1", word.text)
 }

--- a/bundle/regal/lsp/completion/providers/snippet/snippet.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet.rego
@@ -30,6 +30,26 @@ items contains item if {
 	}
 }
 
+items contains item if {
+	position := location.to_position(input.regal.context.location)
+	line := input.regal.file.lines[position.line]
+
+	startswith("metadata", line)
+
+	word := location.word_at(line, input.regal.context.location.col)
+
+	item := {
+		"label": "metadata annotation (snippet)",
+		"kind": kind.snippet,
+		"detail": "metadata annotation",
+		"textEdit": {
+			"range": location.word_range(word, position),
+			"newText": "# METADATA\n# title: ${1:title}\n# description: ${2:description}",
+		},
+		"insertTextFormat": 2, # snippet
+	}
+}
+
 _snippets := {
 	"some value iteration": {
 		"body": "some ${1:var} in ${2:collection}\n$0",

--- a/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
@@ -108,3 +108,26 @@ allow if `
 		},
 	}
 }
+
+test_metadata_snippet_completion if {
+	policy := `package policy
+
+import rego.v1
+
+
+`
+	items := provider.items with input as util.input_with_location(policy, {"row": 5, "col": 1})
+	items == {{
+		"detail": "metadata annotation",
+		"insertTextFormat": 2,
+		"kind": 15,
+		"label": "metadata annotation (snippet)",
+		"textEdit": {
+			"newText": "# METADATA\n# title: ${1:title}\n# description: ${2:description}",
+			"range": {
+				"end": {"character": 0, "line": 4},
+				"start": {"character": 0, "line": 4},
+			},
+		},
+	}}
+}


### PR DESCRIPTION
Also in this PR is a minor fixup, where many `invoke_suggestion` functions have been replaced by `startswith` alone, as `startswith("foo", "")` is true, and doesn't need special handling.


https://github.com/StyraInc/regal/assets/510711/ee7a9e87-ed74-4f93-b3b2-764674efbf46

