### PR TITLE
add JUnit output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,12 +599,13 @@ are:
   from the linter report
 - `sarif` - [SARIF](https://sarifweb.azurewebsites.net/) JSON output, for consumption by tools processing code analysis
   reports
+- `junit` - JUnit XML output, e.g. for CI servers like GitLab that show these results in a merge request.
 
 ## OPA Check and Strict Mode
 
 Linting with Regal assumes syntactically correct Rego. If there are errors parsing any files during linting, the
 process is aborted and any parser errors are logged similarly to OPA. OPA itself provides a "linter" of sorts,
-via the `opa check` comand and its `--strict` flag. This checks the provided Rego files not only for syntax errors,
+via the `opa check` command and its `--strict` flag. This checks the provided Rego files not only for syntax errors,
 but also for OPA [strict mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode) violations.
 
 > **Note** It is recommended to run `opa check --strict` as part of your policy build process, and address any violations

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -13,4 +13,6 @@ const (
 	formatFestive = "festive"
 	// formatSarif is the SARIF format value for the --format flag in various commands.
 	formatSarif = "sarif"
+	// formatJunit is the JUnit format value for the --format flag in various commands.
+	formatJunit = "junit"
 )

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -41,9 +41,14 @@ regal_lint_policies:
     name: ghcr.io/styrainc/regal:latest
     entrypoint: ['/bin/sh', '-c']
   script:
-    - regal lint ./policy
+    - regal lint ./policy --format junit > regal-results.xml
+  artifacts:
+    reports:
+      junit: regal-results.xml
+    when: always
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
 ```
 
-The above will run Regal on the `policy` directory when a merge request is created or updated.
+The above will run Regal on the `policy` directory when a merge request is created or updated and will show linting
+violations as part of the merge request.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.6.0
+	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-policy-agent/opa v0.66.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/flatbuffers v24.3.25+incompatible h1:CX395cjN9Kke9mmalRoL3d81AtFUxJM+yDthflgJGkI=
 github.com/google/flatbuffers v24.3.25+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -90,6 +91,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9K
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jstemmer/go-junit-report/v2 v2.1.0 h1:X3+hPYlSczH9IMIpSC9CQSZA0L+BipYafciZUWHEmsc=
+github.com/jstemmer/go-junit-report/v2 v2.1.0/go.mod h1:mgHVr7VUo5Tn8OLVr1cKnLuEy0M92wdRntM99h7RkgQ=
 github.com/klauspost/compress v1.17.0 h1:Rnbp4K9EjcDuVuHtd0dgA4qNuv9yKDYKK1ulpJwgrqM=
 github.com/klauspost/compress v1.17.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -595,3 +595,65 @@ func TestSarifReporterPublishNoViolations(t *testing.T) {
 		t.Errorf("expected %s, got %s", expect, buf.String())
 	}
 }
+
+//nolint:lll // the expected output is unfortunately longer than the allowed max line length
+func TestJUnitReporterPublish(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	sr := NewJUnitReporter(&buf)
+
+	err := sr.Publish(context.Background(), rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `<testsuites name="regal" tests="2" failures="2">
+	<testsuite name="a.rego" tests="1" failures="1" errors="0" id="0" time="">
+		<testcase name="legal/breaking-the-law: Rego must not break the law!" classname="a.rego:1:1">
+			<failure message="Rego must not break the law!. To learn more, see: https://example.com/illegal" type="error"><![CDATA[Rule: breaking-the-law
+Description: Rego must not break the law!
+Category: legal
+Location: a.rego:1:1
+Text: package illegal
+Documentation: https://example.com/illegal]]></failure>
+		</testcase>
+	</testsuite>
+	<testsuite name="b.rego" tests="1" failures="1" errors="0" id="0" time="">
+		<testcase name="really?/questionable-decision: Questionable decision found" classname="b.rego:22:18">
+			<failure message="Questionable decision found. To learn more, see: https://example.com/questionable" type="warning"><![CDATA[Rule: questionable-decision
+Description: Questionable decision found
+Category: really?
+Location: b.rego:22:18
+Text: default allow = true
+Documentation: https://example.com/questionable]]></failure>
+		</testcase>
+	</testsuite>
+</testsuites>
+`
+
+	if buf.String() != expect {
+		t.Errorf("expected \n%s, got \n%s", expect, buf.String())
+	}
+}
+
+func TestJUnitReporterPublishNoViolations(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	sr := NewJUnitReporter(&buf)
+
+	err := sr.Publish(context.Background(), report.Report{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expect := `<testsuites name="regal"></testsuites>
+`
+
+	if buf.String() != expect {
+		t.Errorf("expected \n%s, got \n%s", expect, buf.String())
+	}
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->

fixes #928 

The output groups violations by files in a testsuite and expresses each violation inside a file as a testcase. The files are sorted so that we have stable output during tests and each failure message contains the documentation link for a failed rule.

I'm not entirely sure whether notices should be part of the output as well. I've skipped them because most other reporters do not output them either.