### PR TITLE
Rule: `unused-output-variable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The following rules are currently available:
 | bugs        | [rule-shadows-builtin](https://docs.styra.com/regal/rules/bugs/rule-shadows-builtin)                  | Rule name shadows built-in                                |
 | bugs        | [top-level-iteration](https://docs.styra.com/regal/rules/bugs/top-level-iteration)                    | Iteration in top-level assignment                         |
 | bugs        | [unassigned-return-value](https://docs.styra.com/regal/rules/bugs/unassigned-return-value)            | Non-boolean return value unassigned                       |
+| bugs        | [unused-output-variable](https://docs.styra.com/regal/rules/bugs/unused-output-variable)              | Unused output variable                                    |
 | bugs        | [var-shadows-builtin](https://docs.styra.com/regal/rules/bugs/var-shadows-builtin)                    | Variable name shadows built-in                            |
 | bugs        | [zero-arity-function](https://docs.styra.com/regal/rules/bugs/zero-arity-function)                    | Avoid functions without args                              |
 | custom      | [forbidden-function-call](https://docs.styra.com/regal/rules/custom/forbidden-function-call)          | Forbidden function call                                   |
@@ -696,7 +697,7 @@ in the near future:
 
 - [ ] Allow remediation of more `style` category rules using the `regal fix` command
 - [ ] Add [unused-rule](https://github.com/StyraInc/regal/issues/358) linter
-- [ ] Add [unused-output-variable](https://github.com/StyraInc/regal/issues/60) linter
+- [x] Add [unused-output-variable](https://github.com/StyraInc/regal/issues/60) linter
 
 ### Language Server
 

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -71,13 +71,23 @@ _find_every_vars(value) := var if {
 
 # METADATA
 # description: |
-#   traverses all nodes in provided term (using `walk`), and returns an array with
-#   all variables declared in term, i,e [x, y] or {x: y}, etc.
-find_term_vars(term) := [value |
-	walk(term, [_, value])
+#   traverses all nodes in provided terms (using `walk`), and returns an array with
+#   all variables declared in terms, i,e [x, y] or {x: y}, etc.
+find_term_vars(terms) := [term |
+	walk(terms, [_, term])
 
-	value.type == "var"
+	term.type == "var"
 ]
+
+# METADATA
+# description: |
+#   traverses all nodes in provided terms (using `walk`), and returns true if any variable
+#   is found in terms, with early exit (as opposed to find_term_vars)
+has_term_var(terms) if {
+	walk(terms, [_, term])
+
+	term.type == "var"
+}
 
 _find_vars(value, last) := {"term": find_term_vars(function_ret_args(fn_name, value))} if {
 	last == "terms"
@@ -221,6 +231,11 @@ find_names_in_local_scope(rule, location) := names if {
 	var_names := {var.value | some var in find_vars_in_local_scope(rule, location)}
 
 	names := fn_arg_names | var_names
+}
+
+_function_arg_names(rule) := {arg.value |
+	some arg in rule.head.args
+	arg.type == "var"
 }
 
 # METADATA

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -40,6 +40,8 @@ rules:
       level: error
     unassigned-return-value:
       level: error
+    unused-output-variable:
+      level: error
     var-shadows-builtin:
       level: error
     zero-arity-function:

--- a/bundle/regal/rules/bugs/unused_output_variable.rego
+++ b/bundle/regal/rules/bugs/unused_output_variable.rego
@@ -1,0 +1,84 @@
+# METADATA
+# description: Unused output variable
+package regal.rules.bugs["unused-output-variable"]
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.result
+
+# METADATA
+# description: |
+#   The `report` set contains unused output vars from `some` declarations. Using a
+#   stricter ruleset than OPA, Regal considers an output var "unused" if it's used
+#   only once in a ref, as that usage may just as well be replaced by a wildcard.
+#   ```
+#   some y
+#   x := data.foo.bar[y]
+#   # y not used later
+#   ```
+#   Would better be written as:
+#   ```
+#   some x in data.foo.bar
+#   ```
+report contains violation if {
+	some rule_index, name
+
+	var_refs := _ref_vars[rule_index][name]
+
+	count(var_refs) == 1
+
+	some var in var_refs
+
+	not _var_in_head(input.rules[to_number(rule_index)].head, var.value)
+	not _var_in_call(ast.function_calls, rule_index, var.value)
+
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(var))
+}
+
+_ref_vars[rule_index][var.value] contains var if {
+	some rule_index
+	var := ast.vars[rule_index].ref[_]
+
+	not startswith(var.value, "$")
+}
+
+_var_in_head(head, name) if head.value.value == name
+
+_var_in_head(head, name) if {
+	some var in ast.find_term_vars(head.value.value)
+
+	var.value == name
+}
+
+_var_in_head(head, name) if head.key.value == name
+
+_var_in_head(head, name) if {
+	some var in ast.find_term_vars(head.key.value)
+
+	var.value == name
+}
+
+_var_in_call(calls, rule_index, name) if _var_in_arg(calls[rule_index][_].args[_], name)
+
+_var_in_arg(arg, name) if {
+	arg.type == "var"
+	arg.value == name
+}
+
+_var_in_arg(arg, name) if {
+	arg.type == "ref"
+
+	some val in arg.value
+
+	val.type == "var"
+	val.value == name
+}
+
+_var_in_arg(arg, name) if {
+	arg.type in {"array", "object"}
+
+	some var in ast.find_term_vars(arg)
+
+	var.value == name
+}

