### PR TITLE
Add end location to `metasyntactic-variable` violations

### DIFF
--- a/bundle/regal/rules/testing/metasyntactic_variable.rego
+++ b/bundle/regal/rules/testing/metasyntactic_variable.rego
@@ -26,9 +26,9 @@ metasyntactic := {
 
 report contains violation if {
 	some rule in input.rules
-	some ref in ast.named_refs(rule.head.ref)
+	some part in ast.named_refs(rule.head.ref)
 
-	lower(ref.value) in metasyntactic
+	lower(part.value) in metasyntactic
 
 	# In case we have chained rule bodies — only flag the location where we have an actual name:
 	# foo {
@@ -38,7 +38,7 @@ report contains violation if {
 	# }
 	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
-	violation := result.fail(rego.metadata.chain(), result.location(ref))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(part))
 }
 
 report contains violation if {
@@ -49,5 +49,5 @@ report contains violation if {
 
 	ast.is_output_var(input.rules[to_number(i)], var, var.location)
 
-	violation := result.fail(rego.metadata.chain(), result.location(var))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(var))
 }

--- a/bundle/regal/rules/testing/metasyntactic_variable_test.rego
+++ b/bundle/regal/rules/testing/metasyntactic_variable_test.rego
@@ -11,7 +11,13 @@ test_fail_rule_named_foo if {
 	module := ast.policy("foo := true")
 
 	r := rule.report with input as module
-	r == {expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "foo := true"})}
+	r == {expected_with_location({
+		"col": 1,
+		"file": "policy.rego",
+		"row": 3,
+		"text": "foo := true",
+		"end": {"col": 4, "row": 3},
+	})}
 }
 
 test_fail_metasyntactic_vars if {
@@ -22,8 +28,20 @@ test_fail_metasyntactic_vars if {
 
 	r := rule.report with input as module
 	r == {
-		expected_with_location({"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tfooBar := true"}),
-		expected_with_location({"col": 9, "file": "policy.rego", "row": 5, "text": "\t\tinput[baz]"}),
+		expected_with_location({
+			"col": 3,
+			"file": "policy.rego",
+			"row": 4,
+			"text": "\t\tfooBar := true",
+			"end": {"col": 9, "row": 4},
+		}),
+		expected_with_location({
+			"col": 9,
+			"file": "policy.rego",
+			"row": 5,
+			"text": "\t\tinput[baz]",
+			"end": {"col": 12, "row": 5},
+		}),
 	}
 }
 
@@ -32,9 +50,27 @@ test_fail_metasyntactic_vars_ref_head_strings if {
 
 	r := rule.report with input as module
 	r == {
-		expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "foo.a.BAR.b.C.baz := true"}),
-		expected_with_location({"col": 7, "file": "policy.rego", "row": 3, "text": "foo.a.BAR.b.C.baz := true"}),
-		expected_with_location({"col": 15, "file": "policy.rego", "row": 3, "text": "foo.a.BAR.b.C.baz := true"}),
+		expected_with_location({
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"text": "foo.a.BAR.b.C.baz := true",
+			"end": {"col": 4, "row": 3},
+		}),
+		expected_with_location({
+			"col": 7,
+			"file": "policy.rego",
+			"row": 3,
+			"text": "foo.a.BAR.b.C.baz := true",
+			"end": {"col": 10, "row": 3},
+		}),
+		expected_with_location({
+			"col": 15,
+			"file": "policy.rego",
+			"row": 3,
+			"text": "foo.a.BAR.b.C.baz := true",
+			"end": {"col": 18, "row": 3},
+		}),
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->