### PR TITLE
LSP: Provide output.json option for non-VS Code clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ dist/
 
 /regal
 /regal.exe
+
+# These two files are used by the Regal evaluation Code Lens, where input.json
+# defines the input to use for evaluation, and output.json is where the output
+# ends up unless the client supports presenting it in a different way.
+input.json
+output.json


### PR DESCRIPTION
And use a reader instead of a string for input as suggested by @charlieegan3

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->