### PR TITLE
lsp: Clear old directories when renaming

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/styrainc/regal/internal/git"
 	rio "github.com/styrainc/regal/internal/io"
+	"github.com/styrainc/regal/internal/util"
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/fixer"
 	"github.com/styrainc/regal/pkg/fixer/fileprovider"
@@ -381,7 +382,7 @@ please run fix from a clean state to support the use of git checkout for undo`,
 				return fmt.Errorf("failed to delete file %s: %w", file, err)
 			}
 
-			err = deleteEmptyDirs(filepath.Dir(file))
+			err = util.DeleteEmptyDirs(filepath.Dir(file))
 			if err != nil {
 				return fmt.Errorf("failed to delete empty directories: %w", err)
 			}
@@ -422,31 +423,6 @@ please run fix from a clean state to support the use of git checkout for undo`,
 	err = r.Report(fixReport)
 	if err != nil {
 		return fmt.Errorf("failed to output fix report: %w", err)
-	}
-
-	return nil
-}
-
-func deleteEmptyDirs(dir string) error {
-	for {
-		// os.Remove will only delete empty directories
-		err := os.Remove(dir)
-		if err != nil {
-			if os.IsExist(err) {
-				break
-			}
-
-			if !os.IsNotExist(err) && !os.IsPermission(err) {
-				return fmt.Errorf("failed to clean directory %s: %w", dir, err)
-			}
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-
-		dir = parent
 	}
 
 	return nil

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -828,7 +828,7 @@ test_allow {
 	expectExitCode(t, err, 0, &stdout, &stderr)
 
 	exp := fmt.Sprintf(`8 fixes applied:
-In project root: %[1]s
+In project root: %s
 bar/main.rego -> wow/foo-bar/baz/main.rego:
 - directory-package-mismatch
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -504,6 +504,17 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { // nolint:mai
 				if err != nil {
 					l.logError(fmt.Errorf("failed %s notify: %v", methodWorkspaceApplyEdit, err.Error()))
 				}
+
+				// clean up any left over empty edits dirs
+				if len(renameParams.Edit.DocumentChanges) > 0 {
+					dir := filepath.Dir(uri.ToPath(l.clientIdentifier, renameParams.Edit.DocumentChanges[0].OldURI))
+
+					err := util.DeleteEmptyDirs(dir)
+					if err != nil {
+						l.logError(fmt.Errorf("failed to delete empty directories: %w", err))
+					}
+				}
+
 			case "regal.eval":
 				if len(params.Arguments) != 3 {
 					l.logError(fmt.Errorf("expected three arguments, got %d", len(params.Arguments)))

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -130,4 +131,31 @@ func FilepathJoiner(base string) func(string) string {
 	return func(path string) string {
 		return filepath.Join(base, path)
 	}
+}
+
+// DeleteEmptyDirs will delete empty directories up to the root for a given
+// directory.
+func DeleteEmptyDirs(dir string) error {
+	for {
+		// os.Remove will only delete empty directories
+		err := os.Remove(dir)
+		if err != nil {
+			if os.IsExist(err) {
+				break
+			}
+
+			if !os.IsNotExist(err) && !os.IsPermission(err) {
+				return fmt.Errorf("failed to clean directory %s: %w", dir, err)
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+
+		dir = parent
+	}
+
+	return nil
 }


### PR DESCRIPTION
This matches the behaviour of the fix cmd

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->