### PR TITLE
Add `input.json` completion provider

### DIFF
--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson.rego
@@ -1,0 +1,60 @@
+package regal.lsp.completion.providers.inputdotjson
+
+import rego.v1
+
+import data.regal.lsp.completion.kind
+import data.regal.lsp.completion.location
+
+# METADATA
+# description: returns suggestions based on input.json structure (if found)
+items contains item if {
+	input.regal.context.input_dot_json_path
+
+	position := location.to_position(input.regal.context.location)
+	line := input.regal.file.lines[position.line]
+	word := location.ref_at(line, input.regal.context.location.col)
+
+	some [suggestion, type] in _matching_input_suggestions
+
+	item := {
+		"label": suggestion,
+		"kind": kind.variable,
+		"detail": type,
+		"documentation": {
+			"kind": "markdown",
+			"value": sprintf("(inferred from [`input.json`](%s))", [input.regal.context.input_dot_json_path]),
+		},
+		"textEdit": {
+			"range": location.word_range(word, position),
+			"newText": suggestion,
+		},
+	}
+}
+
+_matching_input_suggestions contains [suggestion, type] if {
+	position := location.to_position(input.regal.context.location)
+	line := input.regal.file.lines[position.line]
+
+	line != ""
+	location.in_rule_body(line)
+
+	word := location.ref_at(line, input.regal.context.location.col)
+
+	some [suggestion, type] in _input_paths
+
+	startswith(suggestion, word.text)
+}
+
+_input_paths contains [input_path, input_type] if {
+	walk(input.regal.context.input_dot_json, [path, value])
+
+	count(path) > 0
+
+	# don't traverse into arrays
+	every value in path {
+		is_string(value)
+	}
+
+	input_type := type_name(value)
+	input_path := concat(".", ["input", concat(".", path)])
+}

--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
@@ -1,0 +1,102 @@
+package regal.lsp.completion.providers.inputdotjson_test
+
+import rego.v1
+
+import data.regal.lsp.completion.providers.inputdotjson as provider
+
+# regal ignore:rule-length
+test_matching_input_suggestions if {
+	items := provider.items with input as input_obj
+	items == {
+		{
+			"detail": "object",
+			"kind": 6,
+			"label": "input.request",
+			"documentation": {
+				"kind": "markdown",
+				"value": "(inferred from [`input.json`](/foo/bar/input.json))",
+			},
+			"textEdit": {
+				"newText": "input.request",
+				"range": {
+					"end": {"character": 13, "line": 5},
+					"start": {"character": 6, "line": 5},
+				},
+			},
+		},
+		{
+			"detail": "string",
+			"kind": 6,
+			"label": "input.request.method",
+			"documentation": {
+				"kind": "markdown",
+				"value": "(inferred from [`input.json`](/foo/bar/input.json))",
+			},
+			"textEdit": {
+				"newText": "input.request.method",
+				"range": {
+					"end": {"character": 13, "line": 5},
+					"start": {"character": 6, "line": 5},
+				},
+			},
+		},
+		{
+			"detail": "string",
+			"kind": 6,
+			"label": "input.request.url",
+			"documentation": {
+				"kind": "markdown",
+				"value": "(inferred from [`input.json`](/foo/bar/input.json))",
+			},
+			"textEdit": {
+				"newText": "input.request.url",
+				"range": {
+					"end": {"character": 13, "line": 5},
+					"start": {"character": 6, "line": 5},
+				},
+			},
+		},
+	}
+}
+
+test_not_matching_input_suggestions if {
+	input_obj_new_loc := object.union(input_obj, {"regal": {"context": {"location": {
+		"row": 1,
+		"col": 1,
+	}}}})
+	items := provider.items with input as input_obj_new_loc
+	items == set()
+}
+
+input_obj := {"regal": {
+	"context": {
+		"location": {
+			"row": 6,
+			"col": 12,
+		},
+		"input_dot_json": {
+			"user": {
+				"name": {
+					"first": "John",
+					"last": "Doe",
+				},
+				"email": "john@doe.com",
+				"roles": [{"name": "admin"}, {"name": "user"}],
+			},
+			"request": {
+				"method": "GET",
+				"url": "https://example.com",
+			},
+		},
+		"input_dot_json_path": "/foo/bar/input.json",
+	},
+	"file": {"lines": [
+		"package p",
+		"",
+		"import rego.v1",
+		"",
+		"allow if {",
+		"    f(input.r",
+		"}",
+	]},
+}}

