### PR TITLE
docs: Fix spelling mistakes

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -77,7 +77,7 @@ build/do.rq test
 
 ### E2E tests
 
-End-to-End (E2E) tests assert the behaviour of the `regal` binary called with certain configs, and test files.
+End-to-End (E2E) tests assert the behavior of the `regal` binary called with certain configs, and test files.
 They expect a `regal` binary either in the top-level directory, or pointed at by `$REGAL_BIN`, and can be run
 locally via
 

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -8,6 +8,7 @@ If you're using Regal, please consider opening a pull request to add your projec
 
 Public open source projects integrating Regal for linting in their CI/CD pipelines.
 
+<!-- cspell:disable -->
 - [Brainiac](https://github.com/carbonetes/brainiac)
 - [Cloudbeat](https://github.com/elastic/cloudbeat)
 - [Conftest](https://github.com/open-policy-agent/conftest)
@@ -25,16 +26,19 @@ Public open source projects integrating Regal for linting in their CI/CD pipelin
 - [Spacelift Policy Library](https://github.com/spacelift-io/spacelift-policies-example-library)
 - [Trino Operator](https://github.com/stackabletech/trino-operator)
 - [Phylum](https://github.com/phylum-dev/policy)
+<!-- cspell:enable -->
 
 ## Integrations
 
 Projects and products that integrate Regal into their offerings.
 
+<!-- cspell:disable -->
 - [Dependency Management Data](https://gitlab.com/tanna.dev/dependency-management-data)
 - [Enterprise OPA](https://github.com/styrainc/enterprise-opa)
 - [The Rego Playground](https://play.openpolicyagent.org)
 - [Trunk Check](https://trunk.io/check)
 - [reviewdog/action-regal](https://github.com/reviewdog/action-regal)
+<!-- cspell:enable-->
 
 ## Packaging
 
@@ -50,11 +54,13 @@ The following package managers include Regal in their repositories, either nativ
 
 Companies and organizations using Regal (not counting organizations behind the open source projects listed above).
 
+<!-- cspell:disable -->
 - [Atlassian](https://www.atlassian.com)
 - [Bankdata](https://www.bankdata.dk)
 - [Miro](https://miro.com)
 - [Stacklok](https://stacklok.com)
 - [Styra](https://www.styra.com)
+<!-- cspell:enable-->
 
 ## Community
 

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -29,7 +29,7 @@ jobs:
 
 Please see [`setup-regal`](https://github.com/StyraInc/setup-regal) for more information.
 
-## GitLab CICD
+## GitLab CI/CD
 
 To use Regal in GitLab CI/CD, you could for example use the following stage in your `.gitlab-ci.yml`:
 

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -28,7 +28,7 @@ by the Regal linter.
   alt="Screenshot of diagnostics as displayed in Zed"/>
 
 Future versions of Regal may include also [compilation errors](https://github.com/StyraInc/regal/issues/745) as part of
-diagnistics messages.
+diagnostics messages.
 
 ### Hover
 
@@ -117,7 +117,8 @@ be suggestions for:
   src={require('./assets/lsp/completion.png').default}
   alt="Screenshot of completion suggestions as displayed in Zed"/>
 
-New completion providers are added continuosly, so if you have a suggestion for a new completion, please
+New completion providers are added continuously, so if you have a suggestion for
+a new completion, please
 [open an issue](https://github.com/StyraInc/regal/issues)!
 
 ### Code actions

--- a/docs/rules/bugs/rule-shadows-builtin.md
+++ b/docs/rules/bugs/rule-shadows-builtin.md
@@ -36,7 +36,7 @@ rules:
 
 - OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
 - OPA Repo: [builtin_metadata.json](https://github.com/open-policy-agent/opa/blob/main/builtin_metadata.json)
-- Regal Docs: [var-shadows-builting](https://docs.styra.com/regal/rules/bugs/var-shadows-builtin)
+- Regal Docs: [var-shadows-builtin](https://docs.styra.com/regal/rules/bugs/var-shadows-builtin)
 
 ## Community
 

--- a/docs/rules/bugs/var-shadows-builtin.md
+++ b/docs/rules/bugs/var-shadows-builtin.md
@@ -52,7 +52,7 @@ rules:
 
 - OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
 - OPA Repo: [builtin_metadata.json](https://github.com/open-policy-agent/opa/blob/main/builtin_metadata.json)
-- Regal Docs: [rule-shadows-builting](https://docs.styra.com/regal/rules/bugs/rule-shadows-builtin)
+- Regal Docs: [rule-shadows-builtin](https://docs.styra.com/regal/rules/bugs/rule-shadows-builtin)
 
 ## Community
 

--- a/docs/rules/idiomatic/prefer-set-or-object-rule.md
+++ b/docs/rules/idiomatic/prefer-set-or-object-rule.md
@@ -150,7 +150,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Genarating Sets](https://www.openpolicyagent.org/docs/latest/policy-language/#generating-sets)
+- OPA Docs: [Generating Sets](https://www.openpolicyagent.org/docs/latest/policy-language/#generating-sets)
 - OPA Docs: [Generating Objects](https://www.openpolicyagent.org/docs/latest/policy-language/#generating-objects)
 - OPA Docs: [Comprehensions](https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions)
 - Styra Blog: [Five Things You Didn't Know About OPA](https://www.styra.com/blog/five-things-you-didnt-know-about-opa/)

--- a/docs/rules/imports/redundant-alias.md
+++ b/docs/rules/imports/redundant-alias.md
@@ -20,7 +20,8 @@ import data.users.permissions
 
 ## Rationale
 
-The last component of an import path is always made referencable by its name inside the package in which it's imported.
+The last component of an import path can always be referenced by the last
+component of the import path itself inside the package in which it's imported.
 Using an alias with the same name is thus redundant, and should be omitted.
 
 ## Configuration Options
@@ -28,7 +29,7 @@ Using an alias with the same name is thus redundant, and should be omitted.
 This linter rule provides the following configuration options:
 
 ```yaml
-rules: 
+rules:
   imports:
     redundant-alias:
       # one of "error", "warning", "ignore"

--- a/docs/rules/testing/metasyntactic-variable.md
+++ b/docs/rules/testing/metasyntactic-variable.md
@@ -31,6 +31,7 @@ occasionally useful in examples, but should be avoided in production policy.
 
 This linter rules forbids any metasyntactic variable names, as listed by Wikipedia:
 
+<!-- cspell:disable -->
 - foobar
 - foo
 - bar
@@ -45,6 +46,7 @@ This linter rules forbids any metasyntactic variable names, as listed by Wikiped
 - plugh
 - xyzzy
 - thud
+<!-- cspell:enable -->
 
 ## Exceptions
 


### PR DESCRIPTION
There were a number of spelling mistakes in the documentation. This PR fixes them as the spelling will soon be enforced in docs.styra.com.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->