### PR TITLE
lsp/perf: don't traverse .git or .idea dirs

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1806,6 +1806,12 @@ func (l *LanguageServer) loadWorkspaceContents(ctx context.Context, newOnly bool
 			return fmt.Errorf("failed to walk workspace dir %q: %w", path, err)
 		}
 
+		// These directories often have thousands of items we don't care about,
+		// so don't even traverse them.
+		if d.IsDir() && (d.Name() == ".git" || d.Name() == ".idea") {
+			return filepath.SkipDir
+		}
+
 		// TODO(charlieegan3): make this configurable for things like .rq etc?
 		if d.IsDir() || !strings.HasSuffix(path, ".rego") {
 			return nil


### PR DESCRIPTION
In the Regal workspace, the time to find the workspace .rego files went from 70 ms to 7 ms. Nice!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->