### PR TITLE
cmd/fix: Only require git when dry-run unset

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -323,7 +323,7 @@ func fix(args []string, params *fixCommandParams) error {
 		return fmt.Errorf("failed to establish git repo: %w", err)
 	}
 
-	if gitRepo == "" && !params.force {
+	if gitRepo == "" && !params.dryRun && !params.force {
 		return errors.New("no git repo found to support undo, use --force to override")
 	}
 


### PR DESCRIPTION
Fixes https://github.com/StyraInc/regal/issues/1063

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->