### PR TITLE
Extend `redundant-existence-check` to fail redundant ref checks

### DIFF
--- a/bundle/regal/rules/bugs/redundant_existence_check.rego
+++ b/bundle/regal/rules/bugs/redundant_existence_check.rego
@@ -7,6 +7,8 @@ import rego.v1
 import data.regal.ast
 import data.regal.result
 
+# METADATA
+# description: check rule bodies for redundant existence checks
 report contains violation if {
 	some rule_index, rule in input.rules
 	some expr_index, expr in ast.exprs[rule_index]
@@ -18,12 +20,28 @@ report contains violation if {
 	ast.static_ref(expr.terms)
 
 	ref_str := ast.ref_to_string(expr.terms.value)
-
 	next_expr := rule.body[expr_index + 1]
 
 	some term in next_expr.terms
 
 	ast.ref_to_string(term.value) == ref_str
 
-	violation := result.fail(rego.metadata.chain(), result.location(expr))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr))
+}
+
+# METADATA
+# description: check for redundant existence checks in rule head assignment
+report contains violation if {
+	some rule_index, rule in input.rules
+
+	rule.head.value.type == "ref"
+
+	ref_str := ast.ref_to_string(rule.head.value.value)
+
+	some expr in ast.exprs[rule_index]
+
+	expr.terms.type == "ref"
+	ast.ref_to_string(expr.terms.value) == ref_str
+
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr.terms))
 }

--- a/bundle/regal/rules/bugs/redundant_existence_check_test.rego
+++ b/bundle/regal/rules/bugs/redundant_existence_check_test.rego
@@ -18,7 +18,7 @@ test_fail_redundant_existence_check if {
 		"category": "bugs",
 		"description": "Redundant existence check",
 		"level": "error",
-		"location": {"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tinput.foo"},
+		"location": {"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tinput.foo", "end": {"col": 12, "row": 7}},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
@@ -46,4 +46,23 @@ test_success_not_redundant_existence_check_with_cancels if {
 	}`)
 	r := rule.report with input as module
 	r == set()
+}
+
+test_fail_redundant_existence_check_head_assignment_of_ref if {
+	module := ast.with_rego_v1(`
+	redundant := input.foo if {
+		input.foo
+	}`)
+	r := rule.report with input as module
+	r == {{
+		"category": "bugs",
+		"description": "Redundant existence check",
+		"level": "error",
+		"location": {"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tinput.foo", "end": {"col": 12, "row": 7}},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-existence-check", "bugs"),
+		}],
+		"title": "redundant-existence-check",
+	}}
 }


### PR DESCRIPTION
Fixes #935

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->