--- a/bundle/regal/rules/bugs/unused_output_variable_test.rego
+++ b/bundle/regal/rules/bugs/unused_output_variable_test.rego
@@ -1,0 +1,109 @@
+package regal.rules.bugs["unused-output-variable_test"]
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.config
+
+import data.regal.rules.bugs["unused-output-variable"] as rule
+
+test_fail_unused_output_variable if {
+	module := ast.with_rego_v1(`
+	fail if {
+		input[x]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == {{
+		"category": "bugs",
+		"description": "Unused output variable",
+		"level": "error",
+		"location": {"col": 9, "end": {"col": 10, "row": 7}, "file": "policy.rego", "row": 7, "text": "\t\tinput[x]"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/unused-output-variable", "bugs"),
+		}],
+		"title": "unused-output-variable",
+	}}
+}
+
+test_fail_unused_output_variable_some if {
+	module := ast.with_rego_v1(`
+	fail if {
+		some xx
+		input[xx]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == {{
+		"category": "bugs",
+		"description": "Unused output variable",
+		"level": "error",
+		"location": {"col": 9, "end": {"col": 11, "row": 8}, "file": "policy.rego", "row": 8, "text": "\t\tinput[xx]"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/unused-output-variable", "bugs"),
+		}],
+		"title": "unused-output-variable",
+	}}
+}
+
+test_success_unused_wildcard if {
+	module := ast.with_rego_v1(`
+	success if {
+		input[_]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_unused_variable_in_head_value if {
+	module := ast.with_rego_v1(`
+	success := x if {
+		input[x]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_unused_variable_in_head_key if {
+	module := ast.with_rego_v1(`
+	success contains x if {
+		input[x]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_unused_output_variable_function_call if {
+	module := ast.with_rego_v1(`
+	success if {
+		some x
+		input[x]
+		regex.match("[x]", x)
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_unused_output_variable_other_ref if {
+	module := ast.with_rego_v1(`
+	success if {
+		some x
+		input[x] == data.foo[x]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}

--- a/docs/rules/bugs/unused-output-variable.md
+++ b/docs/rules/bugs/unused-output-variable.md
@@ -1,0 +1,103 @@
+# unused-output-variable
+
+**Summary**: Unused output variable
+
+**Category**: Bugs
+
+**Avoid**
+```rego
+package policy
+
+allow if {
+    some x
+    role := input.user.roles[x]
+
+    # do something with "role", but not "x"
+}
+```
+
+**Prefer**
+```rego
+package policy
+
+allow if {
+    # don't declare `x` output var as it is redundant
+    role := input.user.roles[_]
+
+    # do something with "role"
+}
+
+# or better (see prefer-some-in-iteration rule)
+
+allow if {
+    some role in input.user.roles
+
+    # do something with "role"
+}
+
+# or actually _use_ value bound to `x` somewhere, like in another
+# reference, function call, etc
+
+allow if {
+    some x
+    input.user.roles[x] == data.required_roles[x]
+}
+```
+
+## Rationale
+
+Output variables are variables "automatically" bound to values during evaluation, most commonly in iteration. This is
+a powerful feature of Rego that when used correctly can create concise but readable policies. However, output variables
+that are declared but not later referenced are _effectively_ unused and should be replaced by wildcard variables (`_`),
+or the use of `some .. in` iteration.
+
+OPA itself has two methods for detecting and reporting unused variables as errors — one when using `some`:
+
+```rego
+allow if {
+    # `x` is never used in the body — this is a compiler error
+    some x
+    input.user.roles[role]
+
+    role == "admin"
+}
+```
+
+And a [strict mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode) check for unused
+variables defined in assignment (`:=`), or as a function arguments:
+
+```rego
+allow(role, required) {
+    required_roles := data.required_roles
+
+    role == "admin"
+
+    # `required` never used in body, and neither is `required_roles`
+    # both would be errors when strict mode is enabled
+}
+```
+
+Neither of these methods however considers an unused output variable as "unused".
+
+## Configuration Options
+
+This linter rule provides the following configuration options:
+
+```yaml
+rules:
+  bugs:
+    unused-output-variable:
+      # one of "error", "warning", "ignore"
+      level: error
+```
+
+## Related Resources
+
+- Regal Docs: [prefer-some-in-iteration](https://docs.styra.com/regal/rules/style/prefer-some-in-iteration)
+- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode)
+
+## Community
+
+If you think you've found a problem with this rule or its documentation, would like to suggest improvements, new rules,
+or just talk about Regal in general, please join us in the `#regal` channel in the Styra Community
+[Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/e2e/testdata/violations/most_violations.rego
+++ b/e2e/testdata/violations/most_violations.rego
@@ -100,6 +100,11 @@ some_rule := true
 
 var_shadows_builtin if http := true
 
+unused_output_variable if {
+	some x
+	input[x]
+}
+
 ### Idiomatic ###
 
 custom_has_key_construct(map, key) if {

--- a/internal/lsp/examples/examples.go
+++ b/internal/lsp/examples/examples.go
@@ -1,9 +1,10 @@
 package examples
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
+
+	_ "embed"
 )
 
 // GetBuiltInLink returns the URL for the built-in function documentation


### PR DESCRIPTION
One of the rules I've wanted since the project was started, but not until now would this have been wildly expensive to add. With the recent fixes that allow us to reuse the result of `walk`ing the AST, that's no longer the case. Still, this required quite some time and effort to get right!

NOTE: this rule currently only considers output variables as found in references, i.e. `x` in  `input[x]` and NOT `x` in `some x, _ in input`. While that would be easy to add, I'm not sure if those are really "output variables" or should be considered as such... 🤔 or if we should just have another rules for "unused iteration variable" or something like that. Either way, this is a big step forward!

Fixes #60

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->