### PR TITLE
Allow fixing directory structure not matching package paths

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,6 +5,7 @@ linters:
     - rowserrcheck
     - wastedassign
     # annoying
+    - gocyclo
     - tagliatelle
     - nestif
     - gocognit

--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ The Regal language server currently supports the following LSP features:
   - [x] [use-rego-v1](https://docs.styra.com/regal/rules/imports/use-rego-v1)
   - [x] [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator)
   - [x] [no-whitespace-comment](https://docs.styra.com/regal/rules/style/no-whitespace-comment)
+  - [x] [directory-package-mismatch](https://docs.styra.com/regal/rules/idiomatic/directory-package-mismatch)
 - [x] [Code lenses](https://docs.styra.com/regal/language-server#code-lenses-evaluation)
       (click to evaluate any package or rule directly in the editor)
 

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
@@ -7,27 +7,19 @@ import rego.v1
 import data.regal.config
 import data.regal.result
 
-# METADATA
+# - METADATA
 # description: |
 #   emit warning notice when package has more parts than the directory,
-#   as this should likely **not** fail
-notices contains _notice(message, "warning") if {
-	count(_file_path_values) > 0
-	count(_file_path_values) < count(_pkg_path_values)
+# #   as this should likely **not** fail
+# notices contains _notice(message, "warning") if {
+# 	count(_file_path_values) > 0
+# 	count(_file_path_values) < count(_pkg_path_values)
 
-	message := sprintf(
-		"package '%s' has more parts than provided directory path '%s'",
-		[concat(".", _pkg_path_values), concat("/", _file_path_values)],
-	)
-}
-
-# METADATA
-# description: emit notice when single file is provided, but with no severity
-notices contains _notice(message, "none") if {
-	count(_file_path_values) == 0
-
-	message := "provided file has no directory components in its path... try linting a directory"
-}
+# 	message := sprintf(
+# 		"package '%s' has more parts than provided directory path '%s'",
+# 		[concat(".", _pkg_path_values), concat("/", _file_path_values)],
+# 	)
+# }
 
 report contains violation if {
 	# get the last n components from file path, where n == count(_pkg_path_values)
@@ -49,10 +41,10 @@ _pkg_path := [p.value |
 	i > 0
 ]
 
-_pkg_path_values := without_test_suffix if {
-	cfg := config.for_rule("idiomatic", "directory-package-mismatch")
+_pkg_path_values := _pkg_path if not config.for_rule("idiomatic", "directory-package-mismatch")["exclude-test-suffix"]
 
-	cfg["exclude-test-suffix"]
+_pkg_path_values := without_test_suffix if {
+	config.for_rule("idiomatic", "directory-package-mismatch")["exclude-test-suffix"]
 
 	without_test_suffix := array.concat(
 		array.slice(_pkg_path, 0, count(_pkg_path) - 1),

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
@@ -36,32 +36,6 @@ test_success_directory_structure_package_path_match_shorter_directory_path if {
 	r == set()
 }
 
-test_notice_severity_warning_when_directory_path_shorter_than_package_path if {
-	module := regal.parse_module("bar/baz/p.rego", "package foo.bar.baz")
-	r := rule.notices with input as module with config.for_rule as default_config
-
-	r == {{
-		"category": "idiomatic",
-		"description": "package 'foo.bar.baz' has more parts than provided directory path 'bar/baz'",
-		"level": "notice",
-		"severity": "warning",
-		"title": "directory-package-mismatch",
-	}}
-}
-
-test_notice_severity_none_when_no_path_likely_single_file_provided if {
-	module := regal.parse_module("p.rego", "package p")
-	r := rule.notices with input as module with config.for_rule as default_config
-
-	r == {{
-		"category": "idiomatic",
-		"description": "provided file has no directory components in its path... try linting a directory",
-		"level": "notice",
-		"severity": "none",
-		"title": "directory-package-mismatch",
-	}}
-}
-
 with_location(location) := {{
 	"category": "idiomatic",
 	"description": "Directory structure should mirror package",

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -240,7 +240,13 @@ func fix(args []string, params *fixCommandParams) error {
 		log.Println("no user-provided config file found, will use the default config")
 	}
 
+	roots, err := config.GetPotentialRoots(args...)
+	if err != nil {
+		return fmt.Errorf("could not find potential roots: %w", err)
+	}
+
 	f := fixer.NewFixer()
+	f.RegisterRoots(roots...)
 	f.RegisterFixes(fixes.NewDefaultFixes()...)
 	f.RegisterMandatoryFixes(
 		&fixes.Fmt{

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -1,7 +1,10 @@
 package io
 
 import (
+	"slices"
 	"testing"
+
+	"github.com/open-policy-agent/opa/util/test"
 )
 
 func TestJSONRoundTrip(t *testing.T) {
@@ -21,4 +24,33 @@ func TestJSONRoundTrip(t *testing.T) {
 	if f.Bar != "foo" {
 		t.Errorf("expected JSON roundtrip to set struct value")
 	}
+}
+
+func TestFindManifestLocations(t *testing.T) {
+	t.Parallel()
+
+	fs := map[string]string{
+		"/.git":                          "",
+		"/foo/bar/baz/.manifest":         "",
+		"/foo/bar/qux/.manifest":         "",
+		"/foo/bar/.regal/.manifest.yaml": "",
+		"/node_modules/.manifest":        "",
+	}
+
+	test.WithTempFS(fs, func(root string) {
+		locations, err := FindManifestLocations(root)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(locations) != 2 {
+			t.Errorf("expected 2 locations, got %d", len(locations))
+		}
+
+		expected := []string{"foo/bar/baz", "foo/bar/qux"}
+
+		if !slices.Equal(locations, expected) {
+			t.Errorf("expected %v, got %v", expected, locations)
+		}
+	})
 }

--- a/internal/lsp/bundles/cache.go
+++ b/internal/lsp/bundles/cache.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/open-policy-agent/opa/bundle"
 
+	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/internal/util"
 )
 
@@ -56,26 +57,7 @@ func (c *Cache) Refresh() ([]string, error) {
 	}
 
 	// find all the bundle roots that are currently present on disk
-	var foundBundleRoots []string
-
-	err := filepath.Walk(c.workspacePath, func(path string, info os.FileInfo, _ error) error {
-		if info.IsDir() && (info.Name() == ".git" || info.Name() == ".idea" || info.Name() == "node_modules") {
-			return filepath.SkipDir
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		if filepath.Base(path) == ".manifest" {
-			foundBundleRoots = append(
-				foundBundleRoots,
-				strings.TrimPrefix(filepath.Dir(path), c.workspacePath),
-			)
-		}
-
-		return nil
-	})
+	foundBundleRoots, err := rio.FindManifestLocations(c.workspacePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to walk workspace path: %w", err)
 	}

--- a/internal/lsp/command.go
+++ b/internal/lsp/command.go
@@ -46,3 +46,12 @@ func NoWhiteSpaceCommentCommand(args []string) types.Command {
 		Arguments: toAnySlice(args),
 	}
 }
+
+func DirectoryStructureMismatchCommand(args []string) types.Command {
+	return types.Command{
+		Title:     "Fix directory structure / package path mismatch",
+		Command:   "regal.fix.directory-package-mismatch",
+		Tooltip:   "Fix directory structure / package path mismatch",
+		Arguments: toAnySlice(args),
+	}
+}

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -83,8 +83,8 @@ type ShowMessageParams struct {
 }
 
 type StaleRequestSupportClientCapabilities struct {
-	Cancel                  bool     `json:"cancel"`
-	RetryOnContentModifieds []string `json:"retryOnContentModified"`
+	Cancel                 bool     `json:"cancel"`
+	RetryOnContentModified []string `json:"retryOnContentModified"`
 }
 
 type InitializeResult struct {
@@ -223,6 +223,30 @@ type ExecuteCommandParams struct {
 type ApplyWorkspaceEditParams struct {
 	Label string        `json:"label"`
 	Edit  WorkspaceEdit `json:"edit"`
+}
+
+type ApplyWorkspaceRenameEditParams struct {
+	Label string              `json:"label"`
+	Edit  WorkspaceRenameEdit `json:"edit"`
+}
+
+type RenameFileOptions struct {
+	Overwrite      bool `json:"overwrite"`
+	IgnoreIfExists bool `json:"ignoreIfExists"`
+}
+
+type RenameFile struct {
+	Kind                 string             `json:"kind"` // must always be "rename"
+	OldURI               string             `json:"oldUri"`
+	NewURI               string             `json:"newUri"`
+	Options              *RenameFileOptions `json:"options,omitempty"`
+	AnnotationIdentifier *string            `json:"annotationId,omitempty"`
+}
+
+// WorkspaceRenameEdit is a WorkspaceEdit that is used for renaming files.
+// Perhaps we should use generics and a union type here instead.
+type WorkspaceRenameEdit struct {
+	DocumentChanges []RenameFile `json:"documentChanges"`
 }
 
 type WorkspaceEdit struct {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -64,10 +65,69 @@ func SearchMap(object map[string]any, path []string) (any, error) {
 	return current, nil
 }
 
+// Must takes a value and an error (as commonly returned by Go functions) and panics if the error is not nil.
 func Must[T any](v T, err error) T {
 	if err != nil {
 		panic(err)
 	}
 
 	return v
+}
+
+// Map applies a function to each element of a slice and returns a new slice with the results.
+func Map[T, U any](f func(T) U, a []T) []U {
+	b := make([]U, len(a))
+
+	for i, v := range a {
+		b[i] = f(v)
+	}
+
+	return b
+}
+
+// MapInvert inverts a map (swaps keys and values).
+func MapInvert[K comparable, V comparable](m map[K]V) map[V]K {
+	n := make(map[V]K, len(m))
+	for k, v := range m {
+		n[v] = k
+	}
+
+	return n
+}
+
+// FindClosestMatchingRoot finds the closest matching root for a given path.
+// If no matching root is found, an empty string is returned.
+func FindClosestMatchingRoot(path string, roots []string) string {
+	currentLongestSuffix := 0
+	longestSuffixIndex := -1
+
+	for i, root := range roots {
+		if root == path {
+			return path
+		}
+
+		if !strings.HasPrefix(path, root) {
+			continue
+		}
+
+		suffix := strings.TrimPrefix(root, path)
+
+		if len(suffix) > currentLongestSuffix {
+			currentLongestSuffix = len(suffix)
+			longestSuffixIndex = i
+		}
+	}
+
+	if longestSuffixIndex == -1 {
+		return ""
+	}
+
+	return roots[longestSuffixIndex]
+}
+
+// FilepathJoiner returns a function that joins provided path with base path.
+func FilepathJoiner(base string) func(string) string {
+	return func(path string) string {
+		return filepath.Join(base, path)
+	}
 }

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,50 @@
+package util
+
+import "testing"
+
+func TestFindClosestMatchingRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		roots    []string
+		path     string
+		expected string
+	}{
+		{
+			name:     "different length roots",
+			roots:    []string{"/a/b/c", "/a/b", "/a"},
+			path:     "/a/b/c/d/e/f",
+			expected: "/a/b/c",
+		},
+		{
+			name:     "exact match",
+			roots:    []string{"/a/b/c", "/a/b", "/a"},
+			path:     "/a/b",
+			expected: "/a/b",
+		},
+		{
+			name:     "mixed roots",
+			roots:    []string{"/a/b/c/b/a", "/c/b", "/a/d/c/f"},
+			path:     "/c/b/a",
+			expected: "/c/b",
+		},
+		{
+			name:     "no matching root",
+			roots:    []string{"/a/b/c"},
+			path:     "/d",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := FindClosestMatchingRoot(test.path, test.roots)
+			if got != test.expected {
+				t.Fatalf("expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gobwas/glob"
 
 	"github.com/open-policy-agent/opa/bundle"
+
+	rio "github.com/styrainc/regal/internal/io"
 )
 
 func FilterIgnoredPaths(paths, ignore []string, checkFileExists bool, rootDir string) ([]string, error) {
@@ -22,9 +24,10 @@ func FilterIgnoredPaths(paths, ignore []string, checkFileExists bool, rootDir st
 		filtered := make([]string, 0, len(paths))
 
 		if err := walkPaths(paths, func(path string, info os.DirEntry, err error) error {
-			if info.IsDir() && (info.Name() == ".git" || info.Name() == ".idea" || info.Name() == "node_modules") {
+			if rio.IsSkipWalkDirectory(info) {
 				return filepath.SkipDir
 			}
+
 			if !info.IsDir() && strings.HasSuffix(path, bundle.RegoExt) {
 				filtered = append(filtered, path)
 			}

--- a/pkg/fixer/fileprovider/fp.go
+++ b/pkg/fixer/fileprovider/fp.go
@@ -6,5 +6,6 @@ type FileProvider interface {
 	ListFiles() ([]string, error)
 	GetFile(string) ([]byte, error)
 	PutFile(string, []byte) error
+	DeleteFile(string) error
 	ToInput() (rules.Input, error)
 }

--- a/pkg/fixer/fileprovider/inmem.go
+++ b/pkg/fixer/fileprovider/inmem.go
@@ -43,6 +43,12 @@ func (p *InMemoryFileProvider) PutFile(file string, content []byte) error {
 	return nil
 }
 
+func (p *InMemoryFileProvider) DeleteFile(file string) error {
+	delete(p.files, file)
+
+	return nil
+}
+
 func (p *InMemoryFileProvider) ToInput() (rules.Input, error) {
 	modules := make(map[string]*ast.Module)
 

--- a/pkg/fixer/fixer_test.go
+++ b/pkg/fixer/fixer_test.go
@@ -64,7 +64,7 @@ deny := true
 `),
 	}
 
-	if got, exp := fixReport.TotalFixes(), 2; got != exp {
+	if got, exp := fixReport.TotalFixes(), uint(2); got != exp {
 		t.Fatalf("expected %d fixed files, got %d", exp, got)
 	}
 
@@ -93,15 +93,21 @@ deny := true
 		}
 
 		// check that the fixed violations are correct
-		fixedViolations := fixReport.FixedViolationsForFile(file)
+		fxs := fixReport.FixesForFile(file)
 
-		expectedViolations, ok := expectedFileFixedViolations[file]
+		expectedFixes, ok := expectedFileFixedViolations[file]
 		if !ok {
 			t.Fatalf("unexpected file waas fixed %s", file)
 		}
 
-		if !slices.Equal(fixedViolations, expectedViolations) {
-			t.Fatalf("unexpected fixed violations for %s:\ngot: %v\nexpected: %v", file, fixedViolations, expectedViolations)
+		if len(fxs) != len(expectedFixes) {
+			t.Fatalf("unexpected number of fixes for %s:\ngot: %v\nexpected: %v", file, fxs, expectedFixes)
+		}
+
+		for _, fx := range fxs {
+			if !slices.Contains(expectedFixes, fx.Title) {
+				t.Fatalf("expected fixes to contain %s:\ngot: %v", fx.Title, expectedFixes)
+			}
 		}
 	}
 }
@@ -166,7 +172,7 @@ deny := true
 `),
 	}
 
-	if got, exp := fixReport.TotalFixes(), 1; got != exp {
+	if got, exp := fixReport.TotalFixes(), uint(1); got != exp {
 		t.Fatalf("expected %d fixed files, got %d", exp, got)
 	}
 
@@ -195,15 +201,21 @@ deny := true
 		}
 
 		// check that the fixed violations are correct
-		fixedViolations := fixReport.FixedViolationsForFile(file)
+		fxs := fixReport.FixesForFile(file)
 
-		expectedViolations, ok := expectedFileFixedViolations[file]
+		expectedFixes, ok := expectedFileFixedViolations[file]
 		if !ok {
 			t.Fatalf("unexpected file waas fixed %s", file)
 		}
 
-		if !slices.Equal(fixedViolations, expectedViolations) {
-			t.Fatalf("unexpected fixed violations for %s:\ngot: %v\nexpected: %v", file, fixedViolations, expectedViolations)
+		if len(fxs) != len(expectedFixes) {
+			t.Fatalf("unexpected number of fixes for %s:\ngot: %v\nexpected: %v", file, fxs, expectedFixes)
+		}
+
+		for _, fx := range fxs {
+			if !slices.Contains(expectedFixes, fx.Title) {
+				t.Fatalf("expected fixes to contain %s:\ngot: %v", fx.Title, expectedFixes)
+			}
 		}
 	}
 }

--- a/pkg/fixer/fixes/directorypackagemismatch.go
+++ b/pkg/fixer/fixes/directorypackagemismatch.go
@@ -1,0 +1,183 @@
+package fixes
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/pkg/config"
+)
+
+type DirectoryPackageMismatch struct {
+	// DryRun indicates whether this fixer should perform the actual rename or not, and if true simply signals to the
+	// client which file should be moved and to where. Whether to actually treat it as a "dry run" is up to the client.
+	DryRun bool
+}
+
+func (*DirectoryPackageMismatch) Name() string {
+	return "directory-package-mismatch"
+}
+
+// For now, just handle the "normal" set of characters, plus hyphens.
+// We can broaden this later, but we should avoid characters that may have
+// special meaning in files and directories.
+var regularName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
+
+// Fix moves a file to the correct directory based on the package name, and relative to the base
+// directory provided in opts. If the file is already in the correct directory, no action is taken.
+// If the DryRun field is set to true, the file is not moved by the fixer, but will rather have the
+// old location and new location passed back to the client who will decide what to do with that.
+func (d *DirectoryPackageMismatch) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
+	pkgPath, err := getPackagePathDirectory(fc, opts.Config)
+	if err != nil {
+		return nil, err
+	}
+
+	rootPath := opts.BaseDir
+	if rootPath == "" {
+		rootPath = filepath.Dir(fc.Filename)
+	}
+
+	rootPath = filepath.Clean(rootPath)
+
+	newPath := filepath.Join(rootPath, pkgPath, filepath.Base(fc.Filename))
+
+	if newPath == fc.Filename {
+		return nil, nil // File is where it should be. We are done!
+	}
+
+	if d.DryRun {
+		newRel, err := filepath.Rel(rootPath, newPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to calculate relative path: %w", err)
+		}
+
+		return []FixResult{{
+			Title:    d.Name(),
+			Root:     rootPath,
+			Contents: fc.Contents,
+			Rename: &Rename{
+				FromPath: fc.Filename,
+				ToPath:   filepath.Join(rootPath, newRel),
+			},
+		}}, nil
+	}
+
+	if err := recursiveMoveFile(fc.Filename, newPath); err != nil {
+		return nil, fmt.Errorf("unexpected error when moving file %w", err)
+	}
+
+	if err := cleanOldPath(rootPath, fc.Filename); err != nil {
+		return nil, fmt.Errorf("failed to clean up directory made empty by moving file %w", err)
+	}
+
+	return []FixResult{{
+		Title:    d.Name(),
+		Root:     rootPath,
+		Contents: fc.Contents,
+		Rename: &Rename{
+			FromPath: fc.Filename,
+			ToPath:   newPath, // TODO: should we check that this is relative to base somewhere?
+		},
+	}}, nil
+}
+
+func getPackagePathDirectory(fc *FixCandidate, config *config.Config) (string, error) {
+	module, err := ast.ParseModule(fc.Filename, string(fc.Contents))
+	if err != nil {
+		return "", err // nolint:wrapcheck
+	}
+
+	parts := make([]string, len(module.Package.Path)-1)
+	excludeTestSuffix := shouldExcludeTestSuffix(config)
+	pathWithoutData := module.Package.Path[1:]
+
+	for i, part := range pathWithoutData {
+		text := strings.Trim(part.Value.String(), "\"")
+
+		if !regularName.MatchString(text) {
+			return "", fmt.Errorf("can only handle [a-zA-Z0-9_-] characters in package name, got: %s", text)
+		}
+
+		if i == len(pathWithoutData)-1 && excludeTestSuffix {
+			text = strings.TrimSuffix(text, "_test")
+		}
+
+		parts[i] = text
+	}
+
+	return filepath.Join(parts...), nil
+}
+
+// nolint:wrapcheck
+func recursiveMoveFile(oldPath, newPath string) error {
+	_, err := os.Stat(filepath.Dir(newPath))
+	if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+
+	err = os.Rename(oldPath, newPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// nolint:wrapcheck
+func cleanOldPath(rootPath, oldPath string) error {
+	// Remove empty directories
+	dir := filepath.Dir(oldPath)
+
+	f, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if errors.Is(err, io.EOF) { // dir is empty
+		if err := os.Remove(dir); err != nil {
+			return err
+		}
+
+		// traverse one level up in the directory tree to see
+		// if we've left more empty directories behind
+		up, _ := filepath.Split(dir)
+
+		if up != rootPath {
+			return cleanOldPath(rootPath, up)
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func shouldExcludeTestSuffix(config *config.Config) bool {
+	if category, ok := config.Rules["idiomatic"]; ok {
+		if rule, ok := category["directory-package-mismatch"]; ok {
+			if exclude, ok := rule.Extra["exclude-test-suffix"].(bool); ok {
+				return exclude
+			}
+		}
+	}
+
+	// this is the default, and this should be unreachable provided that the
+	// provided configuration was included (which it always would be)
+	return true
+}

--- a/pkg/fixer/fixes/directorypackagemismatch_test.go
+++ b/pkg/fixer/fixes/directorypackagemismatch_test.go
@@ -1,0 +1,252 @@
+package fixes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/styrainc/regal/pkg/config"
+)
+
+func TestFixDirectoryPackageMismatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		files             map[string]string
+		expected          map[string]string
+		wantErr           string
+		includeTestSuffix bool // inverse of exclude-text-suffix to avoid providing the default everywhere
+	}{
+		{
+			name: "files are moved according to their package",
+			files: map[string]string{
+				"main.rego":    "package main",
+				"foo/bar.rego": "package bar",
+				"foo/baz.rego": "package foo.baz",
+			},
+			expected: map[string]string{
+				"main/main.rego":   "package main",
+				"bar/bar.rego":     "package bar",
+				"foo/baz/baz.rego": "package foo.baz",
+			},
+		},
+		{
+			name: "empty directories are cleaned up",
+			files: map[string]string{
+				"foo/bar.rego": "package bar",
+			},
+			expected: map[string]string{
+				"bar/bar.rego": "package bar",
+			},
+		},
+		{
+			name: "non-empty directories are not cleaned up",
+			files: map[string]string{
+				"foo/bar.rego":  "package bar",
+				"foo/README.md": "This is docs!",
+			},
+			expected: map[string]string{
+				"bar/bar.rego":  "package bar",
+				"foo/README.md": "This is docs!",
+			},
+		},
+		{
+			name: "nested directories are created correctly",
+			files: map[string]string{
+				"baz.rego": "package foo.bar.baz",
+				"qux.rego": "package foo.bar",
+			},
+			expected: map[string]string{
+				"foo/bar/baz/baz.rego": "package foo.bar.baz",
+				"foo/bar/qux.rego":     "package foo.bar",
+			},
+		},
+		{
+			name: "nested directories are cleaned up correctly",
+			files: map[string]string{
+				"foo/bar/qux/yoo/foo.rego": "package foo",
+				"foo/bar/foo.bar.rego":     "package foo.bar",
+			},
+			expected: map[string]string{
+				"foo/foo.rego":         "package foo",
+				"foo/bar/foo.bar.rego": "package foo.bar",
+			},
+		},
+		{
+			name: "package name with hyphens creates directories with hyphens",
+			files: map[string]string{
+				"foo.rego": `package foo["bar-baz"].qux`,
+			},
+			expected: map[string]string{
+				"foo/bar-baz/qux/foo.rego": `package foo["bar-baz"].qux`,
+			},
+		},
+		{
+			name: "package name with special characters returns an error",
+			files: map[string]string{
+				"foo.rego": `package foo["bar/baz"].qux`,
+			},
+			expected: map[string]string{
+				"foo.rego": `package foo["bar/baz"].qux`,
+			},
+			wantErr: "can only handle [a-zA-Z0-9_-] characters in package name, got: bar/baz",
+		},
+		{
+			name: "package names with _test suffix are by default treated as if without the suffix",
+			files: map[string]string{
+				"foo_test.rego": "package foo_test",
+				"foo.rego":      "package foo",
+			},
+			expected: map[string]string{
+				"foo/foo_test.rego": "package foo_test",
+				"foo/foo.rego":      "package foo",
+			},
+		},
+		{
+			name: "package names with _test suffix are accounted for when config exclude-test-suffix is false",
+			files: map[string]string{
+				"foo_test.rego": "package foo_test",
+				"foo.rego":      "package foo",
+			},
+			expected: map[string]string{
+				"foo_test/foo_test.rego": "package foo_test",
+				"foo/foo.rego":           "package foo",
+			},
+			includeTestSuffix: true,
+		},
+		{
+			name: "nested package names with _test suffix are accounted for when config exclude-test-suffix is false",
+			files: map[string]string{
+				"foo_test.rego":    "package foo.bar.baz_test",
+				"foo.rego":         "package foo.bar.baz",
+				"qux.rego":         "package foo[\"bar-baz\"].qux",
+				"bar/bar/bar.rego": "package foo[\"bar-baz\"].qux_test",
+			},
+			expected: map[string]string{
+				"foo/bar/baz_test/foo_test.rego": "package foo.bar.baz_test",
+				"foo/bar/baz/foo.rego":           "package foo.bar.baz",
+				"foo/bar-baz/qux/qux.rego":       "package foo[\"bar-baz\"].qux",
+				"foo/bar-baz/qux_test/bar.rego":  "package foo[\"bar-baz\"].qux_test",
+			},
+			includeTestSuffix: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			baseDir := filepath.Join(tmpDir, "bundle")
+
+			writeFiles(t, baseDir, tc.files)
+
+			dpm := DirectoryPackageMismatch{}
+
+			for file, contents := range tc.files {
+				if !strings.HasSuffix(file, ".rego") {
+					continue
+				}
+
+				_, err := dpm.Fix(&FixCandidate{
+					Filename: filepath.Join(baseDir, file),
+					Contents: []byte(contents),
+				}, &RuntimeOptions{
+					BaseDir: baseDir,
+					Config:  configWithExcludeTestSuffix(!tc.includeTestSuffix),
+				})
+				if err != nil {
+					if tc.wantErr == "" {
+						t.Errorf("failed to fix %s: %v", file, err)
+					}
+
+					if strings.Contains(err.Error(), tc.wantErr) {
+						continue
+					} else {
+						t.Errorf("expected error to contain %q, got %q", tc.wantErr, err.Error())
+					}
+				}
+			}
+
+			result := readFiles(t, baseDir)
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("expected %d files, got %d", len(tc.expected), len(result))
+			}
+
+			for file, contents := range tc.expected {
+				if result[file] != contents {
+					t.Errorf("expected %s to be %s, got %s", file, contents, result[file])
+				}
+			}
+		})
+	}
+}
+
+func writeFiles(t *testing.T, path string, files map[string]string) {
+	t.Helper()
+
+	for file, contents := range files {
+		filePath := filepath.Join(path, file)
+
+		dir := filepath.Dir(filePath)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create directory %s: %v", dir, err)
+		}
+
+		err := os.WriteFile(filePath, []byte(contents), 0o600)
+		if err != nil {
+			t.Fatalf("failed to write file %s: %v", filePath, err)
+		}
+	}
+}
+
+// recursively traverse dir entry and create a map[string]string of all files
+// where the key is the full path, and the value is the file contents.
+func readFiles(t *testing.T, baseDir string) map[string]string {
+	t.Helper()
+
+	files := make(map[string]string)
+
+	err := filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Fatalf("failed to walk path %s: %v", path, err)
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file %s: %v", path, err)
+		}
+
+		relPath, _ := filepath.Rel(baseDir, path)
+		files[relPath] = string(contents)
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("failed to walk path %s: %v", baseDir, err)
+	}
+
+	return files
+}
+
+func configWithExcludeTestSuffix(exclude bool) *config.Config {
+	return &config.Config{
+		Rules: map[string]config.Category{
+			"idiomatic": {
+				"directory-package-mismatch": config.Rule{
+					Level: "ignore",
+					Extra: map[string]any{
+						"exclude-test-suffix": exclude,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/fixer/fixes/fixes.go
+++ b/pkg/fixer/fixes/fixes.go
@@ -3,11 +3,30 @@ package fixes
 import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/format"
+
+	"github.com/styrainc/regal/internal/lsp/clients"
+	"github.com/styrainc/regal/pkg/config"
 )
 
 // NewDefaultFixes returns a list of default fixes that are applied by the fix command.
 // When a new fix is added, it should be added to this list.
 func NewDefaultFixes() []Fix {
+	return []Fix{
+		&Fmt{
+			NameOverride: "use-rego-v1",
+			OPAFmtOpts: format.Opts{
+				RegoVersion: ast.RegoV0CompatV1,
+			},
+		},
+		&UseAssignmentOperator{},
+		&NoWhitespaceComment{},
+		&DirectoryPackageMismatch{},
+	}
+}
+
+// NewDefaultFormatterFixes returns a list of default fixes that are applied by the formatter.
+// Notably, this does not include fixers that move files around.
+func NewDefaultFormatterFixes() []Fix {
 	return []Fix{
 		&Fmt{
 			NameOverride: "use-rego-v1",
@@ -31,6 +50,11 @@ type Fix interface {
 // RuntimeOptions are the options that are passed to the Fix method when the Fix is executed.
 // Location based fixes will have the locations populated by the caller.
 type RuntimeOptions struct {
+	// BaseDir is the base directory for the files being fixed. This is often the same as the
+	// workspace root directory, but not necessarily.
+	BaseDir   string
+	Config    *config.Config
+	Client    clients.Identifier
 	Locations []ast.Location
 }
 
@@ -40,8 +64,27 @@ type FixCandidate struct {
 	Contents []byte
 }
 
+// Rename represents a file that has been moved (renamed).
+type Rename struct {
+	FromPath string
+	ToPath   string
+}
+
 // FixResult is returned from the Fix method and contains the new contents or fix recommendations.
-// In future this might support diff based updates, or renames.
+// In future this might support diff based updates.
 type FixResult struct {
+	// Title is the name of the fix applied.
+	Title string
+	// Root is the project root of the file fixed. This is persisted for presentation purposes,
+	// as it makes it easier to understand the context of the fix.
+	Root string
+	// Contents is the new contents of the file. May be nil or identical to the original contents,
+	// as not all fixes involve content changes. It is the responsibility of the caller to handle
+	// this.
 	Contents []byte
+	// Rename is used to indicate that a rename operation should be performed by the **caller**.
+	// An example of this would be the DirectoryPackageMismatch fix, which in the context of
+	// `regal fix` renames files as part of the fix, while when invoked as a LSP Code Action will
+	// defer the actual rename back to the client.
+	Rename *Rename
 }

--- a/pkg/fixer/fixes/fmt.go
+++ b/pkg/fixer/fixes/fmt.go
@@ -27,7 +27,7 @@ func (f *Fmt) Name() string {
 	return "opa-fmt"
 }
 
-func (f *Fmt) Fix(fc *FixCandidate, _ *RuntimeOptions) ([]FixResult, error) {
+func (f *Fmt) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
 	if fc.Filename == "" {
 		return nil, errors.New("filename is required when formatting")
 	}
@@ -41,9 +41,9 @@ func (f *Fmt) Fix(fc *FixCandidate, _ *RuntimeOptions) ([]FixResult, error) {
 		return nil, nil
 	}
 
-	return []FixResult{
-		{
-			Contents: formatted,
-		},
-	}, nil
+	return []FixResult{{
+		Title:    f.Name(),
+		Root:     opts.BaseDir,
+		Contents: formatted,
+	}}, nil
 }

--- a/pkg/fixer/fixes/fmt_test.go
+++ b/pkg/fixer/fixes/fmt_test.go
@@ -55,7 +55,9 @@ allow := true
 		t.Run(testName, func(t *testing.T) {
 			t.Parallel()
 
-			fixResults, err := tc.fmt.Fix(tc.fc, nil)
+			fixResults, err := tc.fmt.Fix(tc.fc, &RuntimeOptions{
+				BaseDir: "",
+			})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/pkg/fixer/fixes/nowhitespacecomment.go
+++ b/pkg/fixer/fixes/nowhitespacecomment.go
@@ -12,7 +12,7 @@ func (*NoWhitespaceComment) Name() string {
 	return "no-whitespace-comment"
 }
 
-func (*NoWhitespaceComment) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
+func (n *NoWhitespaceComment) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
 	lines := bytes.Split(fc.Contents, []byte("\n"))
 
 	if opts == nil {
@@ -46,5 +46,9 @@ func (*NoWhitespaceComment) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixRe
 		return nil, nil
 	}
 
-	return []FixResult{{Contents: bytes.Join(lines, []byte("\n"))}}, nil
+	return []FixResult{{
+		Title:    n.Name(),
+		Root:     opts.BaseDir,
+		Contents: bytes.Join(lines, []byte("\n")),
+	}}, nil
 }

--- a/pkg/fixer/fixes/useassignmentoperator.go
+++ b/pkg/fixer/fixes/useassignmentoperator.go
@@ -12,7 +12,7 @@ func (*UseAssignmentOperator) Name() string {
 	return "use-assignment-operator"
 }
 
-func (*UseAssignmentOperator) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
+func (u *UseAssignmentOperator) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
 	lines := bytes.Split(fc.Contents, []byte("\n"))
 
 	if opts == nil {
@@ -45,5 +45,9 @@ func (*UseAssignmentOperator) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]Fix
 		return nil, nil
 	}
 
-	return []FixResult{{Contents: bytes.Join(lines, []byte("\n"))}}, nil
+	return []FixResult{{
+		Title:    u.Name(),
+		Root:     opts.BaseDir,
+		Contents: bytes.Join(lines, []byte("\n")),
+	}}, nil
 }

--- a/pkg/fixer/reporter_test.go
+++ b/pkg/fixer/reporter_test.go
@@ -1,0 +1,73 @@
+package fixer
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/styrainc/regal/pkg/fixer/fixes"
+)
+
+func TestPrettyReporterOutput(t *testing.T) {
+	t.Parallel()
+
+	var buffer bytes.Buffer
+
+	reporter := NewPrettyReporter(&buffer)
+
+	report := NewReport()
+
+	report.AddFileFix("/workspace/bundle1/policy1.rego", fixes.FixResult{
+		Title: "rego-v1",
+		Root:  "/workspace/bundle1",
+	})
+	report.AddFileFix("/workspace/bundle2/policy1.rego", fixes.FixResult{
+		Title: "rego-v1",
+		Root:  "/workspace/bundle2",
+	})
+	report.AddFileFix("/workspace/bundle1/policy1.rego", fixes.FixResult{
+		Title: "directory-package-mismatch",
+		Root:  "/workspace/bundle1",
+	})
+	report.AddFileFix("/workspace/bundle2/policy1.rego", fixes.FixResult{
+		Title: "directory-package-mismatch",
+		Root:  "/workspace/bundle2",
+	})
+	report.AddFileFix("/workspace/bundle1/policy3.rego", fixes.FixResult{
+		Title: "no-whitespace-comment",
+		Root:  "/workspace/bundle1",
+	})
+	report.AddFileFix("/workspace/bundle2/policy3.rego", fixes.FixResult{
+		Title: "use-assignment-operator",
+		Root:  "/workspace/bundle2",
+	})
+
+	report.SetMovedFiles(map[string]string{
+		"/workspace/bundle1/policy1.rego": "/workspace/bundle1/main/policy1.rego",
+		"/workspace/bundle2/policy1.rego": "/workspace/bundle2/lib/policy2.rego",
+	})
+
+	err := reporter.Report(report)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := `6 fixes applied:
+In project root: /workspace/bundle1
+policy1.rego -> main/policy1.rego:
+- rego-v1
+- directory-package-mismatch
+policy3.rego:
+- no-whitespace-comment
+
+In project root: /workspace/bundle2
+policy1.rego -> lib/policy2.rego:
+- rego-v1
+- directory-package-mismatch
+policy3.rego:
+- use-assignment-operator
+`
+
+	if got := buffer.String(); got != expected {
+		t.Fatalf("unexpected output:\nexpected:\n%s\ngot:\n%s", expected, got)
+	}
+}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -226,7 +226,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 		return report.Report{}, errors.New("nothing provided to lint")
 	}
 
-	conf, err := l.combinedConfig()
+	conf, err := l.GetConfig()
 	if err != nil {
 		return report.Report{}, fmt.Errorf("failed to merge config: %w", err)
 	}
@@ -862,7 +862,9 @@ func resultSetToReport(resultSet rego.ResultSet) (report.Report, error) {
 	return r, nil
 }
 
-func (l Linter) combinedConfig() (*config.Config, error) {
+// GetConfig returns the final configuration for the linter, i.e. Regal's default
+// configuration plus any user-provided configuration merged on top of it.
+func (l Linter) GetConfig() (*config.Config, error) {
 	if l.combinedCfg != nil {
 		return l.combinedCfg, nil
 	}
@@ -918,7 +920,7 @@ func (l Linter) enabledGoRules() ([]rules.Rule, error) {
 		return enabledGoRules, nil
 	}
 
-	conf, err := l.combinedConfig()
+	conf, err := l.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create merged config: %w", err)
 	}

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -438,7 +438,7 @@ func TestLintMergedConfigInheritsLevelFromProvided(t *testing.T) {
 		WithUserConfig(userConfig).
 		WithInputModules(&input)
 
-	mergedConfig := testutil.Must(linter.combinedConfig())(t)
+	mergedConfig := testutil.Must(linter.GetConfig())(t)
 
 	// Since no level was provided, "error" should be inherited from the provided configuration for the rule
 	if mergedConfig.Rules["style"]["file-length"].Level != "error" {
@@ -477,7 +477,7 @@ func TestLintMergedConfigUsesProvidedDefaults(t *testing.T) {
 		WithUserConfig(userConfig).
 		WithInputModules(&input)
 
-	mergedConfig := testutil.Must(linter.combinedConfig())(t)
+	mergedConfig := testutil.Must(linter.GetConfig())(t)
 
 	// specifically configured rule should not be affected by the default
 	if mergedConfig.Rules["style"]["opa-fmt"].Level != "warning" {


### PR DESCRIPTION
Following the recent addition of the `directory-package-mismatch` rule, this PR brings a corresponding `regal fix` remediator as well as a code action to fix this directly in the editor.

Fixes #1025

Todo:
- [x] Make it possible to set roots like how the OPA VS Code extension does
  - [x] For VS Code, we can send `opa.roots` as part of the init options, but what about updates?
  - [x] For `regal lint` we will need to either add a flag or read from config (or both)
- [ ] Docs for `regal fix` (including settings for DAS compliance)
- [ ] Docs for LSP integration (Code Action / Execute Command)
- [x] Setting config without `exclude-test-suffix` or to `false` leads to no Code Action shown
- [ ] #1029 
- [x] Show before/after paths in Code Action hover, and ideally in `regal fix`
  - [ ] Later... allow `--dry-run` for all fixes of `regal lint`

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->