### PR TITLE
Allow tests to be in 'test' package

### DIFF
--- a/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix.rego
+++ b/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix.rego
@@ -10,7 +10,12 @@ import data.regal.result
 report contains violation if {
 	count(ast.tests) > 0
 
-	not endswith(input.regal.file.name, "_test.rego")
+	not _valid_test_file_name(input.regal.file.name)
 
 	violation := result.fail(rego.metadata.chain(), {"location": {"file": input.regal.file.name}})
 }
+
+_valid_test_file_name(filename) if endswith(filename, "_test.rego")
+
+# Styra DAS convention considered OK
+_valid_test_file_name("test.rego")

--- a/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix_test.rego
+++ b/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix_test.rego
@@ -3,6 +3,7 @@ package regal.rules.testing["file-missing-test-suffix_test"]
 import rego.v1
 
 import data.regal.config
+
 import data.regal.rules.testing["file-missing-test-suffix"] as rule
 
 test_fail_test_in_file_without_test_suffix if {
@@ -11,7 +12,7 @@ test_fail_test_in_file_without_test_suffix if {
 	test_foo { false }
 	`)
 
-	r := rule.report with input as ast with config.for_rule as {"level": "error"}
+	r := rule.report with input as ast
 	r == {{
 		"category": "testing",
 		"description": "Files containing tests should have a _test.rego suffix",
@@ -23,4 +24,24 @@ test_fail_test_in_file_without_test_suffix if {
 		"location": {"file": "policy.rego"},
 		"level": "error",
 	}}
+}
+
+test_success_test_in_file_with_test_suffix if {
+	ast := regal.parse_module("policy_test.rego", `package policy_test
+
+	test_foo { false }
+	`)
+
+	r := rule.report with input as ast
+	r == set()
+}
+
+test_success_test_in_file_named_test if {
+	ast := regal.parse_module("test.rego", `package test
+
+	test_foo { false }
+	`)
+
+	r := rule.report with input as ast
+	r == set()
 }

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package.rego
@@ -8,9 +8,14 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	not endswith(ast.package_name, "_test")
+	not _is_test_package(ast.package_name)
 
 	some rule in ast.tests
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(rule.head))
 }
+
+_is_test_package(package_name) if endswith(package_name, "_test")
+
+# Styra DAS convention considered OK
+_is_test_package("test")

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
@@ -18,7 +18,13 @@ test_fail_test_outside_test_package if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/test-outside-test-package", "testing"),
 		}],
 		"title": "test-outside-test-package",
-		"location": {"col": 1, "file": "p_test.rego", "row": 5, "text": `test_foo if { false }`},
+		"location": {
+			"col": 1,
+			"file": "p_test.rego",
+			"row": 5,
+			"end": {"col": 9, "row": 5},
+			"text": `test_foo if { false }`,
+		},
 		"level": "error",
 	}}
 }


### PR DESCRIPTION
This is a Styra DAS convention, and while I'd say `*_test` is preferred, I think it's OK to allow this single exception.

Also update this rule to report end location.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->