### PR TITLE
Allow using `regal fix` as a formatter

### DIFF
--- a/docs/fixing.md
+++ b/docs/fixing.md
@@ -22,3 +22,8 @@ Currently, the following rules are automatically fixable:
 Need to fix individual violations? Checkout the editors Regal supports
 [here](/regal/editor-support).
 :::
+
+## Community
+
+If you'd like to discuss Regal development or just talk about Regal in general, please join us in the `#regal`
+channel in the Styra Community [Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -88,12 +88,17 @@ user-defined functions too.
 
 ### Formatting
 
-Regal uses the `opa fmt` formatter for formatting Rego. This is made available as a command in editors, but also via
-a [code action](#code-actions) when unformatted files are encountered.
+By default, Regal uses the `opa fmt` formatter for formatting Rego. This is made available as a command in editors,
+but also via a [code action](#code-actions) when unformatted files are encountered.
 
 <img
   src={require('./assets/lsp/format.png').default}
   alt="Screenshot of diagnostics as displayed in Zed"/>
+
+Two other formatters are also available — `opa fmt --rego-v1` and `regal fix`. See the docs on
+[Fixing Violations](fixing.md) for more information about the `fix` command. Which formatter to use
+can be set via the `formatter` configuration option, which can be passed to Regal via the client (see
+the documentation for your client for how to do that).
 
 ### Code completions
 

--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -60,31 +60,3 @@ func ComputeEdits(before, after string) []types.TextEdit {
 
 	return edits
 }
-
-// The opa fmt command does not allow configuration options, so we will have
-// to ignore them if provided by the client. We can however log the warnings
-// so that the caller has some chance to be made aware of why their options
-// aren't applied.
-func validateFormattingOptions(opts types.FormattingOptions) []string {
-	warnings := make([]string, 0)
-
-	if opts.InsertSpaces {
-		warnings = append(warnings, "opa fmt: only tabs supported for indentation")
-	}
-
-	if !opts.TrimTrailingWhitespace {
-		warnings = append(warnings, "opa fmt: trailing whitespace always trimmed")
-	}
-
-	if !opts.InsertFinalNewline {
-		warnings = append(warnings, "opa fmt: final newline always inserted")
-	}
-
-	if !opts.TrimFinalNewlines {
-		warnings = append(warnings, "opa fmt: final newlines always trimmed")
-	}
-
-	// opts.TabSize ignored as we don't support using spaces
-
-	return warnings
-}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -19,15 +19,20 @@ type FileEvent struct {
 	URI  string `json:"uri"`
 }
 
+type InitializationOptions struct {
+	Formatter *string `json:"formatter,omitempty"`
+}
+
 type InitializeParams struct {
-	ProcessID        int                `json:"processId"`
-	ClientInfo       Client             `json:"clientInfo"`
-	Locale           string             `json:"locale"`
-	RootPath         string             `json:"rootPath"`
-	RootURI          string             `json:"rootUri"`
-	Capabilities     ClientCapabilities `json:"capabilities"`
-	Trace            string             `json:"trace"`
-	WorkspaceFolders []WorkspaceFolder  `json:"workspaceFolders"`
+	ProcessID             int                    `json:"processId"`
+	ClientInfo            Client                 `json:"clientInfo"`
+	Locale                string                 `json:"locale"`
+	RootPath              string                 `json:"rootPath"`
+	RootURI               string                 `json:"rootUri"`
+	Capabilities          ClientCapabilities     `json:"capabilities"`
+	Trace                 string                 `json:"trace"`
+	WorkspaceFolders      []WorkspaceFolder      `json:"workspaceFolders"`
+	InitializationOptions *InitializationOptions `json:"initializationOptions,omitempty"`
 }
 
 type WorkspaceFolder struct {

--- a/pkg/fixer/fixer.go
+++ b/pkg/fixer/fixer.go
@@ -12,10 +12,15 @@ import (
 	"github.com/styrainc/regal/pkg/linter"
 )
 
+// NewFixer instantiates a Fixer.
 func NewFixer() *Fixer {
-	return &Fixer{}
+	return &Fixer{
+		registeredFixes:          make(map[string]any),
+		registeredMandatoryFixes: make(map[string]any),
+	}
 }
 
+// Fixer must be instantiated via NewFixer.
 type Fixer struct {
 	registeredFixes          map[string]any
 	registeredMandatoryFixes map[string]any
@@ -24,12 +29,10 @@ type Fixer struct {
 // RegisterFixes sets the fixes that will be fixed if there are related linter
 // violations that can be fixed by fixes.
 func (f *Fixer) RegisterFixes(fixes ...fixes.Fix) {
-	if f.registeredFixes == nil {
-		f.registeredFixes = make(map[string]any)
-	}
-
 	for _, fix := range fixes {
-		f.registeredFixes[fix.Name()] = fix
+		if _, mandatory := f.registeredMandatoryFixes[fix.Name()]; !mandatory {
+			f.registeredFixes[fix.Name()] = fix
+		}
 	}
 }
 
@@ -37,12 +40,10 @@ func (f *Fixer) RegisterFixes(fixes ...fixes.Fix) {
 // fixes, against all files which are not ignored, regardless of linter
 // violations.
 func (f *Fixer) RegisterMandatoryFixes(fixes ...fixes.Fix) {
-	if f.registeredMandatoryFixes == nil {
-		f.registeredMandatoryFixes = make(map[string]any)
-	}
-
 	for _, fix := range fixes {
 		f.registeredMandatoryFixes[fix.Name()] = fix
+
+		delete(f.registeredFixes, fix.Name())
 	}
 }
 

--- a/pkg/fixer/fixer_test.go
+++ b/pkg/fixer/fixer_test.go
@@ -49,7 +49,7 @@ deny = true
 
 	expectedFileFixedViolations := map[string][]string{
 		// use-assignment-operator is not expected since use-rego-v1 also addresses this in this example
-		"main.rego": {"no-whitespace-comment", "opa-fmt", "use-rego-v1"},
+		"main.rego": {"no-whitespace-comment", "use-rego-v1"},
 	}
 	expectedFileContents := map[string][]byte{
 		"main.rego": []byte(`package test
@@ -64,7 +64,7 @@ deny := true
 `),
 	}
 
-	if got, exp := fixReport.TotalFixes(), 3; got != exp {
+	if got, exp := fixReport.TotalFixes(), 2; got != exp {
 		t.Fatalf("expected %d fixed files, got %d", exp, got)
 	}
 

--- a/pkg/fixer/fixes/fixes.go
+++ b/pkg/fixer/fixes/fixes.go
@@ -9,7 +9,6 @@ import (
 // When a new fix is added, it should be added to this list.
 func NewDefaultFixes() []Fix {
 	return []Fix{
-		&Fmt{},
 		&Fmt{
 			NameOverride: "use-rego-v1",
 			OPAFmtOpts: format.Opts{


### PR DESCRIPTION
Also:
- Removed the code that would send a response back for formatter options that `opa fmt` can't handle. This was a good idea, but since there isn't any obvious way for users to fix that, it hurts more than it helps
- Removed the fmt fix from the default fixer options as formatting is done anyway by the rego-v1 fixer

Fixes #839

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->