### PR TITLE
100% test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://github.com/styrainc/regal/workflows/Build/badge.svg?branch=main)](https://github.com/styrainc/regal/actions)
 ![OPA v0.68.0](https://openpolicyagent.org/badge/v0.68.0)
+[![codecov](https://codecov.io/github/StyraInc/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
 
 Regal is a linter and language server for [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/), making
 your Rego magnificent, and you the ruler of rules!

--- a/build/simplecov/simplecov.rego
+++ b/build/simplecov/simplecov.rego
@@ -42,3 +42,12 @@ to_value(cm, ncm, line) := null if {
 	not cm[line]
 	not ncm[line]
 }
+
+# utility rule to evaluate when only the
+# lines not covered are of interest
+# invoke like:
+#   regal test --coverage bundle \
+#   | opa eval -f pretty -I -d build/simplecov/simplecov.rego 'data.build.simplecov.not_covered'
+not_covered[file] := info.not_covered if {
+	some file, info in input.files
+}

--- a/bundle/regal/ast/imports.rego
+++ b/bundle/regal/ast/imports.rego
@@ -71,6 +71,8 @@ _arr(xs) := [y.value | some y in xs.path.value]
 
 _has_keyword(["future", "keywords"], _)
 
+_has_keyword(["future", "keywords", "every"], "in")
+
 _has_keyword(["future", "keywords", keyword], keyword)
 
 _has_keyword(["rego", "v1"], _)

--- a/bundle/regal/ast/imports_test.rego
+++ b/bundle/regal/ast/imports_test.rego
@@ -1,0 +1,43 @@
+package regal.ast_test
+
+import rego.v1
+
+import data.regal.ast
+
+test_imports_keyword_rego_v1 if {
+	module := ast.policy("import rego.v1")
+
+	ast.imports_keyword(module.imports, "in")
+	ast.imports_keyword(module.imports, "if")
+	ast.imports_keyword(module.imports, "every")
+	ast.imports_keyword(module.imports, "contains")
+}
+
+test_imports_keyword_future_keywords_all if {
+	module := ast.policy("import future.keywords")
+
+	ast.imports_keyword(module.imports, "in")
+	ast.imports_keyword(module.imports, "if")
+	ast.imports_keyword(module.imports, "every")
+	ast.imports_keyword(module.imports, "contains")
+}
+
+test_imports_keyword_future_keywords_single if {
+	module := ast.policy("import future.keywords.contains")
+
+	ast.imports_keyword(module.imports, "contains")
+
+	not ast.imports_keyword(module.imports, "in")
+	not ast.imports_keyword(module.imports, "if")
+	not ast.imports_keyword(module.imports, "every")
+}
+
+test_imports_keyword_future_keywords_every if {
+	module := ast.policy("import future.keywords.every")
+
+	ast.imports_keyword(module.imports, "every")
+	ast.imports_keyword(module.imports, "in")
+
+	not ast.imports_keyword(module.imports, "if")
+	not ast.imports_keyword(module.imports, "contains")
+}

--- a/bundle/regal/config/config_test.rego
+++ b/bundle/regal/config/config_test.rego
@@ -178,3 +178,7 @@ test_all_configured_rules_exist if {
 
 	count(missing_rules - go_rules) == 0
 }
+
+test_default_level_is_error if {
+	config.rule_level("unknown") == "error"
+}

--- a/bundle/regal/config/exclusion_test.rego
+++ b/bundle/regal/config/exclusion_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.regal.config
 
-# map[pattern: string]map[filename: string]excluded: bool
 cases := {
 	"p.rego": {
 		"p.rego": true,
@@ -47,11 +46,10 @@ cases := {
 test_all_cases_are_as_expected if {
 	not_exp := {pattern: res |
 		some pattern, subcases in cases
-		res := {file: res1 |
+		res := {file |
 			some file, exp in subcases
 			act := config.exclude(pattern, file)
 			exp != act
-			res1 := {"exp": exp, "act": act}
 		}
 		count(res) > 0
 	}
@@ -96,4 +94,10 @@ test_excluded_file_cli_overrides_config if {
 	e := config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
 		with data.eval.params as object.union(params, {"ignore_files": [""]})
 	e == false
+}
+
+test_trailing_slash if {
+	config.trailing_slash("foo/**/bar") == {"foo/**/bar", "foo/**/bar/**"}
+	config.trailing_slash("foo") == {"foo", "foo/**"}
+	config.trailing_slash("foo/**") == {"foo/**"}
 }

--- a/bundle/regal/lsp/completion/kind/kind_test.rego
+++ b/bundle/regal/lsp/completion/kind/kind_test.rego
@@ -1,0 +1,10 @@
+package regal.lsp.completion.kind_test
+
+import rego.v1
+
+import data.regal.lsp.completion.kind
+
+test_kind_for_coverage if {
+	kind_values := [value | some value in kind]
+	sort(kind_values) == numbers.range(1, 25)
+}

--- a/bundle/regal/lsp/completion/main.rego
+++ b/bundle/regal/lsp/completion/main.rego
@@ -10,9 +10,7 @@ import rego.v1
 # METADATA
 # description: main entry point for completion suggestions
 # entrypoint: true
-items contains item if {
-	some provider
-	completion := data.regal.lsp.completion.providers[provider].items[_]
-
-	item := object.union(completion, {"_regal": {"provider": provider}})
+items contains object.union(completion, {"_regal": {"provider": provider}}) if {
+	some provider, completion
+	data.regal.lsp.completion.providers[provider].items[completion]
 }

--- a/bundle/regal/lsp/completion/main_test.rego
+++ b/bundle/regal/lsp/completion/main_test.rego
@@ -1,0 +1,11 @@
+package regal.lsp.completion_test
+
+import rego.v1
+
+import data.regal.lsp.completion
+
+test_completion_entrypoint if {
+	items := completion.items with completion.providers as {"test": {"items": {{"foo": "bar"}}}}
+
+	items == {{"_regal": {"provider": "test"}, "foo": "bar"}}
+}

--- a/bundle/regal/lsp/completion/providers/booleans/booleans.rego
+++ b/bundle/regal/lsp/completion/providers/booleans/booleans.rego
@@ -5,8 +5,6 @@ import rego.v1
 import data.regal.lsp.completion.kind
 import data.regal.lsp.completion.location
 
-parsed_current_file := data.workspace.parsed[input.regal.file.uri]
-
 items contains item if {
 	position := location.to_position(input.regal.context.location)
 

--- a/bundle/regal/lsp/completion/providers/locals/locals.rego
+++ b/bundle/regal/lsp/completion/providers/locals/locals.rego
@@ -12,11 +12,12 @@ items contains item if {
 
 	line := input.regal.file.lines[position.line]
 	line != ""
+
 	location.in_rule_body(line)
 
-	word := location.word_at(line, input.regal.context.location.col)
+	not _excluded(line, position)
 
-	not excluded(line, position)
+	word := location.word_at(line, input.regal.context.location.col)
 
 	some local in location.find_locals(
 		parsed_current_file.rules,
@@ -38,7 +39,7 @@ items contains item if {
 
 # exclude local suggestions in function args definition,
 # as those would recursively contribute to themselves
-excluded(line, position) if _function_args_position(substring(line, 0, position.character))
+_excluded(line, position) if _function_args_position(substring(line, 0, position.character))
 
 _function_args_position(text) if {
 	text == trim_left(text, " \t")

--- a/bundle/regal/lsp/completion/providers/locals/locals_test.rego
+++ b/bundle/regal/lsp/completion/providers/locals/locals_test.rego
@@ -122,3 +122,29 @@ function(bar) := f if {
 	count(items) == 1
 	utils.expect_item(items, "foo", {"end": {"character": 18, "line": 4}, "start": {"character": 17, "line": 4}})
 }
+
+test_no_locals_in_completion_items_function_args if {
+	workspace := {"file:///p.rego": `package policy
+
+import rego.v1
+
+function() if {
+	foo := 1
+}
+`}
+
+	regal_module := {"regal": {
+		"file": {
+			"name": "p.rego",
+			"uri": "file:///p.rego",
+			"lines": split(workspace["file:///p.rego"], "\n"),
+		},
+		"context": {"location": {
+			"row": 5,
+			"col": 10,
+		}},
+	}}
+	items := provider.items with input as regal_module with data.workspace.parsed as utils.parsed_modules(workspace)
+
+	count(items) == 0
+}

--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
@@ -9,10 +9,6 @@ import data.regal.lsp.completion.location
 
 ref_is_internal(ref) if contains(ref, "._")
 
-default determine_ref_prefix(_) := ""
-
-determine_ref_prefix(word) := word if word != ":="
-
 position := location.to_position(input.regal.context.location)
 
 line := input.regal.file.lines[position.line]
@@ -92,11 +88,10 @@ matching_rule_ref_suggestions contains ref if {
 
 	# \W is used here to match ( in the case of func() := ..., as well as the space in the case of rule := ...
 	first_word := regex.split(`\W+`, trim_space(line))[0]
-	prefix := determine_ref_prefix(word.text)
 
 	some ref in rule_ref_suggestions
 
-	startswith(ref, prefix)
+	startswith(ref, word.text)
 
 	# this is to avoid suggesting a recursive rule, e.g. rule := rule, or func() := func()
 	ref != first_word

--- a/bundle/regal/lsp/completion/ref_names.rego
+++ b/bundle/regal/lsp/completion/ref_names.rego
@@ -6,15 +6,10 @@ import data.regal.ast
 
 # ref_names returns a list of ref names that are used in the module.
 # built-in functions are not included as they are provided by another completions provider.
-# imports are not included as we need to use the imported_identifier instead
-# (i.e. maybe an alias).
 ref_names contains name if {
-	some ref in ast.all_refs
+	name := ast.ref_to_string(ast.found.refs[_][_].value)
 
-	name := ast.ref_to_string(ref.value)
-
-	not name in ast.builtin_functions_called
-	not name in imports
+	not name in ast.builtin_names
 }
 
 # if a user has imported data.foo, then foo should be suggested.
@@ -23,11 +18,4 @@ ref_names contains name if {
 # imported_identifiers will only match data.* and input.*
 ref_names contains name if {
 	some name in ast.imported_identifiers
-}
-
-# imports are not shown as we need to show the imported alias instead
-imports contains ref if {
-	some imp in ast.imports
-
-	ref := ast.ref_to_string(imp.path.value)
 }

--- a/bundle/regal/lsp/completion/ref_names_test.rego
+++ b/bundle/regal/lsp/completion/ref_names_test.rego
@@ -1,0 +1,37 @@
+package regal.lsp.completion_test
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.capabilities
+
+import data.regal.lsp.completion
+
+test_ref_names if {
+	module := ast.with_rego_v1(`
+	import data.imp
+	import data.foo.bar as bb
+
+	x := 1
+
+	allow if {
+		some x
+		input.foo[x] == data.bar[x]
+		startswith("hey", "h")
+
+		imp.foo == data.x
+	}
+	`)
+
+	ref_names := completion.ref_names with input as module
+		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
+	ref_names == {
+		"imp",
+		"bb",
+		"input.foo.$x",
+		"data.bar.$x",
+		"imp.foo",
+		"data.x",
+	}
+}

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -16,7 +16,7 @@ lint_aggregate.violations := aggregate_report
 
 lint.violations := report
 
-rules_to_run[category][title] if {
+rules_to_run[category] contains title if {
 	some category, title
 	config.merged_config.rules[category][title]
 
@@ -78,7 +78,6 @@ report contains violation if {
 
 	config.for_rule(category, title).level != "ignore"
 	not config.excluded_file(category, title, input.regal.file.name)
-
 	not ignored(violation, ast.ignore_directives)
 }
 
@@ -148,7 +147,7 @@ aggregate_report contains violation if {
 	# for custom rules, we can't assume that the author included
 	# a location in the violation, although they _really_ should
 	file := object.get(violation, ["location", "file"], "")
-	ignore_directives := object.get(input.ignore_directives, file, {})
+	ignore_directives := object.get(input, ["ignore_directives", file], {})
 
 	not ignored(violation, util.keys_to_numbers(ignore_directives))
 }

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
@@ -11,10 +11,9 @@ report contains violation if {
 	some indices in duplicates
 
 	first := indices[0]
-	rest := array.slice(indices, 1, count(indices))
 
 	dup_locations := [location |
-		some index in rest
+		some index in util.rest(indices)
 		location := util.to_location_object(input.rules[index].location)
 	]
 

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
@@ -8,7 +8,8 @@ import data.regal.ast
 import data.regal.result
 import data.regal.util
 
-package_path := [part.value | some part in input["package"].path]
+# note: not ast.package_path as we want the "data" component here
+_package_path := [part.value | some part in input["package"].path]
 
 multivalue_rules contains path if {
 	some rule in ast.rules
@@ -21,10 +22,7 @@ multivalue_rules contains path if {
 		path.type == "string"
 	}
 
-	path := concat(".", array.concat(package_path, [p |
-		some ref in rule.head.ref
-		p := ref.value
-	]))
+	path := concat(".", array.concat(_package_path, [ref.value | some ref in rule.head.ref]))
 }
 
 negated_refs contains negated_ref if {
@@ -38,7 +36,7 @@ negated_refs contains negated_ref if {
 	ref := var_to_ref(value.terms)
 
 	# for now, ignore ref if it has variable components
-	every path in array.slice(ref, 1, count(ref)) {
+	every path in util.rest(ref) {
 		path.type == "string"
 	}
 
@@ -50,7 +48,7 @@ negated_refs contains negated_ref if {
 
 	negated_ref := {
 		"ref": ref,
-		"resolved_path": resolve(ref, package_path, ast.resolved_imports),
+		"resolved_path": resolve(ref, _package_path, ast.resolved_imports),
 	}
 }
 

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
@@ -152,6 +152,24 @@ test_fail_multivalue_not_reference_in_same_file_reported_in_normal_report if {
 	r == expected_with_location({"col": 7, "file": "p1.rego", "row": 8, "text": "not partial"})
 }
 
+test_success_multivalue_ref_head_rule_not_accounted_for if {
+	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+
+	import rego.v1
+
+	my.partial[rule] contains "foo" if {
+		some rule in input
+	}
+
+	test_partial if {
+		not partial
+	}
+	`)
+
+	r := rule.aggregate_report with input as {"aggregate": agg1}
+	r == set()
+}
+
 expected := {
 	"category": "bugs",
 	"description": "Impossible `not` condition",

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
@@ -88,10 +88,3 @@ expected := {
 
 # regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)
-
-# regal ignore:external-reference
-expected_with_location(location) := {object.union(expected, {"location": loc}) |
-	some loc in location
-} if {
-	is_set(location)
-}

--- a/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint_test.rego
+++ b/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint_test.rego
@@ -29,6 +29,34 @@ _allow := true
 	}}
 }
 
+test_fail_internal_entrypoint_rule_ref if {
+	module := ast.with_rego_v1(`
+
+# METADATA
+# entrypoint: true
+authz._allow := true
+	`)
+
+	r := rule.report with input as module
+	r == {{
+		"category": "bugs",
+		"description": "Entrypoint can't be marked internal",
+		"level": "error",
+		"location": {
+			"col": 7,
+			"end": {"col": 13, "row": 9},
+			"file": "policy.rego",
+			"row": 9,
+			"text": "authz._allow := true",
+		},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/internal-entrypoint", "bugs"),
+		}],
+		"title": "internal-entrypoint",
+	}}
+}
+
 test_success_non_internal_entrypoint if {
 	module := ast.with_rego_v1(`
 

--- a/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch.rego
+++ b/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch.rego
@@ -34,8 +34,6 @@ report contains violation if {
 	violation := result.fail(rego.metadata.chain(), result.ranged_location_between(fn.args[0], regal.last(fn.args)))
 }
 
-default _repeated_explicit_argument_indexes(_) := 0
-
 # see: https://pkg.go.dev/fmt#hdr-Explicit_argument_indexes
 # each distinct explicit argument index should only contribute one value to the
 # values array. this calculates the number to subtract from the total expected

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
@@ -143,6 +143,18 @@ test_success_not_unused_output_variable_other_ref if {
 	r == set()
 }
 
+test_success_not_unused_output_variable_head_ref if {
+	module := ast.with_rego_v1(`
+	success[x] if {
+		some x
+		input[x]
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
 test_success_not_output_variable_rule if {
 	module := ast.with_rego_v1(`
 	x := 1

--- a/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
+++ b/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
@@ -82,10 +82,3 @@ expected := {
 
 # regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)
-
-# regal ignore:external-reference
-expected_with_location(location) := {object.union(expected, {"location": loc}) |
-	some loc in location
-} if {
-	is_set(location)
-}

--- a/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
+++ b/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
@@ -162,10 +162,3 @@ expected := {
 
 # regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)
-
-# regal ignore:external-reference
-expected_with_location(location) := {object.union(expected, {"location": loc}) |
-	some loc in location
-} if {
-	is_set(location)
-}

--- a/bundle/regal/rules/imports/ignored-import/ignored_import.rego
+++ b/bundle/regal/rules/imports/ignored-import/ignored_import.rego
@@ -16,7 +16,7 @@ import_paths contains path if {
 }
 
 report contains violation if {
-	some ref in ast.all_rules_refs
+	ref := ast.found.refs[_][_]
 
 	ref.value[0].type == "var"
 	ref.value[0].value in {"data", "input"}

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
@@ -4,14 +4,13 @@ package regal.rules.imports["prefer-package-imports"]
 
 import rego.v1
 
+import data.regal.ast
 import data.regal.config
 import data.regal.result
 
 cfg := config.for_rule("imports", "prefer-package-imports")
 
 aggregate contains entry if {
-	package_path := [part.value | some i, part in input["package"].path; i > 0]
-
 	imports_with_location := [imp |
 		some _import in input.imports
 
@@ -22,14 +21,14 @@ aggregate contains entry if {
 
 		# Special case for custom rules, where we don't want to flag e.g. `import data.regal.ast`
 		# as unknown, even though it's not a package included in evaluation.
-		not custom_regal_package_and_import(package_path, path)
+		not custom_regal_package_and_import(ast.package_path, path)
 
 		imp := object.union(result.location(_import), {"path": path})
 	]
 
 	entry := result.aggregate(rego.metadata.chain(), {
 		"imports": imports_with_location,
-		"package_path": package_path,
+		"package_path": ast.package_path,
 	})
 }
 

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
@@ -4,13 +4,12 @@ package regal.rules.imports["unresolved-import"]
 
 import rego.v1
 
+import data.regal.ast
 import data.regal.config
 import data.regal.result
 import data.regal.util
 
 aggregate contains entry if {
-	package_path := [part.value | some i, part in input["package"].path; i > 0]
-
 	imports_with_location := [imp |
 		some _import in input.imports
 
@@ -21,17 +20,17 @@ aggregate contains entry if {
 
 		# Special case for custom rules, where we don't want to flag e.g. `import data.regal.ast`
 		# as unknown, even though it's not a package included in evaluation.
-		not custom_regal_package_and_import(package_path, path)
+		not _custom_regal_package_and_import(ast.package_path, path)
 
 		imp := object.union(result.location(_import), {"path": path})
 	]
 
-	exported_refs := {package_path} | {ref |
+	exported_refs := {ast.package_path} | {ref |
 		some rule in input.rules
 
 		# locations will only contribute to each item in the set being unique,
 		# which we don't want here — we only care for distinct ref paths
-		some ref in to_paths(package_path, rule.head.ref)
+		some ref in _to_paths(ast.package_path, rule.head.ref)
 	}
 
 	entry := result.aggregate(rego.metadata.chain(), {
@@ -55,16 +54,16 @@ aggregate_report contains violation if {
 	}
 
 	some imp in all_imports
-	not imp.path in (all_known_refs | except_imports)
+	not imp.path in (all_known_refs | _except_imports)
 
 	# cheap operation failed — need to check wildcards here to account
 	# for map generating / general ref head rules
-	not wildcard_match(imp.path, all_known_refs, except_imports)
+	not _wildcard_match(imp.path, all_known_refs, _except_imports)
 
 	violation := result.fail(rego.metadata.chain(), result.location(imp))
 }
 
-custom_regal_package_and_import(pkg_path, path) if {
+_custom_regal_package_and_import(pkg_path, path) if {
 	pkg_path[0] == "custom"
 	pkg_path[1] == "regal"
 	path[0] == "regal"
@@ -73,48 +72,46 @@ custom_regal_package_and_import(pkg_path, path) if {
 # the package part will always be included exported refs
 # but if we have a rule like foo.bar.baz
 # we'll want to include both foo.bar and foo.bar.baz
-to_paths(pkg_path, ref) := util.all_paths(to_path(pkg_path, ref)) if count(ref) < 3
+_to_paths(pkg_path, ref) := util.all_paths(_to_path(pkg_path, ref)) if count(ref) < 3
 
-to_paths(pkg_path, ref) := paths if {
+_to_paths(pkg_path, ref) := paths if {
 	count(ref) > 2
 
 	paths := [path |
 		some p in util.all_paths(ref)
-		path := to_path(pkg_path, p)
+		path := _to_path(pkg_path, p)
 	]
 }
 
-to_path(pkg_path, ref) := array.concat(pkg_path, [str |
+_to_path(pkg_path, ref) := array.concat(pkg_path, [str |
 	some i, part in ref
-	str := to_string(i, part)
+	str := _to_string(i, part)
 ])
 
-to_string(0, part) := part.value
+_to_string(0, part) := part.value
 
-to_string(i, part) := part.value if {
+_to_string(i, part) := part.value if {
 	i > 0
 	part.type == "string"
 }
 
-to_string(i, part) := "**" if {
+_to_string(i, part) := "**" if {
 	i > 0
 	part.type == "var"
 }
 
-all_paths(path) := [array.slice(path, 0, len) | some len in numbers.range(1, count(path))]
-
-except_imports contains exception if {
+_except_imports contains exception if {
 	cfg := config.for_rule("imports", "unresolved-import")
 
 	some str in cfg["except-imports"]
-	exception := trim_data(split(str, "."))
+	exception := _trim_data(split(str, "."))
 }
 
-trim_data(path) := array.slice(path, 1, count(path)) if path[0] == "data"
+_trim_data(path) := array.slice(path, 1, count(path)) if path[0] == "data"
 
-trim_data(path) := path if path[0] != "data"
+_trim_data(path) := path if path[0] != "data"
 
-wildcard_match(imp_path, all_known_refs, except_imports) if {
+_wildcard_match(imp_path, all_known_refs, except_imports) if {
 	except_imports_wildcards := {path |
 		some except in except_imports
 		path := concat(".", except)

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -62,6 +62,19 @@ test_success_unresolved_imports_are_excepted if {
 	r == set()
 }
 
+test_success_unresolved_imports_with_wildcards_are_excepted if {
+	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
+	import data.bar.x
+	import data.bar.excepted
+
+	x := 1
+	`)
+
+	r := rule.aggregate_report with input as {"aggregate": agg1}
+		with config.for_rule as {"level": "error", "except-imports": ["data.bar.*"]}
+	r == set()
+}
+
 test_success_resolved_import_in_middle_of_explicit_paths if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 	import data.bar.x.y
@@ -126,6 +139,17 @@ test_success_general_ref_head_rule_may_resolve_so_allow if {
 	`)
 
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+	r == set()
+}
+
+test_success_custom_rule_not_flagging_regal_import if {
+	agg := rule.aggregate with input as regal.parse_module("p2.rego", `package custom.regal.bar
+	import data.regal.ast
+
+	x := 1
+	`)
+
+	r := rule.aggregate_report with input as {"aggregate": agg}
 	r == set()
 }
 

--- a/bundle/regal/rules/style/default-over-not/default_over_not.rego
+++ b/bundle/regal/rules/style/default-over-not/default_over_not.rego
@@ -16,7 +16,8 @@ report contains violation if {
 	not rule["default"]
 	not rule.body
 
-	name := _static_rule_name(rule)
+	name := ast.ref_static_to_string(rule.head.ref)
+
 	value := rule.head.value
 
 	ast.static_ref(value)
@@ -27,7 +28,7 @@ report contains violation if {
 	sibling_rules := [sibling |
 		some j, sibling in ast.rules
 		i != j
-		_static_rule_name(sibling) == name
+		ast.ref_static_to_string(sibling.head.ref) == name
 	]
 
 	some sibling in sibling_rules
@@ -38,18 +39,4 @@ report contains violation if {
 	ast.ref_to_string(sibling.body[0].terms.value) == ast.ref_to_string(value.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(sibling.body[0]))
-}
-
-_static_rule_name(rule) := rule.head.ref[0].value if count(rule.head.ref) == 1
-
-_static_rule_name(rule) := concat(".", array.concat([rule.head.ref[0].value], [ref.value |
-	some i, ref in rule.head.ref
-	i > 0
-])) if {
-	c := count(rule.head.ref)
-	c > 1
-
-	every t in array.slice(rule.head.ref, 1, c) {
-		t.type != "var"
-	}
 }

--- a/bundle/regal/rules/testing/todo-test/todo_test.rego
+++ b/bundle/regal/rules/testing/todo-test/todo_test.rego
@@ -8,7 +8,7 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some rule in input.rules
+	some rule in ast.rules
 
 	startswith(ast.ref_to_string(rule.head.ref), "todo_test_")
 

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -56,3 +56,5 @@ json_pretty(value) := json.marshal_with_options(value, {
 	"indent": "  ",
 	"pretty": true,
 })
+
+rest(arr) := array.slice(arr, 1, count(arr))

--- a/bundle/regal/util/util_test.rego
+++ b/bundle/regal/util/util_test.rego
@@ -18,3 +18,9 @@ test_json_pretty if {
   ]
 }`
 }
+
+test_rest if {
+	util.rest([1, 2, 3]) == [2, 3]
+	util.rest([1]) == []
+	util.rest([]) == []
+}


### PR DESCRIPTION
Like with previous PR aiming to increase our test coverage (#1058), doing so this time revealed a few places where code was unused, or could be rewritten to be better optimized, removed, or made easier to read.

One find that is yet to be addressed here is how we copy the whole `ast.found.refs` object into `ast.all_refs`, which surely comes with a cost that seems unnecessary, given we can use `ast.found.refs` directly instead. But since there are a few consumers, and they are not **exactly** identical (`all_refs` contains import refs too), I'll follow up on that in a later PR.

I'm also adding the codecov badge to the README to make it easy to see when our coverage drops. But I'm not as convinced we should fail PRs when coverage isn't 100% as I was before, as it might make for a worse contributor experience.

Fixes #918