### PR TITLE
Add `Debug` Code Lens

### DIFF
--- a/bundle/regal/lsp/codelens/codelens.rego
+++ b/bundle/regal/lsp/codelens/codelens.rego
@@ -1,0 +1,82 @@
+# METADATA
+# description: |
+#   the code lens provider decides where code lenses should be placed in the given input file
+# schemas:
+#   - input: schema.regal.ast
+package regal.lsp.codelens
+
+import rego.v1
+
+import data.regal.ast
+import data.regal.result
+import data.regal.util
+
+import data.regal.lsp.util.location
+
+# code lenses are displayed in the order they come back in the returned
+# array, and 'evaluate' somehow feels better to the left of 'debug'
+lenses := array.concat(
+	[l | some l in _eval_lenses],
+	[l | some l in _debug_lenses],
+)
+
+_eval_lenses contains {
+	"range": location.to_range(result.ranged_location_from_text(input["package"]).location),
+	"command": {
+		"title": "Evaluate",
+		"command": "regal.eval",
+		"arguments": [
+			input.regal.file.name,
+			ast.ref_to_string(input["package"].path),
+			util.to_location_object(input["package"].location).row,
+		],
+	},
+}
+
+_eval_lenses contains _rule_lens(rule, "regal.eval", "Evaluate") if {
+	some rule in ast.rules
+}
+
+_debug_lenses contains {
+	"range": location.to_range(result.ranged_location_from_text(input["package"]).location),
+	"command": {
+		"title": "Debug",
+		"command": "regal.debug",
+		"arguments": [
+			input.regal.file.name,
+			ast.ref_to_string(input["package"].path),
+			util.to_location_object(input["package"].location).row,
+		],
+	},
+}
+
+_debug_lenses contains _rule_lens(rule, "regal.debug", "Debug") if {
+	some rule in ast.rules
+
+	# no need to add a debug lens for a rule like `pi := 3.14`
+	not _unconditional_constant(rule)
+}
+
+_rule_lens(rule, command, title) := {
+	"range": location.to_range(result.ranged_location_from_text(rule).location),
+	"command": {
+		"title": title,
+		"command": command,
+		"arguments": [
+			input.regal.file.name, # regal ignore:external-reference
+			sprintf("%s.%s", [ast.ref_to_string(input["package"].path), ast.ref_static_to_string(rule.head.ref)]),
+			util.to_location_object(rule.head.location).row,
+		],
+	},
+}
+
+_rule_lens_args(filename, rule) := [
+	filename,
+	sprintf("%s.%s", [ast.ref_to_string(input["package"].path), ast.ref_static_to_string(rule.head.ref)]),
+	util.to_location_object(rule.head.location).row,
+]
+
+_unconditional_constant(rule) if {
+	not rule.body
+	ast.is_constant(rule.head.value)
+}

--- a/bundle/regal/lsp/codelens/codelens_test.rego
+++ b/bundle/regal/lsp/codelens/codelens_test.rego
@@ -1,0 +1,61 @@
+package regal.lsp.codelens_test
+
+import rego.v1
+
+import data.regal.lsp.codelens
+
+# regal ignore:rule-length
+test_code_lenses_for_module if {
+	module := regal.parse_module("policy.rego", `
+	package foo
+
+	import rego.v1
+
+	rule1 := 1
+
+	rule2 if 1 + rule1 == 2
+	`)
+	lenses := codelens.lenses with input as module
+
+	lenses == [
+		{
+			"command": {
+				"arguments": ["policy.rego", "data.foo", 2],
+				"command": "regal.eval",
+				"title": "Evaluate",
+			},
+			"range": {"end": {"character": 8, "line": 1}, "start": {"character": 1, "line": 1}},
+		},
+		{
+			"command": {
+				"arguments": ["policy.rego", "data.foo.rule1", 6],
+				"command": "regal.eval",
+				"title": "Evaluate",
+			},
+			"range": {"end": {"character": 11, "line": 5}, "start": {"character": 1, "line": 5}},
+		},
+		{
+			"command": {
+				"arguments": ["policy.rego", "data.foo.rule2", 8],
+				"command": "regal.eval", "title": "Evaluate",
+			},
+			"range": {"end": {"character": 24, "line": 7}, "start": {"character": 1, "line": 7}},
+		},
+		{
+			"command": {
+				"arguments": ["policy.rego", "data.foo", 2],
+				"command": "regal.debug",
+				"title": "Debug",
+			},
+			"range": {"end": {"character": 8, "line": 1}, "start": {"character": 1, "line": 1}},
+		},
+		{
+			"command": {
+				"arguments": ["policy.rego", "data.foo.rule2", 8],
+				"command": "regal.debug",
+				"title": "Debug",
+			},
+			"range": {"end": {"character": 24, "line": 7}, "start": {"character": 1, "line": 7}},
+		},
+	]
+}

