### PR TITLE
docs: Update notes on neovim and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ brew install styrainc/packages/regal
 ```
 
 <details>
-  <summary><strong>Manual download options</strong></summary>
+  <summary><strong>Other Installation Options</strong></summary>
+
+Please see [Packages](https://docs.styra.com/regal/adopters#packaging)
+for a list of package repositories which distribute Regal.
+
+Manual installation commands:
 
 **MacOS (Apple Silicon)**
 ```shell
@@ -88,16 +93,8 @@ curl.exe -L -o regal.exe "https://github.com/StyraInc/regal/releases/latest/down
 docker pull ghcr.io/styrainc/regal:latest
 ```
 
-**asdf**
-```shell
-asdf plugin add regal
-asdf install regal latest
-asdf global regal latest
-```
-
 See all versions, and checksum files, at the Regal [releases](https://github.com/StyraInc/regal/releases/) page, and
 published Docker images at the [packages](https://github.com/StyraInc/regal/pkgs/container/regal) page.
-
 </details>
 
 ### Try it out!

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -43,7 +43,8 @@ The following package managers include Regal in their repositories, either nativ
 - [Homebrew](https://brew.sh/) via Styra's [homebrew-packages](https://github.com/StyraInc/homebrew-packages)
 - [asdf](https://asdf-vm.com/) via [asdf-regal](https://github.com/asdf-community/asdf-regal)
 - [pkgsrc](https://www.pkgsrc.se/) and the [regal](https://pkgsrc.se/devel/regal) package
-- [Nix](https://nixos.org/): [regal](https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/re/regal/package.nix)
+- [Nix](https://nixos.org/): [regal](https://search.nixos.org/packages?channel=24.05&show=regal&from=0&size=50&sort=relevance&type=packages&query=regal)
+- [mason.vim](https://github.com/williamboman/mason.nvim): [regal](https://github.com/mason-org/mason-registry/blob/main/packages/regal/package.yaml)
 
 ## Companies and Organizations
 

--- a/docs/editor-support.md
+++ b/docs/editor-support.md
@@ -18,20 +18,32 @@ Zed supports Rego via Regal and the [zed-rego](https://github.com/StyraInc/zed-r
 community. The extension provides syntax highlighting, linting, and all the other language server features provided by
 Regal.
 
-## Neovim via nvim-lspconfig
+## Neovim
+
+There are a number of different plugins available for Neovim which integrate
+with language servers using the Language Server Protocol.
+
+Generally, the Regal binary should be [installed](https://docs.styra.com/regal#getting-started)
+first. [`mason.vim`](https://github.com/williamboman/mason.nvim) users can install the
+Regal binary with `:MasonInstall regal`
+([package definition](https://github.com/mason-org/mason-registry/blob/2024-07-23-asian-hate/packages/regal/package.yaml)).
+
+Below are a number of different plugin options to configure a language server
+client for Regal in Neovim.
+
+### nvim-lspconfig
 
 [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) has native support for the
-Regal language server. Provided that you already have the `regal` binary installed,
-use the configuration below to enable LSP features in [Neovim](https://neovim.io).
+Regal language server. Use the configuration below to configure Regal:
 
 ```lua
 require('lspconfig').regal.setup()
 ```
 
-## Neovim via none-ls
+## none-ls
 
-[none-ls](https://github.com/nvimtools/none-ls.nvim) - Use Neovim as a language server to inject LSP diagnostics,
-code actions, and more via Lua.
+[none-ls](https://github.com/nvimtools/none-ls.nvim) - Use Neovim as a
+language server to inject LSP diagnostics, code actions, and more via Lua.
 
 Minimal installation via [VimPlug](https://github.com/junegunn/vim-plug)
 
@@ -58,3 +70,22 @@ default allowRbac := true
 Example of the diagnostics in as shown in the UI:
 
 ![regal in none-ls](./assets/editors-neovim.png)
+
+## nvim-cmp
+
+[nvim-cmp](https://github.com/hrsh7th/nvim-cmp) supports the adding of language
+servers as a source.
+
+To use Regal with `nvim-cmp`, it is recommended that you use
+the [`nvim-lspconfig` source](https://github.com/hrsh7th/cmp-nvim-lsp) and
+follow the instructions above to configure `nvim-lspconfig`.
+
+## Other plugins
+
+To see live linting of Rego, your plugin must support
+[`textDocument/diagnostic`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_diagnostic)
+messages.
+
+There are many language server integrations for Neovim, if you'd like to see
+another one listed, please [open an issue](https://github.com/StyraInc/regal/issues/new)
+or drop us a message in [Slack](http://communityinviter.com/apps/styracommunity/signup).


### PR DESCRIPTION
Some minor updates to the packaging and editor integration docs, mainly:

- updates to nvim integration options since there are so many
- updates to installation options in readme since there are more package managers with Regal now I've opted to like to packages instead.