### PR TITLE
Add `except-function-name-pattern` option to `argument-always-wildcard`

### DIFF
--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -7,6 +7,7 @@ rules:
       level: error
     argument-always-wildcard:
       level: error
+      except-function-name-pattern: "^mock_"
     constant-condition:
       level: error
     deprecated-builtin:

--- a/bundle/regal/rules/bugs/argument_always_wildcard.rego
+++ b/bundle/regal/rules/bugs/argument_always_wildcard.rego
@@ -5,10 +5,11 @@ package regal.rules.bugs["argument-always-wildcard"]
 import rego.v1
 
 import data.regal.ast
+import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	some functions in _function_groups
+	some name, functions in _function_groups
 
 	fn := _any_member(functions)
 
@@ -19,6 +20,8 @@ report contains violation if {
 		startswith(function.head.args[pos].value, "$")
 	}
 
+	not _function_name_excepted(config.for_rule("bugs", "argument-always-wildcard"), name)
+
 	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(fn.head.args[pos]))
 }
 
@@ -27,5 +30,7 @@ _function_groups[name] contains fn if {
 
 	name := ast.ref_to_string(fn.head.ref)
 }
+
+_function_name_excepted(cfg, name) if regex.match(cfg["except-function-name-pattern"], name)
 
 _any_member(s) := [x | some x in s][0]

--- a/bundle/regal/rules/bugs/argument_always_wildcard_test.rego
+++ b/bundle/regal/rules/bugs/argument_always_wildcard_test.rego
@@ -26,6 +26,15 @@ test_fail_single_function_single_argument_always_a_wildcard if {
 	}}
 }
 
+test_success_single_function_single_argument_always_a_wildcard_except_function_name if {
+	module := ast.with_rego_v1(`
+	mock_f(_) := 1
+	`)
+
+	r := rule.report with input as module with config.for_rule as {"except-function-name-pattern": "^mock_"}
+	r == set()
+}
+
 test_fail_single_argument_always_a_wildcard if {
 	module := ast.with_rego_v1(`
 	f(_) := 1

--- a/docs/rules/bugs/argument-always-wildcard.md
+++ b/docs/rules/bugs/argument-always-wildcard.md
@@ -85,6 +85,10 @@ rules:
     argument-always-wildcard:
       # one of "error", "warning", "ignore"
       level: error
+      # function name patterns for which this rule should make an exception
+      # default is to ignore any function name starting with "mock_" as these
+      # commonly don't need named arguments
+      except-function-name-pattern: "^mock_"
 ```
 
 ## Community


### PR DESCRIPTION
And have functions starting with "mock_" excepted by default.

Fixes #923

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->