--- a/internal/embeds/schemas/regal-ast.json
+++ b/internal/embeds/schemas/regal-ast.json
@@ -394,6 +394,12 @@
             },
             "workspace_root": {
               "type": "string"
+            },
+            "input_dot_json": {
+              "type": "object"
+            },
+            "input_dot_json_path": {
+              "type": "string"
             }
           }
         }

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -2,9 +2,12 @@ package io
 
 import (
 	"fmt"
+	"io"
 	files "io/fs"
 	"log"
 	"os"
+	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/anderseknert/roast/pkg/encoding"
@@ -100,4 +103,22 @@ func ExcludeTestFilter() filter.LoaderFilter {
 			// more polished to deal with this for the time being.
 			info.Name() != "todo_test.rego"
 	}
+}
+
+// FindInput finds input.json file in workspace closest to the file, and returns
+// both the location and the reader.
+func FindInput(file string, workspacePath string) (string, io.Reader) {
+	relative := strings.TrimPrefix(file, workspacePath)
+	components := strings.Split(path.Dir(relative), string(filepath.Separator))
+
+	for i := range len(components) {
+		inputPath := path.Join(workspacePath, path.Join(components[:len(components)-i]...), "input.json")
+
+		f, err := os.Open(inputPath)
+		if err == nil {
+			return inputPath, f
+		}
+	}
+
+	return "", nil
 }

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -5,10 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"path"
-	"path/filepath"
-	"strings"
 
 	"github.com/anderseknert/roast/pkg/encoding"
 
@@ -95,22 +91,6 @@ type EvalPathResult struct {
 	Value       any              `json:"value"`
 	IsUndefined bool             `json:"isUndefined"`
 	PrintOutput map[int][]string `json:"printOutput"`
-}
-
-func FindInput(file string, workspacePath string) io.Reader {
-	relative := strings.TrimPrefix(file, workspacePath)
-	components := strings.Split(path.Dir(relative), string(filepath.Separator))
-
-	for i := range len(components) {
-		inputPath := path.Join(workspacePath, path.Join(components[:len(components)-i]...), "input.json")
-
-		f, err := os.Open(inputPath)
-		if err == nil {
-			return f
-		}
-	}
-
-	return nil
 }
 
 func (l *LanguageServer) EvalWorkspacePath(

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/internal/parse"
 )
 
@@ -108,7 +109,7 @@ func createWithContent(t *testing.T, path string, content string) {
 func readInputString(t *testing.T, file, workspacePath string) string {
 	t.Helper()
 
-	input := FindInput(file, workspacePath)
+	_, input := rio.FindInput(file, workspacePath)
 
 	if input == nil {
 		return ""

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -506,7 +506,7 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) {
 				ruleHeadLocations := allRuleHeadLocations[path]
 
 				workspacePath := uri.ToPath(l.clientIdentifier, l.workspaceRootURI)
-				input := FindInput(uri.ToPath(l.clientIdentifier, file), workspacePath)
+				_, input := rio.FindInput(uri.ToPath(l.clientIdentifier, file), workspacePath)
 
 				result, err := l.EvalWorkspacePath(ctx, path, input)
 				if err != nil {


### PR DESCRIPTION
This provider suggests completions based on the nested attributes found in the `input.json` file, if such a file exists.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->