### PR TITLE
lsp/format,cmd/fix: Apply rego.v1 formatting by default

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -14,6 +14,9 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
+
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/fixer"
@@ -239,6 +242,14 @@ func fix(args []string, params *fixCommandParams) error {
 
 	f := fixer.NewFixer()
 	f.RegisterFixes(fixes.NewDefaultFixes()...)
+	f.RegisterMandatoryFixes(
+		&fixes.Fmt{
+			NameOverride: "use-rego-v1",
+			OPAFmtOpts: format.Opts{
+				RegoVersion: ast.RegoV0CompatV1,
+			},
+		},
+	)
 
 	ignore := userConfig.Ignore.Files
 

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -778,7 +778,6 @@ func TestFix(t *testing.T) {
 	stderr := bytes.Buffer{}
 	td := t.TempDir()
 
-	// only violation is for the opa-fmt rule
 	unformattedContents := []byte(`package wow
 
 import rego.v1
@@ -805,11 +804,10 @@ allow if {
 	// 0 exit status is expected as all violations should have been fixed
 	expectExitCode(t, err, 0, &stdout, &stderr)
 
-	exp := fmt.Sprintf(`3 fixes applied:
+	exp := fmt.Sprintf(`2 fixes applied:
 %s/main.rego:
 - no-whitespace-comment
-- opa-fmt
-- use-assignment-operator
+- use-rego-v1
 `, td)
 
 	if act := stdout.String(); exp != act {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1287,7 +1287,7 @@ func (l *LanguageServer) handleTextDocumentFoldingRange(
 }
 
 func (l *LanguageServer) handleTextDocumentFormatting(
-	_ context.Context,
+	ctx context.Context,
 	_ *jsonrpc2.Conn,
 	req *jsonrpc2.Request,
 ) (result any, err error) {
@@ -1340,7 +1340,7 @@ func (l *LanguageServer) handleTextDocumentFormatting(
 		},
 	)
 
-	fixReport, err := f.Fix(context.Background(), &li, memfp)
+	fixReport, err := f.Fix(ctx, &li, memfp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to format: %w", err)
 	}

--- a/mess.rego
+++ b/mess.rego
@@ -1,0 +1,7 @@
+package p
+
+import rego.v1
+
+# comment
+
+allow := true

--- a/pkg/fixer/fixer.go
+++ b/pkg/fixer/fixer.go
@@ -65,10 +65,12 @@ func (f *Fixer) GetMandatoryFixForName(name string) (fixes.Fix, bool) {
 	if !ok {
 		return nil, false
 	}
+
 	fixInstance, ok := fix.(fixes.Fix)
 	if !ok {
 		return nil, false
 	}
+
 	return fixInstance, true
 }
 
@@ -105,7 +107,10 @@ func (f *Fixer) Fix(ctx context.Context, l *linter.Linter, fp fileprovider.FileP
 
 				for _, fixResult := range fixResults {
 					if !bytes.Equal(fc, fixResult.Contents) {
-						fp.PutFile(file, fixResult.Contents)
+						err := fp.PutFile(file, fixResult.Contents)
+						if err != nil {
+							return nil, fmt.Errorf("failed to write fixed rego for file %s: %w", file, err)
+						}
 
 						fixReport.SetFileFixedViolation(file, fix)
 

--- a/pkg/fixer/fixer.go
+++ b/pkg/fixer/fixer.go
@@ -120,6 +120,12 @@ func (f *Fixer) Fix(ctx context.Context, l *linter.Linter, fp fileprovider.FileP
 		}
 	}
 
+	// if there are no registeredFixes (fixes that require a linter), then
+	// we are done
+	if len(f.registeredFixes) == 0 {
+		return fixReport, nil
+	}
+
 	// next, run the fixes that require a linter violation trigger
 	enabledRules, err := l.DetermineEnabledRules(ctx)
 	if err != nil {

--- a/pkg/fixer/fixer_test.go
+++ b/pkg/fixer/fixer_test.go
@@ -6,6 +6,9 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/format"
+
 	"github.com/styrainc/regal/pkg/fixer/fileprovider"
 	"github.com/styrainc/regal/pkg/fixer/fixes"
 	"github.com/styrainc/regal/pkg/linter"
@@ -62,6 +65,108 @@ deny := true
 	}
 
 	if got, exp := fixReport.TotalFixes(), 3; got != exp {
+		t.Fatalf("expected %d fixed files, got %d", exp, got)
+	}
+
+	fpFiles, err := memfp.ListFiles()
+	if err != nil {
+		t.Fatalf("failed to list files: %v", err)
+	}
+
+	for _, file := range fpFiles {
+		// check that the content is correct
+		expectedContent, ok := expectedFileContents[file]
+		if !ok {
+			t.Fatalf("unexpected file %s", file)
+		}
+
+		content, err := memfp.GetFile(file)
+		if err != nil {
+			t.Fatalf("failed to get file %s: %v", file, err)
+		}
+
+		if !bytes.Equal(content, expectedContent) {
+			t.Fatalf("unexpected content for %s:\ngot:\n%s---\nexpected:\n%s---",
+				file,
+				string(content),
+				string(expectedContent))
+		}
+
+		// check that the fixed violations are correct
+		fixedViolations := fixReport.FixedViolationsForFile(file)
+
+		expectedViolations, ok := expectedFileFixedViolations[file]
+		if !ok {
+			t.Fatalf("unexpected file waas fixed %s", file)
+		}
+
+		if !slices.Equal(fixedViolations, expectedViolations) {
+			t.Fatalf("unexpected fixed violations for %s:\ngot: %v\nexpected: %v", file, fixedViolations, expectedViolations)
+		}
+	}
+}
+
+func TestFixerWithRegisterMandatoryFixes(t *testing.T) {
+	t.Parallel()
+
+	policies := map[string][]byte{
+		"main.rego": []byte(`package test
+
+allow {
+true #no space
+}
+
+deny = true
+`),
+	}
+
+	memfp := fileprovider.NewInMemoryFileProvider(policies)
+
+	input, err := memfp.ToInput()
+	if err != nil {
+		t.Fatalf("failed to create input: %v", err)
+	}
+
+	l := linter.NewLinter().
+		WithEnableAll(true).
+		WithInputModules(&input)
+
+	f := NewFixer()
+	// No fixes are registered here, we are only testing the functionality of
+	// RegisterMandatoryFixes
+	f.RegisterMandatoryFixes(
+		&fixes.Fmt{
+			NameOverride: "use-rego-v1",
+			OPAFmtOpts: format.Opts{
+				RegoVersion: ast.RegoV0CompatV1,
+			},
+		},
+	)
+
+	fixReport, err := f.Fix(context.Background(), &l, memfp)
+	if err != nil {
+		t.Fatalf("failed to fix: %v", err)
+	}
+
+	expectedFileFixedViolations := map[string][]string{
+		"main.rego": {"use-rego-v1"},
+	}
+	expectedFileContents := map[string][]byte{
+		// note that since only the rego-v1-format fix is run, the
+		// no-whitespace-comment fix is not applied
+		"main.rego": []byte(`package test
+
+import rego.v1
+
+allow := true
+
+#no space
+
+deny := true
+`),
+	}
+
+	if got, exp := fixReport.TotalFixes(), 1; got != exp {
 		t.Fatalf("expected %d fixed files, got %d", exp, got)
 	}
 


### PR DESCRIPTION
Summary of changes:

- when running the fix cmd, the rego.v1 formatter will be run for files regardless of `rego.v1` being imported.
- when formatting on save in a language server client, the rego.v1 formatter will run, and all fixable violations will also be corrected at save time.

This is implemented by adding the concept of mandatory fixes, where these are run on all files even if there are no violations, before the linter based fixes are run.

LSP on save:


https://github.com/user-attachments/assets/7be3d304-62ab-4b3a-8b71-2364b758033a



Fix cmd:
<img width="639" alt="Screenshot 2024-08-01 at 18 04 54" src="https://github.com/user-attachments/assets/b4b71931-e798-4a77-8651-0df14a40fe16">
