### PR TITLE
Fix missing locals completions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,7 @@ jobs:
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         if: matrix.os.name == 'linux'
         with:
-          version: v1.59.0
+          version: v1.60.3
       - uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
         with:
           name: regal-${{ matrix.os.name }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,6 +26,7 @@ linters:
     - depguard
     - gomoddirectives # need replacements for wasip1
     - execinquery # deprecated
+    - exportloopref # deprecated
 linters-settings:
   tagliatelle:
     case:

--- a/bundle/regal/lsp/completion/location/location.rego
+++ b/bundle/regal/lsp/completion/location/location.rego
@@ -69,7 +69,8 @@ find_rule(rules, location) := [rule |
 # METADATA
 # description: |
 #   find local variables (declared via function arguments, some/every
-#   declarations or assignment) at the given location
+#   declarations or assignment) at the given location. note that this expects
+#   `location` as a map, not a string
 find_locals(rules, location) := ast.find_names_in_local_scope(find_rule(rules, location), location)
 
 # METADATA

--- a/internal/lsp/diff.go
+++ b/internal/lsp/diff.go
@@ -88,6 +88,7 @@ func operations(a, b []string) []*operation {
 				break
 			}
 		}
+
 		add(op, x, y)
 		op = nil
 		// insert (vertical)
@@ -102,6 +103,7 @@ func operations(a, b []string) []*operation {
 
 			y++
 		}
+
 		add(op, x, y)
 		op = nil
 		// equal (diagonal)

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -46,8 +46,8 @@ func PositionFromLocation(loc *ast.Location) types.Position {
 
 func LocationFromPosition(pos types.Position) *ast.Location {
 	return &ast.Location{
-		Row: int(pos.Line + 1),
-		Col: int(pos.Character + 1),
+		Row: int(pos.Line + 1),      // nolint: gosec
+		Col: int(pos.Character + 1), // nolint: gosec
 	}
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2063,6 +2063,7 @@ func positionToOffset(text string, p types.Position) int {
 			bytesRead += len(line) + 1
 		}
 
+		//nolint:gosec
 		if i == int(p.Line)-1 {
 			return bytesRead + int(p.Character)
 		}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -418,7 +418,7 @@ allow := neo4j.q
 	// neo4j.query is an EOPA-specific builtin, it should never appear if
 	// we're using the normal OPA capabilities file.
 	resp := make(map[string]any)
-	err = connClient.Call(ctx, "textDocument/completion", types.CompletionParams{
+	if err = connClient.Call(ctx, "textDocument/completion", types.CompletionParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: mainRegoURI,
 		},
@@ -426,17 +426,13 @@ allow := neo4j.q
 			Line:      2,
 			Character: 16,
 		},
-	}, &resp)
-	//nolint:wsl
-	// NOTE(charles): gofumpt does not want a space here, but golint
-	// requires one to be present.
-	if err != nil {
+	}, &resp); err != nil {
 		t.Fatalf("failed to send completion notification: %s", err)
 	}
 
 	foundNeo4j := false
-	itemsList, ok := resp["items"].([]any)
 
+	itemsList, ok := resp["items"].([]any)
 	if !ok {
 		t.Fatalf("failed to cast resp[items] to []any")
 	}
@@ -455,7 +451,7 @@ allow := neo4j.q
 	}
 
 	if !foundNeo4j {
-		t.Errorf("expected neo4j.query in completion results for neo4j.q")
+		t.Errorf("expected neo4j.query in completion results for neo4j.q, got %v", itemsList)
 	}
 }
 

--- a/internal/lsp/store_test.go
+++ b/internal/lsp/store_test.go
@@ -1,0 +1,110 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"testing"
+
+	"github.com/open-policy-agent/opa/storage"
+
+	"github.com/styrainc/regal/internal/parse"
+)
+
+func TestPutFileModStoresRoastRepresentation(t *testing.T) {
+	t.Parallel()
+
+	store := NewRegalStore()
+	ctx := context.Background()
+	fileURI := "file:///example.rego"
+	module := parse.MustParseModule("package example\n\nrule := true")
+
+	err := PutFileMod(ctx, store, fileURI, module)
+	if err != nil {
+		t.Fatalf("PutFileMod failed: %v", err)
+	}
+
+	parsed, err := storage.ReadOne(ctx, store, storage.Path{"workspace", "parsed", fileURI})
+	if err != nil {
+		t.Fatalf("store.Read failed: %v", err)
+	}
+
+	pretty, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent failed: %v", err)
+	}
+
+	// This is certainly testing the implementation rather than the behavior, but we actually
+	// want some tests to fail if the implementation changes, so we don't have to chase this
+	// down elsewhere.
+	expect := `{
+  "package": {
+    "location": "1:1:cGFja2FnZQ==",
+    "path": [
+      {
+        "location": "1:9:ZXhhbXBsZQ==",
+        "type": "var",
+        "value": "data"
+      },
+      {
+        "location": "1:9:ZXhhbXBsZQ==",
+        "type": "string",
+        "value": "example"
+      }
+    ]
+  },
+  "rules": [
+    {
+      "head": {
+        "assign": true,
+        "location": "3:1:cnVsZSA6PSB0cnVl",
+        "name": "rule",
+        "ref": [
+          {
+            "location": "3:1:cnVsZQ==",
+            "type": "var",
+            "value": "rule"
+          }
+        ],
+        "value": {
+          "location": "3:9:dHJ1ZQ==",
+          "type": "boolean",
+          "value": true
+        }
+      },
+      "location": "3:1:cnVsZSA6PSB0cnVl"
+    }
+  ]
+}`
+
+	if string(pretty) != expect {
+		t.Errorf("expected %s, got %s", expect, pretty)
+	}
+}
+
+func TestPutFileRefs(t *testing.T) {
+	t.Parallel()
+
+	store := NewRegalStore()
+	ctx := context.Background()
+	fileURI := "file:///example.rego"
+
+	err := PutFileRefs(ctx, store, fileURI, []string{"foo", "bar"})
+	if err != nil {
+		t.Fatalf("PutFileRefs failed: %v", err)
+	}
+
+	value, err := storage.ReadOne(ctx, store, storage.Path{"workspace", "defined_refs", fileURI})
+	if err != nil {
+		t.Fatalf("store.Read failed: %v", err)
+	}
+
+	arr, ok := value.([]string)
+	if !ok {
+		t.Fatalf("expected []string, got %T", value)
+	}
+
+	if !slices.Equal(arr, []string{"foo", "bar"}) {
+		t.Fatalf("expected [foo bar], got %v", arr)
+	}
+}

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -10,7 +10,9 @@ import (
 	rio "github.com/styrainc/regal/internal/io"
 )
 
-// ParserOptions provides the parse options necessary to include location data in AST results.
+// ParserOptions provides parser options with annotation processing. JSONOptions are not included,
+// as it is assumed that the caller will marshal the AST to JSON with the roast encoder rather than
+// encoding/json (and consequently, the OPA marshaller implementations).
 func ParserOptions() ast.ParserOptions {
 	return ast.ParserOptions{
 		ProcessAnnotation: true,


### PR DESCRIPTION
This was caused by us no longer passing JSONOPtions to the parser that parsed workspace files, and so when passed to the store, the locations went missing in the roundtrip the store would do before persisting the data.

The store is now created with the roundtrip option disabled, and we'll make sure ourselves that the data is serialized correctly, and in the case of modules — serialized to RoAST. This should mean less data stored in `data.workspace.parsed` and lower latency for policies that rely on that store, which is nice!

Also:
- bump golangci-lint and address some new issues

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->