### PR TITLE
lsp: Skip textDocument/completion for ignored files

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -863,6 +863,15 @@ func (l *LanguageServer) handleTextDocumentCompletion(
 		return nil, fmt.Errorf("failed to unmarshal params: %w", err)
 	}
 
+	// when config ignores a file, then we return an empty completion list
+	// as a no-op.
+	if l.ignoreURI(params.TextDocument.URI) {
+		return types.CompletionList{
+			IsIncomplete: false,
+			Items:        []types.CompletionItem{},
+		}, nil
+	}
+
 	// items is allocated here so that the return value is always a non-nil CompletionList
 	items, err := l.completionsManager.Run(params, &providers.Options{
 		ClientIdentifier: l.clientIdentifier,


### PR DESCRIPTION
When files are ignored, they will have no file contents in the cache, and so completions are impossible. This leads to an error message which is now avoided by just returning an empty list.

Fixes https://github.com/StyraInc/regal/issues/879

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->