### PR TITLE
Ensure custom rules docs are up to date

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -221,7 +221,9 @@ func addToDataYAML(params newRuleCommandParams) error {
 }
 
 func scaffoldCustomRule(params newRuleCommandParams) error {
-	rulesDir := filepath.Join(params.output, ".regal", "rules", params.category)
+	rulesDir := filepath.Join(
+		params.output, ".regal", "rules", "custom", "regal", "rules", params.category, params.name,
+	)
 
 	if err := os.MkdirAll(rulesDir, 0o770); err != nil {
 		return err

--- a/internal/embeds/templates/custom/custom_test.rego.tpl
+++ b/internal/embeds/templates/custom/custom_test.rego.tpl
@@ -6,20 +6,20 @@ import data.custom.regal.rules.{{.Category}}{{.Name}} as rule
 
 # Example test, replace with your own
 test_rule_named_foo_not_allowed if {
-    module := regal.parse_module("example.rego", `
-    package policy
+	module := regal.parse_module("example.rego", `
+	package policy
 
-    foo := true`)
+	foo := true`)
 
-    r := rule.report with input as module
+	r := rule.report with input as module
 
-    # Use print(r) here to see the report. Great for development!
+	# Use print(r) here to see the report. Great for development!
 
-    r == {{ "{{" }}
-    	"category": "{{.Category}}",
-    	"description": "Add description of rule here!",
-    	"level": "error",
-    	"location": {"col": 5, "file": "example.rego", "row": 4, "text": "    foo := true"},
-    	"title": "{{.NameOriginal}}"
-    }}
+	r == {{ "{{" }}
+		"category": "{{.Category}}",
+		"description": "Add description of rule here!",
+		"level": "error",
+		"location": {"col": 2, "file": "example.rego", "row": 4, "text": "\tfoo := true"},
+		"title": "{{.NameOriginal}}",
+	}}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -261,6 +261,13 @@ func rootsFromRegalDirectory(regalDir *os.File) ([]string, error) {
 		}
 	}
 
+	customRulesDir := filepath.Join(regalDir.Name(), "rules")
+
+	info, err := os.Stat(customRulesDir)
+	if err == nil && info.IsDir() {
+		foundBundleRoots = append(foundBundleRoots, customRulesDir)
+	}
+
 	return foundBundleRoots, nil
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -94,10 +94,11 @@ project:
 `
 
 	fs := map[string]string{
-		"/.regal/config.yaml":      cfg, // root from config
-		"/bundle/.manifest":        "",  // bundle from .manifest
-		"/foo/bar/baz/policy.rego": "",  // foo/bar from config
-		"/baz":                     "",  // baz from config
+		"/.regal/config.yaml":       cfg, // root from config
+		"/.regal/rules/policy.rego": "",  // custom rules directory
+		"/bundle/.manifest":         "",  // bundle from .manifest
+		"/foo/bar/baz/policy.rego":  "",  // foo/bar from config
+		"/baz":                      "",  // baz from config
 	}
 
 	test.WithTempFS(fs, func(root string) {
@@ -106,11 +107,11 @@ project:
 			t.Error(err)
 		}
 
-		if len(locations) != 4 {
-			t.Errorf("expected 4 locations, got %d", len(locations))
+		if len(locations) != 5 {
+			t.Errorf("expected 5 locations, got %d", len(locations))
 		}
 
-		expected := util.Map(util.FilepathJoiner(root), []string{"", "baz", "bundle", "foo/bar"})
+		expected := util.Map(util.FilepathJoiner(root), []string{"", ".regal/rules", "baz", "bundle", "foo/bar"})
 
 		if !slices.Equal(expected, locations) {
 			t.Errorf("expected %v, got %v", expected, locations)


### PR DESCRIPTION
Update docs to reflect use of roast format, and much more.

- Add .regal/rules as a root when exists
- Make sure `regal new rule` creates directories matching package path
- Fix missing comma and use tabs in test template leading to Regal flagging the custom test as unformatted
- Replace `ast.name` call with `ast.ref_to_string` in one of the examples. Thanks @drewcorlin1 for pointing that out!

Fixes #1003

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->