### PR TITLE
lsp: Rename on template

### DIFF
--- a/docs/rules/idiomatic/directory-package-mismatch.md
+++ b/docs/rules/idiomatic/directory-package-mismatch.md
@@ -91,11 +91,17 @@ Editors integrating Regal's [language server](https://docs.styra.com/regal/langu
 suggestions for idiomatic package paths based on the directory structure in which a policy resides. The image below
 demonstrates a new policy being created inside an `authorization/rbac/roles` directory, and the editor
 ([via Regal](https://docs.styra.com/regal/language-server#code-completions)) suggesting the package path
- `authorization.rbac.roles`.
+`authorization.rbac.roles`.
 
 <img
-  src={require('../../assets/rules/pkg_name_completion.png').default}
-  alt="Package path auto-completion in VS Code"/>
+src={require('../../assets/rules/pkg_name_completion.png').default}
+alt="Package path auto-completion in VS Code"/>
+
+In addition, empty files will be be 'formatted' to have the correct package
+based on the directory structure. Newly created Rego files are treated in much
+the same way. When a new file is created, the server will send a series of edits
+back to set the content. If `exclude-test-suffix` is set to `false`, the file
+will also be moved if required to the `_test` directory for that package.
 
 ## Configuration Options
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -478,10 +478,7 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { // nolint:mai
 					break
 				}
 
-				// handle this ourselves as it's a rename and not a content edit
-				fixed = false
-
-				err = l.conn.Call(ctx, methodWorkspaceApplyEdit, renameParams, nil)
+				err := l.conn.Call(ctx, methodWorkspaceApplyEdit, renameParams, nil)
 				if err != nil {
 					l.logError(fmt.Errorf("failed %s notify: %v", methodWorkspaceApplyEdit, err.Error()))
 				}
@@ -496,6 +493,8 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { // nolint:mai
 					}
 				}
 
+				// handle this ourselves as it's a rename and not a content edit
+				fixed = false
 			case "regal.eval":
 				if len(params.Arguments) != 3 {
 					l.logError(fmt.Errorf("expected three arguments, got %d", len(params.Arguments)))
@@ -729,6 +728,7 @@ func (l *LanguageServer) StartTemplateWorker(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case evt := <-l.templateFile:
+			// determine the new contents for the file, if permitted
 			newContents, err := l.templateContentsForFile(evt.URI)
 			if err != nil {
 				l.logError(fmt.Errorf("failed to template new file: %w", err))
@@ -737,6 +737,8 @@ func (l *LanguageServer) StartTemplateWorker(ctx context.Context) {
 			}
 
 			// generate the edit params for the templating operation
+			// TODO: Support rename operations in here too to allow making
+			// these changes as a single operation
 			templateParams := &types.ApplyWorkspaceEditParams{
 				Label: "Template new Rego file",
 				Edit: types.WorkspaceEdit{
@@ -754,11 +756,49 @@ func (l *LanguageServer) StartTemplateWorker(ctx context.Context) {
 				l.logError(fmt.Errorf("failed %s notify: %v", methodWorkspaceApplyEdit, err.Error()))
 			}
 
-			// finally, update the cache contents and run diagnostics to clear
-			// empty module warning.
+			// set the contents of the new file in the cache immediately as
+			// these must be update to date in order for fixRenameParams
+			// to work
+			l.cache.SetFileContents(evt.URI, newContents)
+
+			// determine if a rename is needed based on the new file contents
+			renameParams, err := l.fixRenameParams(
+				"Rename file to match package path",
+				&fixes.DirectoryPackageMismatch{},
+				evt.URI,
+			)
+			if err != nil {
+				l.logError(fmt.Errorf("failed to fix directory package mismatch: %w", err))
+
+				continue
+			}
+
+			// move the file and clean up any empty directories ifd required
+			fileURI := evt.URI
+			if len(renameParams.Edit.DocumentChanges) > 0 {
+				fileURI = renameParams.Edit.DocumentChanges[0].NewURI
+				oldURI := renameParams.Edit.DocumentChanges[0].OldURI
+
+				err = l.conn.Call(ctx, methodWorkspaceApplyEdit, renameParams, nil)
+				if err != nil {
+					l.logError(fmt.Errorf("failed %s notify: %v", methodWorkspaceApplyEdit, err.Error()))
+				}
+
+				dir := filepath.Dir(uri.ToPath(l.clientIdentifier, oldURI))
+
+				err := util.DeleteEmptyDirs(dir)
+				if err != nil {
+					continue
+				}
+
+				l.cache.SetFileContents(fileURI, newContents)
+				l.cache.Delete(oldURI)
+			}
+
+			// finally, trigger a diagnostics run for the new file
 			updateEvent := fileUpdateEvent{
 				Reason:  "internal/templateNewFile",
-				URI:     evt.URI,
+				URI:     fileURI,
 				Content: newContents,
 			}
 
@@ -835,6 +875,10 @@ func (l *LanguageServer) templateContentsForFile(fileURI string) (string, error)
 		pkg = "main"
 	}
 
+	if strings.HasSuffix(fileURI, "_test.rego") {
+		pkg += "_test"
+	}
+
 	return fmt.Sprintf("package %s\n\nimport rego.v1\n", pkg), nil
 }
 
@@ -898,7 +942,7 @@ func (l *LanguageServer) fixRenameParams(
 ) (types.ApplyWorkspaceRenameEditParams, error) {
 	contents, ok := l.cache.GetFileContents(fileURL)
 	if !ok {
-		return types.ApplyWorkspaceRenameEditParams{}, fmt.Errorf("failed to get module for file %q", fileURL)
+		return types.ApplyWorkspaceRenameEditParams{}, fmt.Errorf("failed to file contents %q", fileURL)
 	}
 
 	roots, err := config.GetPotentialRoots(l.workspacePath())
@@ -921,6 +965,13 @@ func (l *LanguageServer) fixRenameParams(
 	)
 	if err != nil {
 		return types.ApplyWorkspaceRenameEditParams{}, fmt.Errorf("failed attempted fix: %w", err)
+	}
+
+	if len(results) == 0 {
+		return types.ApplyWorkspaceRenameEditParams{
+			Label: label,
+			Edit:  types.WorkspaceRenameEdit{},
+		}, nil
 	}
 
 	result := results[0]

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -242,7 +242,7 @@ func TestNewFileTemplating(t *testing.T) {
 	}
 
 	// 6. Validate that the client received a workspace edit
-	timeout = time.NewTimer(defaultTimeout)
+	timeout = time.NewTimer(3 * time.Second)
 	defer timeout.Stop()
 
 	expectedMessage := fmt.Sprintf(`{
@@ -277,11 +277,19 @@ func TestNewFileTemplating(t *testing.T) {
           "ignoreIfExists": false,
           "overwrite": false
         }
+      },
+      {
+        "kind": "delete",
+        "options": {
+          "ignoreIfNotExists": true,
+          "recursive": true
+        },
+        "uri": "file://%[3]s/foo/bar"
       }
     ]
   },
   "label": "Template new Rego file"
-}`, newFileURI, expectedNewFileURI)
+}`, newFileURI, expectedNewFileURI, tempDir)
 
 	for {
 		var success bool

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -1,12 +1,19 @@
 package lsp
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/sourcegraph/jsonrpc2"
 
 	"github.com/styrainc/regal/internal/lsp/clients"
+	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/lsp/uri"
 )
 
@@ -114,5 +121,204 @@ func TestTemplateContentsForFile(t *testing.T) {
 				t.Fatalf("expected contents to be\n%s\ngot\n%s", tc.ExpectedContents, newContents)
 			}
 		})
+	}
+}
+
+func TestNewFileTemplating(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// set up the workspace content with some example rego and regal config
+	tempDir := t.TempDir()
+
+	files := map[string]string{
+		".regal/config.yaml": `rules:
+  idiomatic:
+    directory-package-mismatch:
+      level: error
+      exclude-test-suffix: false
+`,
+	}
+
+	for f, fc := range files {
+		err := os.MkdirAll(filepath.Dir(filepath.Join(tempDir, f)), 0o755)
+		if err != nil {
+			t.Fatalf("failed to create directory %s: %s", filepath.Dir(filepath.Join(tempDir, f)), err)
+		}
+
+		err = os.WriteFile(filepath.Join(tempDir, f), []byte(fc), 0o600)
+		if err != nil {
+			t.Fatalf("failed to write file %s: %s", f, err)
+		}
+	}
+
+	// set up the server and client connections
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ls := NewLanguageServer(&LanguageServerOptions{
+		ErrorLog: newTestLogger(t),
+	})
+
+	go ls.StartConfigWorker(ctx)
+	go ls.StartTemplateWorker(ctx)
+
+	receivedMessages := make(chan []byte, 10)
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		bs, err := json.MarshalIndent(req.Params, "", "  ")
+		if err != nil {
+			t.Fatalf("failed to marshal params: %s", err)
+		}
+
+		receivedMessages <- bs
+
+		return struct{}{}, nil
+	}
+
+	connServer, connClient, cleanup := createConnections(ctx, ls.Handle, clientHandler)
+	defer cleanup()
+
+	ls.SetConn(connServer)
+
+	// 1. Client sends initialize request
+	request := types.InitializeParams{
+		RootURI:    fileURIScheme + tempDir,
+		ClientInfo: types.Client{Name: "go test"},
+	}
+
+	var response types.InitializeResult
+
+	err = connClient.Call(ctx, "initialize", request, &response)
+	if err != nil {
+		t.Fatalf("failed to send initialize request: %s", err)
+	}
+
+	// 2. Client sends initialized notification no response to the call is
+	// expected
+	err = connClient.Call(ctx, "initialized", struct{}{}, nil)
+	if err != nil {
+		t.Fatalf("failed to send initialized notification: %s", err)
+	}
+
+	// 3. wait for the server to load it's config
+	timeout := time.NewTimer(defaultTimeout)
+	select {
+	case <-timeout.C:
+		t.Fatalf("timed out waiting for server to load config")
+	default:
+		for {
+			time.Sleep(100 * time.Millisecond)
+
+			if ls.loadedConfig != nil {
+				break
+			}
+		}
+	}
+
+	// 4. Touch the new file on disk
+	newFilePath := filepath.Join(tempDir, "foo/bar/policy_test.rego")
+	newFileURI := uri.FromPath(clients.IdentifierGeneric, newFilePath)
+	expectedNewFileURI := uri.FromPath(clients.IdentifierGeneric, filepath.Join(tempDir, "foo/bar_test/policy_test.rego"))
+
+	err = os.MkdirAll(filepath.Dir(newFilePath), 0o755)
+	if err != nil {
+		t.Fatalf("failed to create directory %s: %s", filepath.Dir(newFilePath), err)
+	}
+
+	err = os.WriteFile(newFilePath, []byte(""), 0o600)
+	if err != nil {
+		t.Fatalf("failed to write file %s: %s", newFilePath, err)
+	}
+
+	// 5. Client sends workspace/didCreateFiles notification
+	err = connClient.Call(ctx, "workspace/didCreateFiles", types.WorkspaceDidCreateFilesParams{
+		Files: []types.WorkspaceDidCreateFilesParamsCreatedFile{
+			{URI: newFileURI},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// 6. Validate that the client received a workspace edit
+	timeout = time.NewTimer(defaultTimeout)
+	defer timeout.Stop()
+
+	expectedMessage := fmt.Sprintf(`{
+  "edit": {
+    "documentChanges": [
+      {
+        "edits": [
+          {
+            "newText": "package foo.bar_test\n\nimport rego.v1\n",
+            "range": {
+              "end": {
+                "character": 0,
+                "line": 0
+              },
+              "start": {
+                "character": 0,
+                "line": 0
+              }
+            }
+          }
+        ],
+        "textDocument": {
+          "uri": "%[1]s",
+          "version": null
+        }
+      },
+      {
+        "kind": "rename",
+        "newUri": "%[2]s",
+        "oldUri": "%[1]s",
+        "options": {
+          "ignoreIfExists": false,
+          "overwrite": false
+        }
+      }
+    ]
+  },
+  "label": "Template new Rego file"
+}`, newFileURI, expectedNewFileURI)
+
+	for {
+		var success bool
+		select {
+		case msg := <-receivedMessages:
+			t.Log("received message:", string(msg))
+
+			expectedLines := strings.Split(expectedMessage, "\n")
+			gotLines := strings.Split(string(msg), "\n")
+
+			if len(gotLines) != len(expectedLines) {
+				t.Logf("expected message to have %d lines, got %d", len(expectedLines), len(gotLines))
+
+				continue
+			}
+
+			allLinesMatch := true
+
+			for i, expected := range expectedLines {
+				if gotLines[i] != expected {
+					t.Logf("expected message line %d to be:\n%s\ngot\n%s", i, expected, gotLines[i])
+
+					allLinesMatch = false
+				}
+			}
+
+			if allLinesMatch {
+				success = true
+			}
+		case <-timeout.C:
+			t.Log("never received expected message", expectedMessage)
+
+			t.Fatalf("timed out waiting for expected message to be sent")
+		}
+
+		if success {
+			break
+		}
 	}
 }

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -243,6 +243,17 @@ type RenameFile struct {
 	AnnotationIdentifier *string            `json:"annotationId,omitempty"`
 }
 
+type DeleteFileOptions struct {
+	Recursive         bool `json:"recursive"`
+	IgnoreIfNotExists bool `json:"ignoreIfNotExists"`
+}
+
+type DeleteFile struct {
+	Kind    string             `json:"kind"` // must always be "delete"
+	URI     string             `json:"uri"`
+	Options *DeleteFileOptions `json:"options,omitempty"`
+}
+
 // WorkspaceRenameEdit is a WorkspaceEdit that is used for renaming files.
 // Perhaps we should use generics and a union type here instead.
 type WorkspaceRenameEdit struct {

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,6 +1,12 @@
 package util
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
 
 func TestFindClosestMatchingRoot(t *testing.T) {
 	t.Parallel()
@@ -44,6 +50,99 @@ func TestFindClosestMatchingRoot(t *testing.T) {
 			got := FindClosestMatchingRoot(test.path, test.roots)
 			if got != test.expected {
 				t.Fatalf("expected %v, got %v", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestDirCleanUpPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		State                     map[string]string
+		DeleteTarget              string
+		AdditionalPreserveTargets []string
+		Expected                  []string
+	}{
+		"simple": {
+			DeleteTarget: "foo/bar.rego",
+			State: map[string]string{
+				"foo/bar.rego": "package foo",
+			},
+			Expected: []string{"foo"},
+		},
+		"not empty": {
+			DeleteTarget: "foo/bar.rego",
+			State: map[string]string{
+				"foo/bar.rego": "package foo",
+				"foo/baz.rego": "package foo",
+			},
+			Expected: []string{},
+		},
+		"all the way up": {
+			DeleteTarget: "foo/bar/baz/bax.rego",
+			State: map[string]string{
+				"foo/bar/baz/bax.rego": "package baz",
+			},
+			Expected: []string{"foo/bar/baz", "foo/bar", "foo"},
+		},
+		"almost all the way up": {
+			DeleteTarget: "foo/bar/baz/bax.rego",
+			State: map[string]string{
+				"foo/bar/baz/bax.rego": "package baz",
+				"foo/bax.rego":         "package foo",
+			},
+			Expected: []string{"foo/bar/baz", "foo/bar"},
+		},
+		"with preserve targets": {
+			DeleteTarget: "foo/bar/baz/bax.rego",
+			AdditionalPreserveTargets: []string{
+				"foo/bar/baz_test/bax.rego",
+			},
+			State: map[string]string{
+				"foo/bar/baz/bax.rego": "package baz",
+				"foo/bax.rego":         "package foo",
+			},
+			// foo/bar is not deleted because of the preserve target
+			Expected: []string{"foo/bar/baz"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+
+			for k, v := range test.State {
+				err := os.MkdirAll(filepath.Dir(filepath.Join(tempDir, k)), 0o755)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				err = os.WriteFile(filepath.Join(tempDir, k), []byte(v), 0o600)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			expected := make([]string, len(test.Expected))
+			for i, v := range test.Expected {
+				expected[i] = filepath.Join(tempDir, v)
+			}
+
+			additionalPreserveTargets := []string{tempDir}
+			for i, v := range test.AdditionalPreserveTargets {
+				additionalPreserveTargets[i] = filepath.Join(tempDir, v)
+			}
+
+			got, err := DirCleanUpPaths(filepath.Join(tempDir, test.DeleteTarget), additionalPreserveTargets)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !slices.Equal(got, expected) {
+				t.Fatalf("expected\n%v\ngot:\n%v", strings.Join(expected, "\n"), strings.Join(got, "\n"))
 			}
 		})
 	}

--- a/pkg/fixer/fixes/directorypackagemismatch.go
+++ b/pkg/fixer/fixes/directorypackagemismatch.go
@@ -82,6 +82,10 @@ func getPackagePathDirectory(fc *FixCandidate, config *config.Config) (string, e
 }
 
 func shouldExcludeTestSuffix(config *config.Config) bool {
+	if config == nil {
+		return true
+	}
+
 	if category, ok := config.Rules["idiomatic"]; ok {
 		if rule, ok := category["directory-package-mismatch"]; ok {
 			if exclude, ok := rule.Extra["exclude-test-suffix"].(bool); ok {


### PR DESCRIPTION
Fixes https://github.com/StyraInc/regal/issues/1061

https://github.com/user-attachments/assets/a6589d87-6885-459d-a0a4-28e5821453a7

I have added some tests for the templating, I was going to determine the desired name for the file in that function too but in the end it was easier to keep the renaming logic separate. Even if this is more verbose, can be revisited tomorrow if we want to do some tidying here. Posting now just to allow testing until I'm next back working on this.