### PR TITLE
fix: Update root detection

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -277,6 +277,23 @@ func fix(args []string, params *fixCommandParams) error {
 		ignore = params.ignoreFiles.v
 	}
 
+	// create a list of absolute paths, these will be used for the file from
+	// this point in order to be able to use the roots for format reporting.
+	absArgs := make([]string, len(args))
+
+	for i, arg := range args {
+		if filepath.IsAbs(arg) {
+			absArgs[i] = arg
+
+			continue
+		}
+
+		absArgs[i], err = filepath.Abs(arg)
+		if err != nil {
+			return fmt.Errorf("failed to get absolute path for %s: %w", arg, err)
+		}
+	}
+
 	filtered, err := config.FilterIgnoredPaths(args, ignore, true, "")
 	if err != nil {
 		return fmt.Errorf("failed to filter ignored paths: %w", err)

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -779,6 +779,7 @@ func TestFix(t *testing.T) {
 	td := t.TempDir()
 
 	initialState := map[string]string{
+		".regal/config.yaml": "", // needed to find the root in the right place
 		"foo/main.rego": `package wow
 
 import rego.v1
@@ -821,13 +822,13 @@ test_allow {
 		mustWriteToFile(t, filepath.Join(td, file), string(content))
 	}
 
-	err := regal(&stdout, &stderr)("fix", td)
+	err := regal(&stdout, &stderr)("fix", filepath.Join(td, "foo"), filepath.Join(td, "bar"))
 
 	// 0 exit status is expected as all violations should have been fixed
 	expectExitCode(t, err, 0, &stdout, &stderr)
 
 	exp := fmt.Sprintf(`8 fixes applied:
-In project root: %s
+In project root: %[1]s
 bar/main.rego -> wow/foo-bar/baz/main.rego:
 - directory-package-mismatch
 


### PR DESCRIPTION
Now the .regal dir will be used as the root, or any bundles configured under it or manually set in the file, unless it does not exist. If this is the case, then the roots will be used as the args to the fix cmd.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->