### PR TITLE
Fix: block comments should take column into account

### DIFF
--- a/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
+++ b/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
@@ -53,7 +53,7 @@ allow := true
 }
 
 test_success_attached_metadata if {
-	r := rule.report with input as ast.policy(`
+	r := rule.report with input as ast.with_rego_v1(`
 # METADATA
 # title: valid
 allow := true
@@ -62,9 +62,7 @@ allow := true
 }
 
 test_success_detached_document_scope_ok if {
-	r := rule.report with input as regal.parse_module("p.rego", `
-package p
-
+	r := rule.report with input as ast.with_rego_v1(`
 # METADATA
 # scope: document
 # description: allow allows
@@ -72,6 +70,15 @@ package p
 # METADATA
 # title: allow
 allow := true
+`)
+	r == set()
+}
+
+test_success_not_detached_by_comment_in_different_column if {
+	r := rule.report with input as ast.with_rego_v1(`
+# METADATA
+# title: allow
+allow := true # not in block
 `)
 	r == set()
 }


### PR DESCRIPTION
A "comment block" should only count comments in sequence when they are on the same column.

Fixes #1086

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->