### PR TITLE
Bump roast to v0.2.0 to ensure annotations encodes correctly

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -938,6 +938,31 @@ test_allow := true
 	}
 }
 
+// verify fix for https://github.com/StyraInc/regal/issues/1082
+func TestLintAnnotationCustomAttributeMultipleItems(t *testing.T) {
+	t.Parallel()
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	cwd := testutil.Must(os.Getwd())(t)
+
+	err := regal(&stdout, &stderr)(
+		"lint",
+		"--disable=directory-package-mismatch",
+		filepath.Join(cwd, "testdata", "bugs", "issue_1082.rego"),
+	)
+
+	expectExitCode(t, err, 0, &stdout, &stderr)
+
+	if exp, act := "", stderr.String(); exp != act {
+		t.Errorf("expected stderr %q, got %q", exp, act)
+	}
+
+	if exp, act := "1 file linted. No violations found.\n", stdout.String(); exp != act {
+		t.Errorf("expected stdout %q, got %q", exp, act)
+	}
+}
+
 func binary() string {
 	var location string
 	if runtime.GOOS == "windows" {

--- a/e2e/testdata/bugs/issue_1082.rego
+++ b/e2e/testdata/bugs/issue_1082.rego
@@ -1,0 +1,11 @@
+# METADATA
+# description: ensure that multiple custom fields are handled correctly
+# related_resources:
+#   - description: issue
+#     ref: https://github.com/StyraInc/regal/issues/1082
+# custom:
+#   x: 1
+#   y: 2
+package bug
+
+import rego.v1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	dario.cat/mergo v1.0.1
-	github.com/anderseknert/roast v0.1.0
+	github.com/anderseknert/roast v0.2.0
 	github.com/coreos/go-semver v0.3.1
 	github.com/fatih/color v1.17.0
 	github.com/fsnotify/fsnotify v1.7.0
@@ -34,7 +34,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
-	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/fgprof v0.9.3 // indirect
@@ -64,7 +63,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.20.2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0k
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/anderseknert/roast v0.1.0 h1:PE1KAcrhMEYzsjGmouOqn0qSqdPd+s8N5/e+eHK4y4c=
-github.com/anderseknert/roast v0.1.0/go.mod h1:ViJIrrLZLl3+EbjYzsr8G60UfRhaMtN3dwDBlS8OD4o=
+github.com/anderseknert/roast v0.2.0 h1:Hi+noJBe+rLhCzApy8Xo5IE6pkAPBGVFLMJ8EecoghA=
+github.com/anderseknert/roast v0.2.0/go.mod h1:+VbTe/Fj1AUhtafMwz9JBdoPqFCS4rkNwsAhJwMgr1Y=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=


### PR DESCRIPTION
This also ups the OPA version used by roast to v0.68.0, aligned with Regal.

Fixes #1082

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->