### PR TITLE
Remove some code made redundant by roast

### DIFF
--- a/bundle/regal/lsp/completion/providers/snippet/snippet.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet.rego
@@ -15,11 +15,7 @@ items contains item if {
 	some label, snippet in _snippets
 
 	strings.any_prefix_match(snippet.prefix, word.text)
-
-	# regal ignore:todo-comment
-	# TODO: use https://github.com/open-policy-agent/opa/pull/6841 when
-	# released.
-	count(regex.find_n(snippet.prefix[0], line, 2)) < 2
+	strings.count(line, snippet.prefix[0]) < 2
 
 	not endswith(trim_space(line), "=")
 


### PR DESCRIPTION
Some special case we previously needed to handle no longer apply since we moved to the roast format. Also fixed a TODO asking to move over to `strings.count` when released, and that is now :)

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->