--- a/bundle/regal/lsp/util/location/location.rego
+++ b/bundle/regal/lsp/util/location/location.rego
@@ -1,0 +1,16 @@
+package regal.lsp.util.location
+
+import rego.v1
+
+# METADATA
+# description: turns an AST location _with end attribute_ into an LSP range
+to_range(location) := {
+	"start": {
+		"line": location.row - 1,
+		"character": location.col - 1,
+	},
+	"end": {
+		"line": location.end.row - 1,
+		"character": location.end.col - 1,
+	},
+}

--- a/internal/lsp/rego/rego_test.go
+++ b/internal/lsp/rego/rego_test.go
@@ -1,0 +1,101 @@
+package rego
+
+import (
+	"context"
+	"testing"
+
+	"github.com/styrainc/regal/internal/parse"
+)
+
+func TestCodeLenses(t *testing.T) {
+	t.Parallel()
+
+	contents := `package p
+
+	import rego.v1
+
+	allow if "foo" in input.bar`
+
+	module := parse.MustParseModule(contents)
+
+	lenses, er := CodeLenses(context.TODO(), "p.rego", contents, module)
+	if er != nil {
+		t.Fatalf("unexpected error: %v", er)
+	}
+
+	// 2 for the package, 2 for the rule
+	// the contents of the lenses are tested in Rego
+	if len(lenses) != 4 {
+		t.Fatalf("expected 4 code lenses, got %d", len(lenses))
+	}
+}
+
+func TestAllRuleHeadLocations(t *testing.T) {
+	t.Parallel()
+
+	contents := `package p
+
+	import rego.v1
+
+	default allow := false
+
+	allow if 1
+	allow if 2
+
+	foo.bar[x] if x := 1
+	foo.bar[x] if x := 2`
+
+	module := parse.MustParseModule(contents)
+
+	ruleHeads, er := AllRuleHeadLocations(context.TODO(), "p.rego", contents, module)
+	if er != nil {
+		t.Fatalf("unexpected error: %v", er)
+	}
+
+	if len(ruleHeads) != 2 {
+		t.Fatalf("expected 2 code lenses, got %d", len(ruleHeads))
+	}
+
+	if len(ruleHeads["data.p.allow"]) != 3 {
+		t.Fatalf("expected 3 allow rule heads, got %d", len(ruleHeads["data.p.allow"]))
+	}
+
+	if len(ruleHeads["data.p.foo.bar"]) != 2 {
+		t.Fatalf("expected 2 foo.bar rule heads, got %d", len(ruleHeads["data.p.foo.bar"]))
+	}
+}
+
+func TestAllKeywords(t *testing.T) {
+	t.Parallel()
+
+	contents := `package p
+
+	import rego.v1
+
+	my_set contains "x" if true
+	`
+
+	module := parse.MustParseModule(contents)
+
+	keywords, er := AllKeywords(context.TODO(), "p.rego", contents, module)
+	if er != nil {
+		t.Fatalf("unexpected error: %v", er)
+	}
+
+	// this is "lines with keywords", not number of keywords
+	if len(keywords) != 3 {
+		t.Fatalf("expected 1 keyword, got %d", len(keywords))
+	}
+
+	if len(keywords["1"]) != 1 {
+		t.Fatalf("expected 1 keywords on line 1, got %d", len(keywords["1"]))
+	}
+
+	if len(keywords["3"]) != 1 {
+		t.Fatalf("expected 1 keywords on line 3, got %d", len(keywords["1"]))
+	}
+
+	if len(keywords["5"]) != 2 {
+		t.Fatalf("expected 2 keywords on line 5, got %d", len(keywords["1"]))
+	}
+}

--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -2,7 +2,6 @@
 package builtins
 
 import (
-	"bytes"
 	"errors"
 
 	"github.com/anderseknert/roast/pkg/encoding"
@@ -62,14 +61,12 @@ func RegalParseModule(_ rego.BuiltinContext, filename *ast.Term, policy *ast.Ter
 		return nil, err
 	}
 
-	json := encoding.JSON()
-
-	var buf bytes.Buffer
-	if err := json.NewEncoder(&buf).Encode(&enhancedAST); err != nil {
+	roast, err := encoding.JSON().MarshalToString(enhancedAST)
+	if err != nil {
 		return nil, err
 	}
 
-	term, err := ast.ParseTerm(buf.String())
+	term, err := ast.ParseTerm(roast)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Following the excellent work on debugger support by @johanfylling, this PR introduces a code lens for debugging, which triggers a command that simply returns a launch configuration where the package or rule clicked is set as the entrypoint.

The code lens provider is now also rewritten in Rego.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->