### PR TITLE
Add end location to `non-raw-regex-pattern` violations

### DIFF
--- a/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non_raw_regex_pattern.rego
@@ -58,5 +58,5 @@ report contains violation if {
 
 	chr == `"`
 
-	violation := result.fail(rego.metadata.chain(), result.location(value[pos]))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(value[pos]))
 }

--- a/bundle/regal/rules/idiomatic/non_raw_regex_pattern_test.rego
+++ b/bundle/regal/rules/idiomatic/non_raw_regex_pattern_test.rego
@@ -15,7 +15,13 @@ test_fail_non_raw_rule_head if {
 		"category": "idiomatic",
 		"description": "Use raw strings for regex patterns",
 		"level": "error",
-		"location": {"col": 18, "file": "policy.rego", "row": 3, "text": "x := regex.match(\"[0-9]+\", \"1\")"},
+		"location": {
+			"col": 18,
+			"file": "policy.rego",
+			"row": 3,
+			"text": "x := regex.match(\"[0-9]+\", \"1\")",
+			"end": {"col": 26, "row": 3},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/non-raw-regex-pattern", "idiomatic"),
@@ -33,7 +39,13 @@ test_fail_non_raw_rule_body if {
 		"category": "idiomatic",
 		"description": "Use raw strings for regex patterns",
 		"level": "error",
-		"location": {"col": 18, "file": "policy.rego", "row": 4, "text": "\t\tregex.is_valid(\"[0-9]+\")"},
+		"location": {
+			"col": 18,
+			"file": "policy.rego",
+			"row": 4,
+			"text": "\t\tregex.is_valid(\"[0-9]+\")",
+			"end": {"col": 26, "row": 4},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/non-raw-regex-pattern", "idiomatic"),
@@ -49,7 +61,13 @@ test_fail_pattern_in_second_arg if {
 		"category": "idiomatic",
 		"description": "Use raw strings for regex patterns",
 		"level": "error",
-		"location": {"col": 25, "file": "policy.rego", "row": 3, "text": "r := regex.replace(\"a\", \"[a]\", \"b\")"},
+		"location": {
+			"col": 25,
+			"file": "policy.rego",
+			"row": 3,
+			"text": "r := regex.replace(\"a\", \"[a]\", \"b\")",
+			"end": {"col": 30, "row": 3},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/non-raw-regex-pattern", "idiomatic"),


### PR DESCRIPTION
This was another one that annoyed me recently, so fixed it :)

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->