### PR TITLE
e2e: Sort output from fix hint

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 
@@ -178,6 +179,9 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 	}
 
 	if fixableViolationsCount > 0 {
+		violationKeys := util.Keys(fixableViolations)
+		slices.Sort(violationKeys)
+
 		_, err = fmt.Fprintf(
 			tr.out,
 			`
@@ -186,7 +190,7 @@ Hint: %d/%d violations can be automatically fixed (%s)
 `,
 			fixableViolationsCount,
 			r.Summary.NumViolations,
-			strings.Join(util.Keys(fixableViolations), ", "),
+			strings.Join(violationKeys, ", "),
 		)
 	}
 


### PR DESCRIPTION
This list is based on map keys and was causing flakes due to the items not always being in the same order.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->