### PR TITLE
Fix issue where .manifest files didn't register as roots

### DIFF
--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -135,6 +135,8 @@ func WalkFiles(root string, f func(path string) error) error {
 	})
 }
 
+// FindManifestLocations walks the file system rooted at root, and returns the
+// *relative* paths of directories containing a .manifest file.
 func FindManifestLocations(root string) ([]string, error) {
 	var foundBundleRoots []string
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -175,7 +175,7 @@ func FindRegalDirectory(path string) (*os.File, error) {
 //
 // - Configuration (`project.roots`)
 // - By the presence of a .manifest file anywhere under the path
-// - By the presence of a .regal directory anywhere under or above the path ... TODO (anders): might reconsider "above"?
+// - By the presence of a .regal directory anywhere under or above the path ...
 //
 // All returned paths are absolute paths. If the provided path itself
 // is determined to be a bundle root directory it will be included in the result.
@@ -219,7 +219,6 @@ func FindBundleRootDirectories(path string) ([]string, error) {
 			foundBundleRoots = append(foundBundleRoots, roots...)
 		}
 
-		// rather than calling rio.FindManifestLocations later, let's
 		// check for .manifest directories as part of the same walk
 		if !info.IsDir() && info.Name() == ".manifest" {
 			foundBundleRoots = append(foundBundleRoots, filepath.Dir(path))
@@ -267,6 +266,13 @@ func rootsFromRegalDirectory(regalDir *os.File) ([]string, error) {
 	if err == nil && info.IsDir() {
 		foundBundleRoots = append(foundBundleRoots, customRulesDir)
 	}
+
+	manifestRoots, err := rio.FindManifestLocations(filepath.Dir(regalDir.Name()))
+	if err != nil {
+		return nil, fmt.Errorf("failed while looking for manifest locations: %w", err)
+	}
+
+	foundBundleRoots = append(foundBundleRoots, util.Map(util.FilepathJoiner(parent), manifestRoots)...)
 
 	return foundBundleRoots, nil
 }


### PR DESCRIPTION
We previously traversed the path downwards, so if we had `foo/bar/.manifest` and `foo/bar/baz` was provided, we would not find `foo/bar` as a root. Now search for manifests from the root.

Fixes #1077

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->