### PR TITLE
rule: Fix pointless reassign issue when using with

### DIFF
--- a/bundle/regal/rules/style/pointless_reassignment.rego
+++ b/bundle/regal/rules/style/pointless_reassignment.rego
@@ -21,19 +21,14 @@ report contains violation if {
 
 # pointless reassignment in rule body
 report contains violation if {
-	some call in ast.all_refs
+	some rule in input.rules
+	some expr in rule.body
 
-	call[0].value[0].type == "var"
-	call[0].value[0].value == "assign"
+	not expr["with"]
 
-	call[2].type == "var"
+	expr.terms[0].value[0].type == "var"
+	expr.terms[0].value[0].value == "assign"
+	expr.terms[2].type == "var"
 
-	violation := result.fail(rego.metadata.chain(), result.location(call))
-}
-
-assign_calls contains call if {
-	some call in ast.all_refs
-
-	call[0].value[0].type == "var"
-	call[0].value[0].value == "assign"
+	violation := result.fail(rego.metadata.chain(), result.location(expr.terms))
 }

--- a/bundle/regal/rules/style/pointless_reassignment_test.rego
+++ b/bundle/regal/rules/style/pointless_reassignment_test.rego
@@ -50,3 +50,18 @@ test_pointless_reassignment_in_rule_body if {
 		"title": "pointless-reassignment",
 	}}
 }
+
+test_pointless_reassignment_in_rule_body_using_with if {
+	module := ast.with_rego_v1(`
+	foo := input
+
+	rule if {
+		bar := foo with input as "wow"
+
+		bar == true
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}


### PR DESCRIPTION
Fixes #904

I find the times to be comparable for the regal bundle + a simple violating file.

```sh
regal $ hyperfine --warmup 3 './regal-main lint . --disable-all --enable=pointless-reassignment' './regal-pointless lint .
 --disable-all --enable=pointless-reassignment'
Benchmark 1: ./regal-main lint . --disable-all --enable=pointless-reassignment
  Time (mean ± σ):      1.171 s ±  0.077 s    [User: 6.188 s, System: 0.192 s]
  Range (min … max):    1.108 s …  1.370 s    10 runs
 
Benchmark 2: ./regal-pointless lint . --disable-all --enable=pointless-reassignment
  Time (mean ± σ):     665.8 ms ±  11.3 ms    [User: 2891.0 ms, System: 100.2 ms]
  Range (min … max):   644.2 ms … 688.2 ms    10 runs
 
Summary
  ./regal-pointless lint . --disable-all --enable=pointless-reassignment ran
    1.76 ± 0.12 times faster than ./regal-main lint . --disable-all --enable=pointless-reassignment
```