### PR TITLE
lsp: Correct Path to URI encoding

### DIFF
--- a/internal/lsp/uri/uri.go
+++ b/internal/lsp/uri/uri.go
@@ -19,6 +19,9 @@ func FromPath(client clients.Identifier, path string) string {
 		// Convert Windows path separators to Unix separators
 		path = filepath.ToSlash(path)
 
+		// spaces must be percent-encoded
+		path = strings.ReplaceAll(path, " ", "%20")
+
 		// If the path is a Windows path, the colon after the drive letter needs to be
 		// percent-encoded.
 		if parts := strings.Split(path, ":"); len(parts) > 1 {

--- a/internal/lsp/uri/uri_test.go
+++ b/internal/lsp/uri/uri_test.go
@@ -52,6 +52,10 @@ func TestPathToURI_VSCode(t *testing.T) {
 			path: "/foo/bar",
 			want: "file:///foo/bar",
 		},
+		"unix spaces": {
+			path: "/foo/bar baz",
+			want: "file:///foo/bar%20baz",
+		},
 		"unix prefixed": {
 			path: "file:///foo/bar",
 			want: "file:///foo/bar",


### PR DESCRIPTION
Spaces must be encoded as %20. This case causing the state worker to reload contents from disk as it appeared a file did not exist in the cache.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->