### PR TITLE
Begin to Include end location where applicable

### DIFF
--- a/bundle/regal/rules/bugs/argument_always_wildcard.rego
+++ b/bundle/regal/rules/bugs/argument_always_wildcard.rego
@@ -7,16 +7,10 @@ import rego.v1
 import data.regal.ast
 import data.regal.result
 
-function_groups[name] contains fn if {
-	some fn in ast.functions
-
-	name := ast.ref_to_string(fn.head.ref)
-}
-
 report contains violation if {
-	some functions in function_groups
+	some functions in _function_groups
 
-	fn := any_member(functions)
+	fn := _any_member(functions)
 
 	some pos in numbers.range(0, count(fn.head.args) - 1)
 
@@ -25,7 +19,13 @@ report contains violation if {
 		startswith(function.head.args[pos].value, "$")
 	}
 
-	violation := result.fail(rego.metadata.chain(), result.location(fn.head.args[pos]))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(fn.head.args[pos]))
 }
 
-any_member(s) := [x | some x in s][0]
+_function_groups[name] contains fn if {
+	some fn in ast.functions
+
+	name := ast.ref_to_string(fn.head.ref)
+}
+
+_any_member(s) := [x | some x in s][0]

--- a/bundle/regal/rules/bugs/argument_always_wildcard_test.rego
+++ b/bundle/regal/rules/bugs/argument_always_wildcard_test.rego
@@ -17,7 +17,7 @@ test_fail_single_function_single_argument_always_a_wildcard if {
 		"category": "bugs",
 		"description": "Argument is always a wildcard",
 		"level": "error",
-		"location": {"col": 4, "file": "policy.rego", "row": 6, "text": "\tf(_) := 1"},
+		"location": {"col": 4, "file": "policy.rego", "row": 6, "text": "\tf(_) := 1", "end": {"col": 5, "row": 6}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/argument-always-wildcard", "bugs"),
@@ -37,7 +37,7 @@ test_fail_single_argument_always_a_wildcard if {
 		"category": "bugs",
 		"description": "Argument is always a wildcard",
 		"level": "error",
-		"location": {"col": 4, "file": "policy.rego", "row": 6, "text": "\tf(_) := 1"},
+		"location": {"col": 4, "file": "policy.rego", "row": 6, "text": "\tf(_) := 1", "end": {"col": 5, "row": 6}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/argument-always-wildcard", "bugs"),
@@ -57,7 +57,13 @@ test_fail_single_argument_always_a_wildcard_default_function if {
 		"category": "bugs",
 		"description": "Argument is always a wildcard",
 		"level": "error",
-		"location": {"col": 12, "file": "policy.rego", "row": 6, "text": "\tdefault f(_) := 1"},
+		"location": {
+			"col": 12,
+			"file": "policy.rego",
+			"row": 6,
+			"text": "\tdefault f(_) := 1",
+			"end": {"col": 13, "row": 6},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/argument-always-wildcard", "bugs"),
@@ -77,7 +83,7 @@ test_fail_multiple_argument_always_a_wildcard if {
 		"category": "bugs",
 		"description": "Argument is always a wildcard",
 		"level": "error",
-		"location": {"col": 7, "file": "policy.rego", "row": 6, "text": "\tf(x, _) := x + 1"},
+		"location": {"col": 7, "file": "policy.rego", "row": 6, "text": "\tf(x, _) := x + 1", "end": {"col": 8, "row": 6}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/argument-always-wildcard", "bugs"),

--- a/bundle/regal/rules/bugs/constant_condition.rego
+++ b/bundle/regal/rules/bugs/constant_condition.rego
@@ -18,6 +18,9 @@ _rules_with_bodies := [rule |
 	not ast.generated_body(rule)
 ]
 
+# METADATA
+# description: single scalar value, like a lone `true` inside a rule body
+# scope: rule
 report contains violation if {
 	expr := _rules_with_bodies[_].body[_]
 
@@ -27,9 +30,12 @@ report contains violation if {
 	# however meaningless it may be. Maybe consider for another rule?
 	expr.terms.type in ast.scalar_types
 
-	violation := result.fail(rego.metadata.chain(), result.location(expr))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr.terms))
 }
 
+# METADATA
+# description: two scalar values with a "boolean operator" between, like 1 == 1, or 2 > 1
+# scope: rule
 report contains violation if {
 	expr := _rules_with_bodies[_].body[_]
 
@@ -39,5 +45,5 @@ report contains violation if {
 	expr.terms[1].type in ast.scalar_types
 	expr.terms[2].type in ast.scalar_types
 
-	violation := result.fail(rego.metadata.chain(), result.location(expr))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr))
 }

--- a/bundle/regal/rules/bugs/constant_condition_test.rego
+++ b/bundle/regal/rules/bugs/constant_condition_test.rego
@@ -14,7 +14,7 @@ test_fail_simple_constant_condition if {
 	r == {{
 		"category": "bugs",
 		"description": "Constant condition",
-		"location": {"col": 2, "file": "policy.rego", "row": 4, "text": "\t1"},
+		"location": {"col": 2, "file": "policy.rego", "row": 4, "text": "\t1", "end": {"row": 4, "col": 3}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
@@ -34,7 +34,13 @@ test_fail_rule_with_body_looking_generated if {
 	r == {{
 		"category": "bugs",
 		"description": "Constant condition",
-		"location": {"col": 9, "file": "policy.rego", "row": 3, "text": "allow { true }"},
+		"location": {
+			"file": "policy.rego",
+			"col": 9,
+			"row": 3,
+			"end": {"row": 3, "col": 13},
+			"text": "allow { true }",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),
@@ -51,7 +57,7 @@ test_fail_operator_constant_condition if {
 	r == {{
 		"category": "bugs",
 		"description": "Constant condition",
-		"location": {"col": 2, "file": "policy.rego", "row": 4, "text": "\t1 == 1"},
+		"location": {"col": 2, "file": "policy.rego", "row": 4, "text": "\t1 == 1", "end": {"col": 8, "row": 4}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/constant-condition", "bugs"),

--- a/bundle/regal/rules/bugs/deprecated_builtin.rego
+++ b/bundle/regal/rules/bugs/deprecated_builtin.rego
@@ -20,17 +20,11 @@ report contains violation if {
 
 	some ref in ast.all_refs
 
-	ref[0].value[0].type == "var"
-	not ref[0].value[0].value in {"input", "data"}
+	call := ref[0]
 
-	name := concat(".", [value |
-		some part in ref[0].value
-		value := part.value
-	])
+	ast.ref_to_string(call.value) in deprecated_builtins
 
-	name in deprecated_builtins
-
-	violation := result.fail(rego.metadata.chain(), result.location(ref))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(call))
 }
 
 any_deprecated_builtin(caps_builtins, deprecated_builtins) if {

--- a/bundle/regal/rules/bugs/deprecated_builtin_test.rego
+++ b/bundle/regal/rules/bugs/deprecated_builtin_test.rego
@@ -19,7 +19,13 @@ test_fail_call_to_deprecated_builtin_function if {
 		"category": "bugs",
 		"description": "Avoid using deprecated built-in functions",
 		"level": "error",
-		"location": {"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tany([true, false])"},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tany([true, false])",
+			"end": {"col": 6, "row": 7},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/deprecated-builtin", "bugs"),

--- a/bundle/regal/rules/bugs/duplicate_rule.rego
+++ b/bundle/regal/rules/bugs/duplicate_rule.rego
@@ -19,7 +19,7 @@ report contains violation if {
 	]
 
 	violation := result.fail(rego.metadata.chain(), object.union(
-		result.location(input.rules[first]),
+		result.ranged_location_from_text(input.rules[first]),
 		{"description": message(dup_locations)},
 	))
 }

--- a/bundle/regal/rules/bugs/duplicate_rule_test.rego
+++ b/bundle/regal/rules/bugs/duplicate_rule_test.rego
@@ -19,12 +19,11 @@ test_fail_simple_duplicate_rule if {
 	`)
 
 	r := rule.report with input as module
-
 	r == {{
 		"category": "bugs",
 		"description": "Duplicate rule found at line 10",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 6, "text": "\tallow if {"},
+		"location": {"col": 2, "file": "policy.rego", "row": 6, "text": "\tallow if {", "end": {"col": 4, "row": 8}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/duplicate-rule", "bugs"),
@@ -68,7 +67,7 @@ test_fail_multiple_duplicate_rules if {
 		"category": "bugs",
 		"description": "Duplicate rules found at lines 14, 18",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 10, "text": "\tallow if {"},
+		"location": {"col": 2, "file": "policy.rego", "row": 10, "text": "\tallow if {", "end": {"col": 4, "row": 12}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/duplicate-rule", "bugs"),

--- a/bundle/regal/rules/bugs/if_empty_object.rego
+++ b/bundle/regal/rules/bugs/if_empty_object.rego
@@ -2,10 +2,6 @@
 # description: Empty object following `if`
 package regal.rules.bugs["if-empty-object"]
 
-# NOTE: this rule has been deprecated and is no longer enabled by default
-# Use the `if-object-literal` rule instead, which checks for any object,
-# non-empty or not
-
 import rego.v1
 
 import data.regal.capabilities
@@ -17,6 +13,11 @@ import data.regal.result
 #   severity: warning
 notices contains result.notice(rego.metadata.chain()) if not capabilities.has_if
 
+# METADATA
+# description: |
+#   NOTE: this rule has been deprecated and is no longer enabled by default
+#   Use the `if-object-literal` rule instead, which checks for any object,
+#   non-empty or not
 report contains violation if {
 	some rule in input.rules
 

--- a/bundle/regal/rules/bugs/if_object_literal.rego
+++ b/bundle/regal/rules/bugs/if_object_literal.rego
@@ -17,8 +17,7 @@ report contains violation if {
 	some rule in input.rules
 
 	count(rule.body) == 1
-
 	rule.body[0].terms.type == "object"
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(rule.body[0].terms))
 }

--- a/bundle/regal/rules/bugs/if_object_literal_test.rego
+++ b/bundle/regal/rules/bugs/if_object_literal_test.rego
@@ -14,7 +14,7 @@ test_fail_if_empty_object if {
 		"category": "bugs",
 		"description": "Object literal following `if`",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": "rule if {}"},
+		"location": {"col": 9, "file": "policy.rego", "row": 5, "text": "rule if {}", "end": {"col": 11, "row": 5}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/if-object-literal", "bugs"),
@@ -30,7 +30,13 @@ test_fail_non_empty_object if {
 		"category": "bugs",
 		"description": "Object literal following `if`",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": `rule if {"x": input.x}`},
+		"location": {
+			"col": 9,
+			"file": "policy.rego",
+			"row": 5,
+			"text": `rule if {"x": input.x}`,
+			"end": {"col": 23, "row": 5},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/if-object-literal", "bugs"),

--- a/bundle/regal/rules/bugs/inconsistent_args.rego
+++ b/bundle/regal/rules/bugs/inconsistent_args.rego
@@ -35,7 +35,25 @@ report contains violation if {
 
 	inconsistent_args(position)
 
-	violation := result.fail(rego.metadata.chain(), result.location(find_function_by_name(name)))
+	violation := result.fail(rego.metadata.chain(), _args_location(find_function_by_name(name)))
+}
+
+_args_location(fn) := loc if {
+	# mostly to get the `text` attribute
+	oloc := result.location(fn)
+
+	farg := fn.head.args[0].location
+	larg := regal.last(fn.head.args).location
+
+	# use the location of the first and last arg for highlighting
+	loc := object.union(oloc, {"location": {
+		"row": farg.row,
+		"col": farg.col,
+		"end": {
+			"row": larg.row,
+			"col": larg.col + count(base64.decode(larg.text)),
+		},
+	}})
 }
 
 inconsistent_args(position) if {

--- a/bundle/regal/rules/bugs/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent_args_test.rego
@@ -15,7 +15,13 @@ test_fail_inconsistent_args if {
 	bar(b, a) if b > a
 	`)
 	r := rule.report with input as module
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 7, "text": "\tfoo(b, a) if b > a"})
+	r == expected_with_location({
+		"col": 6,
+		"file": "policy.rego",
+		"row": 7,
+		"text": "\tfoo(b, a) if b > a",
+		"end": {"col": 10, "row": 7},
+	})
 }
 
 test_fail_nested_inconsistent_args if {
@@ -24,7 +30,13 @@ test_fail_nested_inconsistent_args if {
 	a.b.foo(b, a) if b > a
 	`)
 	r := rule.report with input as module
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 7, "text": "\ta.b.foo(b, a) if b > a"})
+	r == expected_with_location({
+		"col": 10,
+		"file": "policy.rego",
+		"row": 7,
+		"text": "\ta.b.foo(b, a) if b > a",
+		"end": {"col": 14, "row": 7},
+	})
 }
 
 test_success_not_inconsistent_args if {

--- a/bundle/regal/rules/bugs/internal_entrypoint.rego
+++ b/bundle/regal/rules/bugs/internal_entrypoint.rego
@@ -12,7 +12,17 @@ report contains violation if {
 	some annotation in rule.annotations
 
 	annotation.entrypoint == true
-	startswith(ast.ref_to_string(rule.head.ref), "_")
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
+	some i, part in rule.head.ref
+
+	_any_internal(i, part)
+
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(part))
+}
+
+_any_internal(0, part) if startswith(part.value, "_")
+
+_any_internal(_, part) if {
+	part.type == "string"
+	startswith(part.value, "_")
 }

--- a/bundle/regal/rules/bugs/internal_entrypoint_test.rego
+++ b/bundle/regal/rules/bugs/internal_entrypoint_test.rego
@@ -20,7 +20,7 @@ _allow := true
 		"category": "bugs",
 		"description": "Entrypoint can't be marked internal",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 9, "text": "_allow := true"},
+		"location": {"col": 1, "file": "policy.rego", "row": 9, "text": "_allow := true", "end": {"col": 7, "row": 9}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/internal-entrypoint", "bugs"),

--- a/bundle/regal/rules/bugs/invalid_metadata_attribute.rego
+++ b/bundle/regal/rules/bugs/invalid_metadata_attribute.rego
@@ -18,7 +18,10 @@ report contains violation if {
 	some attribute in attributes
 	not attribute in ast.comments.metadata_attributes
 
-	violation := result.fail(rego.metadata.chain(), result.location(_find_line(block, attribute)))
+	violation := result.fail(
+		rego.metadata.chain(),
+		result.location(_find_line(block, attribute)),
+	)
 }
 
 _block_to_string(block) := concat("\n", [line |

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -17,13 +17,22 @@ type RelatedResource struct {
 	Reference   string `json:"ref"`
 }
 
+type Position struct {
+	Row    int `json:"row"`
+	Column int `json:"col"`
+}
+
 // Location provides information on the location of a violation.
+// End attribute added in v0.24.0 and ideally we'd have a Start attribute the same way.
+// But as opposed to adding an optional End attribute, changing the structure of the existing
+// struct would break all existing API clients.
 type Location struct {
-	Column int     `json:"col"`
-	Row    int     `json:"row"`
-	Offset int     `json:"offset,omitempty"`
-	File   string  `json:"file"`
-	Text   *string `json:"text,omitempty"`
+	Column int       `json:"col"`
+	Row    int       `json:"row"`
+	End    *Position `json:"end,omitempty"`
+	Offset int       `json:"offset,omitempty"`
+	File   string    `json:"file"`
+	Text   *string   `json:"text,omitempty"`
 }
 
 // Violation describes any violation found by Regal.

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -186,6 +186,8 @@ func buildPrettyViolationsTable(violations []report.Violation) string {
 		table.Append([]string{yellow("Rule:"), violation.Title})
 		table.Append([]string{yellow("Description:"), description})
 		table.Append([]string{yellow("Category:"), violation.Category})
+		// End location ignored here as it's not too interesting in this format and line:column
+		// allows click-to-open.
 		table.Append([]string{yellow("Location:"), cyan(violation.Location.String())})
 
 		if violation.Location.Text != nil {
@@ -388,12 +390,16 @@ func getLocation(violation report.Violation) *sarif.Location {
 			sarif.NewSimpleArtifactLocation(violation.Location.File),
 		)
 
+	region := sarif.NewRegion().
+		WithStartLine(violation.Location.Row).
+		WithStartColumn(violation.Location.Column)
+
+	if violation.Location.End != nil {
+		region = region.WithEndLine(violation.Location.End.Row).WithEndColumn(violation.Location.End.Column)
+	}
+
 	if violation.Location.Row > 0 && violation.Location.Column > 0 {
-		physicalLocation = physicalLocation.WithRegion(
-			sarif.NewRegion().
-				WithStartLine(violation.Location.Row).
-				WithStartColumn(violation.Location.Column),
-		)
+		physicalLocation = physicalLocation.WithRegion(region)
 	}
 
 	return sarif.NewLocationWithPhysicalLocation(physicalLocation)

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -31,6 +31,10 @@ var rep = report.Report{
 				Row:    1,
 				Column: 1,
 				Text:   ptr("package illegal"),
+				End: &report.Position{
+					Row:    1,
+					Column: 14,
+				},
 			},
 			RelatedResources: []report.RelatedResource{
 				{
@@ -205,6 +209,10 @@ func TestJSONReporterPublish(t *testing.T) {
       "location": {
         "col": 1,
         "row": 1,
+        "end": {
+          "row": 1,
+          "col": 14
+        },
         "file": "a.rego",
         "text": "package illegal"
       }
@@ -416,7 +424,9 @@ func TestSarifReporterPublish(t *testing.T) {
                 },
                 "region": {
                   "startLine": 1,
-                  "startColumn": 1
+                  "startColumn": 1,
+                  "endLine": 1,
+                  "endColumn": 14
                 }
               }
             }


### PR DESCRIPTION
This PR attempts to establish end location as an optional attribute of location data returned in violations, and updates ~10 rules in the bugs category to use this convention.

If no end location is provided, the default is as it used to be — end location will be set to the end of the line. For some rules, this is the right thing to do anyway, and therefore, not all rules will need to be updated..

That obviously doesn't "fix" #654, but it's a start, and as far as I've seen so far, works quite well. Importantly this change is non-breaking method for API users! Ideally, we'd put the current "row" and "col" into a "start" object too, but that *would* be a breaking change, and one that would impact all API users, so let's consider that for our first stable release instead.

NOTE that this does not change anything in the output of `regal lint` using the default "pretty"-reporter, but is only included in the more detailed JSON and SARIF formats. First and foremost this change helps LSP clients display diagnostics more accurately, and that is really where this is most useful.

When this has been merged, I'll create some new issues to get this backported to each of the rule categories.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->