### PR TITLE
lsp: Make length check of inlay hints fatal

### DIFF
--- a/internal/lsp/inlayhint_test.go
+++ b/internal/lsp/inlayhint_test.go
@@ -19,7 +19,7 @@ func TestGetInlayHintsAstCall(t *testing.T) {
 	inlayHints := getInlayHints(module)
 
 	if len(inlayHints) != 2 {
-		t.Errorf("Expected 2 inlay hints, got %d", len(inlayHints))
+		t.Fatalf("Expected 2 inlay hints, got %d", len(inlayHints))
 	}
 
 	if inlayHints[0].Label != "object:" {


### PR DESCRIPTION
Since the rest of the test is making use of the hints, we need to stop execution if the length check fails.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->