### PR TITLE
tests: Fatal error when no inlay hints are found

### DIFF
--- a/internal/lsp/inlayhint_test.go
+++ b/internal/lsp/inlayhint_test.go
@@ -68,7 +68,7 @@ func TestGetInlayHintsAstTerms(t *testing.T) {
 	inlayHints := getInlayHints(module)
 
 	if len(inlayHints) != 1 {
-		t.Errorf("Expected 1 inlay hints, got %d", len(inlayHints))
+		t.Fatalf("Expected 1 inlay hints, got %d", len(inlayHints))
 	}
 
 	if inlayHints[0].Label != "x:" {


### PR DESCRIPTION
Otherwise this test can fail like this

```
2024/09/05 13:33:37 jsonrpc2: protocol error: io: read/write on closed pipe
  --- FAIL: TestGetInlayHintsAstTerms (0.00s)
      inlayhint_test.go:71: Expected 1 inlay hints, got 0
  panic: runtime error: index out of range [0] with length 0 [recovered]
  	panic: runtime error: index out of range [0] with length 0

  goroutine 14 [running]:
  testing.tRunner.func1.2({0x105567cc0, 0x14006a02be8})
  	/Users/runner/hostedtoolcache/go/1.22.5/arm64/src/testing/testing.go:1631 +0x1c4
  testing.tRunner.func1()
  	/Users/runner/hostedtoolcache/go/1.22.5/arm64/src/testing/testing.go:1634 +0x33c
  panic({0x105567cc0?, 0x14006a02be8?})
  	/Users/runner/hostedtoolcache/go/1.22.5/arm64/src/runtime/panic.go:770 +0x124
  github.com/styrainc/regal/internal/lsp.TestGetInlayHintsAstTerms(0x14000c71040)
  	/Users/runner/work/regal/regal/internal/lsp/inlayhint_test.go:74 +0x228
  testing.tRunner(0x14000c71040, 0x1055c7d68)
  	/Users/runner/hostedtoolcache/go/1.22.5/arm64/src/testing/testing.go:1689 +0xec
  created by testing.(*T).Run in goroutine 1
  	/Users/runner/hostedtoolcache/go/1.22.5/arm64/src/testing/testing.go:1742 +0x318
  FAIL	github.com/styrainc/regal/internal/lsp	4.128s
```

https://github.com/StyraInc/regal/actions/runs/10721446802/job/29729982494?pr=1059

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->