### PR TITLE
fix: Only run fix linter with fixable rules

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -237,8 +237,22 @@ func fix(args []string, params *fixCommandParams) error {
 		log.Println("no user-provided config file found, will use the default config")
 	}
 
+	fixes := fixes.NewDefaultFixes()
+
+	// the linter will be run with only the fixable rules enabled.
+	// first, disable all the rules
+	l.WithDisableAll(true)
+
+	fixableRules := make([]string, 0, len(fixes))
+	for _, fix := range fixes {
+		fixableRules = append(fixableRules, fix.Name())
+	}
+
+	// enable only the rules for which fixes are available
+	l.WithEnabledRules(fixableRules...)
+
 	f := fixer.NewFixer()
-	f.RegisterFixes(fixes.NewDefaultFixes()...)
+	f.RegisterFixes(fixes...)
 
 	ignore := userConfig.Ignore.Files
 


### PR DESCRIPTION
This doesn't appear to improve the performance sadly in my testing on the regal bundle and https://github.com/kubescape/regolibrary. However, I feel that this makes sense as a minor tidy up here.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->