### PR TITLE
Address races in test cases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,8 @@ jobs:
           path: ~/go/bin/rq
           key: ${{ runner.os }}-${{ runner.arch }}-go-rq-${{ env.RQ_VERSION }}
       - run: build/do.rq pull_request
+      - run: go test -race ./...
+        if: matrix.os.name == 'linux'
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         if: matrix.os.name == 'linux'
         with:

--- a/internal/lsp/config/watcher_test.go
+++ b/internal/lsp/config/watcher_test.go
@@ -29,7 +29,7 @@ foo: bar
 	defer cancel()
 
 	go func() {
-		err = watcher.Start(ctx)
+		err := watcher.Start(ctx)
 		if err != nil {
 			t.Errorf("failed to start watcher: %v", err)
 		}

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -210,7 +210,7 @@ func TestNewFileTemplating(t *testing.T) {
 		for {
 			time.Sleep(100 * time.Millisecond)
 
-			if ls.loadedConfig != nil {
+			if ls.getLoadedConfig() != nil {
 				break
 			}
 		}

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -176,8 +176,7 @@ func TestNewFileTemplating(t *testing.T) {
 		return struct{}{}, nil
 	}
 
-	connServer, connClient, cleanup := createConnections(ctx, ls.Handle, clientHandler)
-	defer cleanup()
+	connServer, connClient := createConnections(ctx, ls.Handle, clientHandler)
 
 	ls.SetConn(connServer)
 


### PR DESCRIPTION
There were three areas/issues:

- An error var in a config watcher test was accessed in two places
- server loaded config was accessed in a number of places without locking
- a panic caused by early closing of the net.Pipe in the lsp server tests.

This PR addresses these issues and runs the race check on PRs during the Linux build.

Fixes https://github.com/StyraInc/regal/issues/1099