### PR TITLE
Ensure `unused-output-variable` actually is output variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ in the near future:
 
 - [ ] Make "Check on save" unnecessary by allowing diagnostics to include
       [compilation errors](https://github.com/StyraInc/regal/issues/745)
-- [ ] Add Code Lens to "Evaluate" any rule or package
+- [ ] Add Code Lens to "Evaluate" any rule or package (VS Code only, initially)
 - [ ] Implement [Signature Help](https://github.com/StyraInc/regal/issues/695) feature
 
 The roadmap is updated when all the current items have been completed.

--- a/bundle/regal/rules/bugs/unused_output_variable.rego
+++ b/bundle/regal/rules/bugs/unused_output_variable.rego
@@ -33,6 +33,10 @@ report contains violation if {
 	not _var_in_head(input.rules[to_number(rule_index)].head, var.value)
 	not _var_in_call(ast.function_calls, rule_index, var.value)
 
+	# this is by far the most expensive condition to check, so only do
+	# so when all other conditions apply
+	ast.is_output_var(input.rules[to_number(rule_index)], var, var.location)
+
 	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(var))
 }
 

--- a/bundle/regal/rules/bugs/unused_output_variable_test.rego
+++ b/bundle/regal/rules/bugs/unused_output_variable_test.rego
@@ -107,3 +107,27 @@ test_success_not_unused_output_variable_other_ref if {
 	r := rule.report with input as module
 	r == set()
 }
+
+test_success_not_output_variable_rule if {
+	module := ast.with_rego_v1(`
+	x := 1
+
+	success := x if {
+		input[x]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_output_variable_argument if {
+	module := ast.with_rego_v1(`
+	success(x) if {
+		input[x]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}


### PR DESCRIPTION
Found when testing this against some policies in the wild

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->