### PR TITLE
lsp: include `print` output in eval response

### DIFF
--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -48,12 +48,6 @@ func TestEvalWorkspacePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	empty := EvalPathResult{}
-
-	if res == empty {
-		t.Fatal("expected result, got nil")
-	}
-
 	if val, ok := res.Value.(bool); !ok || val != true {
 		t.Fatalf("expected true, got false")
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -508,7 +508,7 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) {
 
 					err = l.conn.Call(ctx, "regal/showEvalResult", responseParams, &responseResult)
 					if err != nil {
-						l.logError(fmt.Errorf("failed %s notify: %v", "regal/hello", err.Error()))
+						l.logError(fmt.Errorf("regal/showEvalResult failed: %v", err.Error()))
 					}
 				} else {
 					output := filepath.Join(workspacePath, "output.json")


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->