### PR TITLE
lsp: No error when missing keywords for hover

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -277,7 +277,7 @@ func (l *LanguageServer) StartHoverWorker(ctx context.Context) {
 		case evt := <-l.builtinsPositionFile:
 			err := l.processHoverContentUpdate(ctx, evt.URI, evt.Content)
 			if err != nil {
-				l.logError(fmt.Errorf("failed to process builtin positions update: %w", err))
+				l.logError(fmt.Errorf("failed to process builtin and keyword positions update: %w", err))
 			}
 		}
 	}
@@ -707,6 +707,8 @@ func (l *LanguageServer) processTextContentUpdate(
 	return false, nil
 }
 
+// processHoverContentUpdate updates information about built in, and keyword
+// positions in the cache for use when handling hover requests.
 func (l *LanguageServer) processHoverContentUpdate(ctx context.Context, fileURI string, content string) error {
 	if l.ignoreURI(fileURI) {
 		return nil
@@ -836,10 +838,8 @@ func (l *LanguageServer) handleTextDocumentHover(
 	}
 
 	keywordsOnLine, ok := l.cache.GetKeywordLocations(params.TextDocument.URI)
-	// when no keywords are found, we can't return a useful hover response.
 	if !ok {
-		l.logError(fmt.Errorf("could not get keywords for uri %q", params.TextDocument.URI))
-
+		// when no keywords are found, we can't return a useful hover response.
 		// return "null" as per the spec
 		return nil, nil
 	}


### PR DESCRIPTION
This means that the keywords for the file have not been computed yet and should be shortly.

There is unlikely much that this message would help with so I have removed it.

The error when processing hover content updates should be enough to establish that the keywords are not being computed, if that ever were to be the case.
