### PR TITLE
perf: refactor to avoid excessive `walk`ing

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -122,11 +122,7 @@ all_rules_refs contains value if {
 # scope: document
 all_refs contains value if some value in all_rules_refs
 
-all_refs contains value if {
-	walk(input.imports, [_, value])
-
-	is_ref(value)
-}
+all_refs contains imported.path if some imported in input.imports
 
 # METADATA
 # title: ref_to_string

--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -189,11 +189,11 @@ test_find_vars_in_local_scope if {
 		"e": {"col": 4, "row": 14},
 	}
 
-	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.a)) == set()
-	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.b)) == {"a"}
-	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.c)) == {"a", "b", "c"}
-	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.d)) == {"a", "b", "c", "d"}
-	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.e)) == {"a", "b", "c", "d", "e"}
+	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.a)) with input as module == set()
+	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.b)) with input as module == {"a"}
+	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.c)) with input as module == {"a", "b", "c"}
+	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.d)) with input as module == {"a", "b", "c", "d"}
+	var_names(ast.find_vars_in_local_scope(allow_rule, var_locations.e)) with input as module == {"a", "b", "c", "d", "e"}
 }
 
 test_find_vars_in_local_scope_complex_comprehension_term if {
@@ -210,7 +210,7 @@ test_find_vars_in_local_scope_complex_comprehension_term if {
 
 	allow_rule := module.rules[0]
 
-	ast.find_vars_in_local_scope(allow_rule, {"col": 10, "row": 10}) == [
+	ast.find_vars_in_local_scope(allow_rule, {"col": 10, "row": 10}) with input as module == [
 		{"location": {"col": 3, "row": 7, "text": "YQ=="}, "type": "var", "value": "a"},
 		{"location": {"col": 15, "row": 7, "text": "Yg=="}, "type": "var", "value": "b"},
 		{"location": {"col": 20, "row": 7, "text": "Yw=="}, "type": "var", "value": "c"},
@@ -264,7 +264,7 @@ test_find_some_decl_vars if {
 
 	module := regal.parse_module("p.rego", policy)
 
-	some_vars := ast.find_some_decl_vars(module.rules[0])
+	some_vars := ast.find_some_decl_vars(module.rules[0]) with input as module
 
 	var_names(some_vars) == {"x", "y", "z"}
 }
@@ -284,8 +284,8 @@ test_find_some_decl_names_in_scope if {
 
 	module := regal.parse_module("p.rego", policy)
 
-	ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 8}) == {"x"}
-	ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 10}) == {"x", "y", "z"}
+	{"x"} == ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 8}) with input as module
+	{"x", "y", "z"} == ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 10}) with input as module
 }
 
 var_names(vars) := {var.value | some var in vars}

--- a/bundle/regal/lsp/completion/location/location_test.rego
+++ b/bundle/regal/lsp/completion/location/location_test.rego
@@ -54,10 +54,10 @@ another if {
 }
 `)
 
-	location.find_locals(module.rules, {"row": 6, "col": 1}) == set()
-	location.find_locals(module.rules, {"row": 6, "col": 10}) == {"x"}
-	location.find_locals(module.rules, {"row": 10, "col": 1}) == {"a", "b"}
-	location.find_locals(module.rules, {"row": 10, "col": 6}) == {"a", "b", "c"}
-	location.find_locals(module.rules, {"row": 15, "col": 1}) == {"x", "y"}
-	location.find_locals(module.rules, {"row": 16, "col": 1}) == {"x", "y", "z"}
+	location.find_locals(module.rules, {"row": 6, "col": 1}) with input as module == set()
+	location.find_locals(module.rules, {"row": 6, "col": 10}) with input as module == {"x"}
+	location.find_locals(module.rules, {"row": 10, "col": 1}) with input as module == {"a", "b"}
+	location.find_locals(module.rules, {"row": 10, "col": 6}) with input as module == {"a", "b", "c"}
+	location.find_locals(module.rules, {"row": 15, "col": 1}) with input as module == {"x", "y"}
+	location.find_locals(module.rules, {"row": 16, "col": 1}) with input as module == {"x", "y", "z"}
 }

--- a/bundle/regal/rules/custom/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming_convention.rego
@@ -81,7 +81,7 @@ report contains violation if {
 
 	target in {"var", "variable"}
 
-	some var in ast.find_vars(input.rules)
+	var := ast.vars[_][_][_]
 
 	not regex.match(convention.pattern, var.value)
 

--- a/bundle/regal/rules/style/prefer_snake_case.rego
+++ b/bundle/regal/rules/style/prefer_snake_case.rego
@@ -17,7 +17,7 @@ report contains violation if {
 }
 
 report contains violation if {
-	some var in ast.find_vars(input.rules)
+	var := ast.vars[_][_][_]
 	not util.is_snake_case(var.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(var))

--- a/bundle/regal/rules/testing/metasyntactic_variable.rego
+++ b/bundle/regal/rules/testing/metasyntactic_variable.rego
@@ -42,12 +42,12 @@ report contains violation if {
 }
 
 report contains violation if {
-	some rule in input.rules
-	some var in ast.find_vars(rule)
+	some i
+	var := ast.vars[i][_][_]
 
 	lower(var.value) in metasyntactic
 
-	ast.is_output_var(rule, var, var.location)
+	ast.is_output_var(input.rules[to_number(i)], var, var.location)
 
 	violation := result.fail(rego.metadata.chain(), result.location(var))
 }


### PR DESCRIPTION
Store result of vars found in `walk` into an intermediate object, keyed by rule index and the variable's "context".

The result is quite an improvement:

```
❯ hyperfine --warmup 2 'regal_main lint bundle' 'regal_new lint bundle'
Benchmark 1: regal_main lint bundle
  Time (mean ± σ):      4.387 s ±  0.174 s    [User: 31.888 s, System: 0.906 s]
  Range (min … max):    4.260 s …  4.820 s    10 runs

Benchmark 2: regal_new lint bundle
  Time (mean ± σ):      3.502 s ±  0.120 s    [User: 24.250 s, System: 0.688 s]
  Range (min … max):    3.308 s …  3.700 s    10 runs

Summary
  regal_new lint bundle ran
    1.25 ± 0.07 times faster than regal_main lint bundle
```