### PR TITLE
fix: don't serialize error location using roast but encoding/json

### DIFF
--- a/internal/lsp/bundles/cache.go
+++ b/internal/lsp/bundles/cache.go
@@ -59,7 +59,7 @@ func (c *Cache) Refresh() ([]string, error) {
 	var foundBundleRoots []string
 
 	err := filepath.Walk(c.workspacePath, func(path string, info os.FileInfo, _ error) error {
-		if info.IsDir() && (info.Name() == ".git" || info.Name() == ".idea") {
+		if info.IsDir() && (info.Name() == ".git" || info.Name() == ".idea" || info.Name() == "node_modules") {
 			return filepath.SkipDir
 		}
 

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -2,11 +2,10 @@ package lsp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/anderseknert/roast/pkg/encoding"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/storage"
@@ -84,8 +83,6 @@ func updateParse(ctx context.Context, cache *cache.Cache, store storage.Store, f
 			Location: parseError.Location,
 		})
 	} else {
-		json := encoding.JSON()
-
 		jsonErrors, err := json.Marshal(unwrappedError)
 		if err != nil {
 			return false, fmt.Errorf("failed to marshal parse errors: %w", err)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1859,7 +1859,7 @@ func (l *LanguageServer) loadWorkspaceContents(ctx context.Context, newOnly bool
 
 		// These directories often have thousands of items we don't care about,
 		// so don't even traverse them.
-		if d.IsDir() && (d.Name() == ".git" || d.Name() == ".idea") {
+		if d.IsDir() && (d.Name() == ".git" || d.Name() == ".idea" || d.Name() == "node_modules") {
 			return filepath.SkipDir
 		}
 

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -22,7 +22,7 @@ func FilterIgnoredPaths(paths, ignore []string, checkFileExists bool, rootDir st
 		filtered := make([]string, 0, len(paths))
 
 		if err := walkPaths(paths, func(path string, info os.DirEntry, err error) error {
-			if info.IsDir() && (info.Name() == ".git" || info.Name() == ".idea") {
+			if info.IsDir() && (info.Name() == ".git" || info.Name() == ".idea" || info.Name() == "node_modules") {
 				return filepath.SkipDir
 			}
 			if !info.IsDir() && strings.HasSuffix(path, bundle.RegoExt) {


### PR DESCRIPTION
Fixes #1017

Which turned into a bug hunt..

Also fixed:
- ast.resolved_imports crashing on duplicate identifiers
- node_modules not excluded from fs walk, as @srenatus reported

Opening the OPA repo now works as expected. The 500+ linter issues notwithstanding.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->