### PR TITLE
More stringent ast.ref_to_string

### DIFF
--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -277,3 +277,54 @@ test_function_calls if {
 test_implicit_boolean_assignment if {
 	ast.implicit_boolean_assignment(ast.with_rego_v1(`a.b if true`).rules[0])
 }
+
+test_ref_to_string if {
+	ast.ref_to_string([{"type": "var", "value": "data"}]) == `data`
+	ast.ref_to_string([{"type": "var", "value": "foo"}, {"type": "var", "value": "bar"}]) == `foo[bar]`
+	ast.ref_to_string([{"type": "var", "value": "data"}, {"type": "string", "value": "/foo/"}]) == `data["/foo/"]`
+	ast.ref_to_string([
+		{"type": "var", "value": "foo"},
+		{"type": "var", "value": "bar"},
+		{"type": "var", "value": "baz"},
+	]) == `foo[bar][baz]`
+	ast.ref_to_string([
+		{"type": "var", "value": "foo"},
+		{"type": "var", "value": "bar"},
+		{"type": "var", "value": "baz"},
+		{"type": "string", "value": "qux"},
+	]) == `foo[bar][baz].qux`
+	ast.ref_to_string([
+		{"type": "var", "value": "foo"},
+		{"type": "string", "value": "~bar~"},
+		{"type": "string", "value": "boo"},
+		{"type": "var", "value": "baz"},
+	]) == `foo["~bar~"].boo[baz]`
+	ast.ref_to_string([
+		{"type": "var", "value": "data"},
+		{"type": "string", "value": "regal"},
+		{"type": "string", "value": "lsp"},
+		{"type": "string", "value": "completion_test"},
+	]) == `data.regal.lsp.completion_test`
+}
+
+test_ref_static_to_string if {
+	ast.ref_static_to_string([{"type": "var", "value": "data"}]) == `data`
+	ast.ref_static_to_string([{"type": "var", "value": "foo"}, {"type": "var", "value": "bar"}]) == `foo`
+	ast.ref_static_to_string([{"type": "var", "value": "data"}, {"type": "string", "value": "/foo/"}]) == `data["/foo/"]`
+	ast.ref_static_to_string([
+		{"type": "var", "value": "foo"},
+		{"type": "string", "value": "bar"},
+		{"type": "var", "value": "baz"},
+	]) == `foo.bar`
+	ast.ref_static_to_string([
+		{"type": "var", "value": "foo"},
+		{"type": "string", "value": "~bar~"},
+		{"type": "string", "value": "qux"},
+	]) == `foo["~bar~"].qux`
+	ast.ref_static_to_string([
+		{"type": "var", "value": "data"},
+		{"type": "string", "value": "regal"},
+		{"type": "string", "value": "lsp"},
+		{"type": "string", "value": "completion_test"},
+	]) == `data.regal.lsp.completion_test`
+}

--- a/bundle/regal/ast/rule_head_locations_test.rego
+++ b/bundle/regal/ast/rule_head_locations_test.rego
@@ -23,7 +23,6 @@ ref_rule[foo] := true if {
 	some foo in [1,2,3]
 }
 `
-
 	result := ast.rule_head_locations with input as regal.parse_module("p.rego", policy)
 
 	result == {

--- a/bundle/regal/lsp/completion/ref_names.rego
+++ b/bundle/regal/lsp/completion/ref_names.rego
@@ -7,7 +7,7 @@ import data.regal.ast
 # ref_names returns a list of ref names that are used in the module.
 # built-in functions are not included as they are provided by another completions provider.
 ref_names contains name if {
-	name := ast.ref_to_string(ast.found.refs[_][_].value)
+	name := ast.ref_static_to_string(ast.found.refs[_][_].value)
 
 	not name in ast.builtin_names
 }

--- a/bundle/regal/lsp/completion/ref_names_test.rego
+++ b/bundle/regal/lsp/completion/ref_names_test.rego
@@ -29,8 +29,8 @@ test_ref_names if {
 	ref_names == {
 		"imp",
 		"bb",
-		"input.foo.$x",
-		"data.bar.$x",
+		"input.foo",
+		"data.bar",
 		"imp.foo",
 		"data.x",
 	}

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -131,7 +131,7 @@ func prepareQuery(store storage.Store, query string) (*rego.PreparedEvalQuery, e
 	// and how to present it if enabled.
 	pq, err := rego.New(regoArgs...).PrepareForEval(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("failed preparing query: %w", err)
+		return nil, fmt.Errorf("failed preparing query: %s, %w", query, err)
 	}
 
 	err = store.Commit(context.Background(), txn)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -575,7 +575,7 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { // nolint:mai
 
 				responseParams := map[string]any{
 					"type":        "opa-debug",
-					"name":        "Debug " + path,
+					"name":        path,
 					"request":     "launch",
 					"command":     "eval",
 					"query":       path,

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -363,19 +363,21 @@ func (l Linter) DetermineEnabledRules(ctx context.Context) ([]string, error) {
 		enabledRules = append(enabledRules, rule.Name())
 	}
 
-	query := ast.MustParseBody(`[rule|
-data.regal.rules[cat][rule]
-data.regal.config.for_rule(cat, rule).level != "ignore"
-]`)
+	queryStr := `[rule |
+	data.regal.rules[cat][rule]
+	data.regal.config.for_rule(cat, rule).level != "ignore"
+]`
+
+	query := ast.MustParseBody(queryStr)
 
 	regoArgs, err := l.prepareRegoArgs(query)
 	if err != nil {
-		return nil, fmt.Errorf("failed preparing query: %w", err)
+		return nil, fmt.Errorf("failed preparing query %s: %w", queryStr, err)
 	}
 
 	rs, err := rego.New(regoArgs...).Eval(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed preparing query: %w", err)
+		return nil, fmt.Errorf("failed evaluating query %s: %w", queryStr, err)
 	}
 
 	if len(rs) != 1 || len(rs[0].Expressions) != 1 {


### PR DESCRIPTION
While I started looking into #1104 I encountered some cases where `ast.ref_to_string`, and it's `static` counterpart would return wrong representations. We already had a bit of a homegrown format, which was convenient for some things, but would also leak out in places where it shouldn't be. Now use the same format as OPA for representing refs as strings.

Also added the query in error messages where we fail to prepare or eval in a couple of places, as the lack of those made debugging this issue much harder than it had to be.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->