### PR TITLE
Remove `ast.all_refs`

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -182,15 +182,6 @@ _exclude_arg(_, _, arg) if arg.type == "call"
 _exclude_arg("assign", 0, _)
 
 # METADATA
-# description: |
-#   set containing all references found in the input AST
-#   NOTE: likely to be deprecated — prefer to use `ast.found.refs` over this
-# scope: document
-all_refs contains found.refs[_][_]
-
-all_refs contains imported.path if some imported in input.imports
-
-# METADATA
 # description: returns the "path" string of any given ref value
 ref_to_string(ref) := concat(".", [_ref_part_to_string(i, part) | some i, part in ref])
 

--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -4,7 +4,6 @@ import rego.v1
 
 import data.regal.ast
 import data.regal.capabilities
-import data.regal.util
 
 # regal ignore:rule-length
 test_find_vars if {
@@ -262,27 +261,6 @@ test_find_some_decl_names_in_scope if {
 }
 
 var_names(vars) := {var.value | some var in vars}
-
-test_all_refs if {
-	policy := `package policy
-
-	import data.foo.bar
-
-    allow := data.foo.baz
-
-    deny[message] {
-		message := data.foo.bax
-    }
-    `
-
-	module := regal.parse_module("p.rego", policy)
-
-	r := ast.all_refs with input as module
-
-	text_refs := {base64.decode(util.to_location_object(ref.location).text) | some ref in r}
-
-	text_refs == {":=", "data.foo.bar", "data.foo.bax", "data.foo.baz"}
-}
 
 test_provided_capabilities_never_undefined if {
 	capabilities.provided == {} with data.internal as {}

--- a/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
+++ b/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
@@ -7,6 +7,7 @@ import rego.v1
 import data.regal.ast
 import data.regal.config
 import data.regal.result
+import data.regal.util
 
 report contains violation if {
 	deprecated_builtins := {
@@ -14,20 +15,13 @@ report contains violation if {
 		"cast_set", "cast_string", "cast_boolean", "cast_null", "cast_object",
 	}
 
-	# if none of the deprecated built-ins are in the
-	# capabilities for the target, bail out early
-	any_deprecated_builtin(object.keys(config.capabilities.builtins), deprecated_builtins)
+	# bail out early if no the deprecated built-ins are in capabilities
+	util.intersects(object.keys(config.capabilities.builtins), deprecated_builtins)
 
-	some ref in ast.all_refs
-
+	ref := ast.found.refs[_][_]
 	call := ref[0]
 
 	ast.ref_to_string(call.value) in deprecated_builtins
 
 	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(call))
-}
-
-any_deprecated_builtin(caps_builtins, deprecated_builtins) if {
-	some builtin in caps_builtins
-	builtin in deprecated_builtins
 }

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
@@ -8,9 +8,17 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some ref in ast.all_refs
+	ref := ast.found.refs[_][_]
 
 	contains(ast.ref_to_string(ref.value), "._")
 
 	violation := result.fail(rego.metadata.chain(), result.location(ref))
+}
+
+report contains violation if {
+	some imported in input.imports
+
+	contains(ast.ref_to_string(imported.path.value), "._")
+
+	violation := result.fail(rego.metadata.chain(), result.location(imported.path.value))
 }

--- a/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call.rego
+++ b/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call.rego
@@ -7,20 +7,15 @@ import rego.v1
 import data.regal.ast
 import data.regal.config
 import data.regal.result
-
-cfg := config.for_rule("custom", "forbidden-function-call")
-
-any_forbidden_function_called if {
-	some function in cfg["forbidden-functions"]
-	function in ast.builtin_functions_called
-}
+import data.regal.util
 
 report contains violation if {
+	cfg := config.for_rule("custom", "forbidden-function-call")
+
 	# avoid traversal if no forbidden function is called
-	any_forbidden_function_called
+	util.intersects(util.to_set(cfg["forbidden-functions"]), ast.builtin_functions_called)
 
-	some ref in ast.all_refs
-
+	ref := ast.found.refs[_][_]
 	name := ast.ref_to_string(ref[0].value)
 	name in cfg["forbidden-functions"]
 

--- a/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
@@ -8,40 +8,11 @@ import data.regal.ast
 import data.regal.result
 import data.regal.util
 
-# Mapping of regex.* functions and the position(s)
-# of their "pattern" attributes
-re_pattern_functions := {
-	"find_all_string_submatch_n": [1],
-	"find_n": [1],
-	"globs_match": [1, 2],
-	"is_valid": [1],
-	"match": [1],
-	"replace": [2],
-	"split": [1],
-	"template_match": [1],
-}
-
-re_pattern_function_names := {
-	"regex.find_all_string_submatch_n",
-	"regex.find_n",
-	"regex.globs_match",
-	"regex.is_valid",
-	"regex.match",
-	"regex.replace",
-	"regex.split",
-	"regex.template_match",
-}
-
-any_regex_function_called if {
-	some name in re_pattern_function_names
-	name in ast.builtin_functions_called
-}
-
 report contains violation if {
-	# skip expensive walk if no builtin regex function calls are registered
-	any_regex_function_called
+	# skip traversing refs if no builtin regex function calls are registered
+	util.intersects(_re_pattern_function_names, ast.builtin_functions_called)
 
-	some value in ast.all_refs
+	value := ast.found.refs[_][_]
 
 	value[0].value[0].type == "var"
 	value[0].value[0].value == "regex"
@@ -49,7 +20,7 @@ report contains violation if {
 	# The name following "regex.", e.g. "match"
 	name := value[0].value[1].value
 
-	some pos in re_pattern_functions[name]
+	some pos in _re_pattern_functions[name]
 
 	value[pos].type == "string"
 
@@ -60,4 +31,28 @@ report contains violation if {
 	chr == `"`
 
 	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(value[pos]))
+}
+
+# Mapping of regex.* functions and the position(s)
+# of their "pattern" attributes
+_re_pattern_functions := {
+	"find_all_string_submatch_n": [1],
+	"find_n": [1],
+	"globs_match": [1, 2],
+	"is_valid": [1],
+	"match": [1],
+	"replace": [2],
+	"split": [1],
+	"template_match": [1],
+}
+
+_re_pattern_function_names := {
+	"regex.find_all_string_submatch_n",
+	"regex.find_n",
+	"regex.globs_match",
+	"regex.is_valid",
+	"regex.match",
+	"regex.replace",
+	"regex.split",
+	"regex.template_match",
 }

--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -14,7 +14,7 @@ import data.regal.result
 import data.regal.util
 
 refs contains ref if {
-	some r in ast.all_refs
+	r := ast.found.refs[_][_]
 
 	r.value[0].value == "data"
 
@@ -23,6 +23,17 @@ refs contains ref if {
 	ref := {
 		"package_path": concat(".", [e.value | some e in r.value]),
 		"location": object.remove(util.to_location_object(r.location), {"text"}),
+	}
+}
+
+refs contains ref if {
+	some imported in ast.imports
+
+	imported.path.value[0].value == "data"
+
+	ref := {
+		"package_path": concat(".", [e.value | some e in imported.path.value]),
+		"location": object.remove(util.to_location_object(imported.path.location), {"text"}),
 	}
 }
 

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
@@ -8,7 +8,7 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some value in ast.all_refs
+	value := ast.found.refs[_][_]
 
 	value[0].value[0].type == "var"
 	value[0].value[0].value in {"equal", "neq"} # perhaps add more operators here?

--- a/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf.rego
+++ b/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf.rego
@@ -8,10 +8,10 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	# skip expensive walk operation if no print calls are registered
+	# skip traversing refs if no print calls are registered
 	"print" in ast.builtin_functions_called
 
-	some value in ast.all_refs
+	value := ast.found.refs[_][_]
 
 	value[0].value[0].type == "var"
 	value[0].value[0].value == "print"

--- a/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call.rego
+++ b/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call.rego
@@ -6,17 +6,13 @@ import rego.v1
 
 import data.regal.ast
 import data.regal.result
-
-print_or_trace_called if {
-	some name in {"print", "trace"}
-	name in ast.builtin_functions_called
-}
+import data.regal.util
 
 report contains violation if {
 	# skip iteration of refs if no print or trace calls are registered
-	print_or_trace_called
+	util.intersects(ast.builtin_functions_called, {"print", "trace"})
 
-	some ref in ast.all_refs
+	ref := ast.found.refs[_][_]
 
 	ref[0].value[0].type == "var"
 	ref[0].value[0].value in {"print", "trace"}

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -58,3 +58,9 @@ json_pretty(value) := json.marshal_with_options(value, {
 })
 
 rest(arr) := array.slice(arr, 1, count(arr))
+
+to_set(x) := x if is_set(x)
+
+to_set(x) := {y | some y in x} if not is_set(x)
+
+intersects(s1, s2) if count(intersection({s1, s2})) > 0


### PR DESCRIPTION
This held a copy of `ast.found.refs` + imported refs Which was quite redundant. Rewrote all consumers to go for `ast.found.refs` directly, and imports where needed.

Also added `util.intersects` for a common pattern used in these rules.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->