### PR TITLE
fix: Require use of --force to fix without git

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -822,7 +822,8 @@ test_allow {
 		mustWriteToFile(t, filepath.Join(td, file), string(content))
 	}
 
-	err := regal(&stdout, &stderr)("fix", filepath.Join(td, "foo"), filepath.Join(td, "bar"))
+	// --force is required to make the changes when there is no git repo
+	err := regal(&stdout, &stderr)("fix", "--force", filepath.Join(td, "foo"), filepath.Join(td, "bar"))
 
 	// 0 exit status is expected as all violations should have been fixed
 	expectExitCode(t, err, 0, &stdout, &stderr)


### PR DESCRIPTION
This also skips the unchanged check when working within a git repo.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->