### PR TITLE
Fix negative number returned by rulerefs provider issue

### DIFF
--- a/bundle/regal/lsp/completion/main.rego
+++ b/bundle/regal/lsp/completion/main.rego
@@ -10,4 +10,9 @@ import rego.v1
 # METADATA
 # description: main entry point for completion suggestions
 # entrypoint: true
-items contains data.regal.lsp.completion.providers[_].items[_]
+items contains item if {
+	some provider
+	completion := data.regal.lsp.completion.providers[provider].items[_]
+
+	item := object.union(completion, {"_regal": {"provider": provider}})
+}

--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs_test.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs_test.rego
@@ -1,8 +1,10 @@
 package regal.lsp.completion.providers.rulerefs_test
 
-import data.regal.ast
-import data.regal.lsp.completion.providers.rulerefs
 import rego.v1
+
+import data.regal.ast
+
+import data.regal.lsp.completion.providers.rulerefs as provider
 
 workspace := {
 	"current_file.rego": `package foo
@@ -69,7 +71,7 @@ another_local_rule := `])
 		}},
 	}}
 
-	items := rulerefs.items with input as regal_module
+	items := provider.items with input as regal_module
 		with data.workspace.parsed as parsed_modules
 		with data.workspace.defined_refs as defined_refs
 
@@ -98,11 +100,11 @@ another_local_rule := imp`])
 		},
 		"context": {"location": {
 			"row": 10,
-			"col": 21,
+			"col": 26,
 		}},
 	}}
 
-	items := rulerefs.items with input as regal_module
+	items := provider.items with input as regal_module
 		with data.workspace.parsed as parsed_modules
 		with data.workspace.defined_refs as defined_refs
 
@@ -135,7 +137,7 @@ a`])
 		}},
 	}}
 
-	items := rulerefs.items with input as regal_module
+	items := provider.items with input as regal_module
 		with data.workspace.parsed as parsed_modules
 		with data.workspace.defined_refs as defined_refs
 
@@ -161,7 +163,7 @@ local_rule if local`])
 		}},
 	}}
 
-	items := rulerefs.items with input as regal_module
+	items := provider.items with input as regal_module
 		with data.workspace.parsed as parsed_modules
 		with data.workspace.defined_refs as defined_refs
 
@@ -191,7 +193,7 @@ local_func("foo") := local_f`])
 		}},
 	}}
 
-	items := rulerefs.items with input as regal_module
+	items := provider.items with input as regal_module
 		with data.workspace.parsed as parsed_modules
 		with data.workspace.defined_refs as defined_refs
 


### PR DESCRIPTION
Since character position is a `uint`, this would fail when returned to the Go handler.

Also:
- Remove some prints we did to debug performance
- Some cleanups to align rulerefs with other providers

Fixes #887

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->