### PR TITLE
lsp: Address test concurrency issues

### DIFF
--- a/internal/lsp/completions/manager.go
+++ b/internal/lsp/completions/manager.go
@@ -1,6 +1,7 @@
 package completions
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/open-policy-agent/opa/storage"
@@ -20,7 +21,7 @@ type Manager struct {
 type ManagerOptions struct{}
 
 type Provider interface {
-	Run(*cache.Cache, types.CompletionParams, *providers.Options) ([]types.CompletionItem, error)
+	Run(context.Context, *cache.Cache, types.CompletionParams, *providers.Options) ([]types.CompletionItem, error)
 	Name() string
 }
 
@@ -42,7 +43,11 @@ func NewDefaultManager(c *cache.Cache, store storage.Store) *Manager {
 	return m
 }
 
-func (m *Manager) Run(params types.CompletionParams, opts *providers.Options) ([]types.CompletionItem, error) {
+func (m *Manager) Run(
+	ctx context.Context,
+	params types.CompletionParams,
+	opts *providers.Options,
+) ([]types.CompletionItem, error) {
 	if m.isInsideOfComment(params) {
 		// Exit early if caret position is inside a comment. We currently don't have any provider
 		// where doing completions inside of a comment makes much sense. Behavior is also editor-specific:
@@ -54,7 +59,7 @@ func (m *Manager) Run(params types.CompletionParams, opts *providers.Options) ([
 	var completionsList []types.CompletionItem
 
 	for _, provider := range m.providers {
-		providerCompletions, err := provider.Run(m.c, params, opts)
+		providerCompletions, err := provider.Run(ctx, m.c, params, opts)
 		if err != nil {
 			return nil, fmt.Errorf("error running completion provider: %w", err)
 		}

--- a/internal/lsp/completions/manager_test.go
+++ b/internal/lsp/completions/manager_test.go
@@ -1,6 +1,7 @@
 package completions
 
 import (
+	"context"
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -39,7 +40,7 @@ func TestManagerEarlyExitInsideComment(t *testing.T) {
 		},
 	}
 
-	completions, err := mgr.Run(completionParams, nil)
+	completions, err := mgr.Run(context.Background(), completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/builtins.go
+++ b/internal/lsp/completions/providers/builtins.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -16,7 +17,12 @@ func (*BuiltIns) Name() string {
 	return "builtins"
 }
 
-func (*BuiltIns) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+func (*BuiltIns) Run(
+	_ context.Context,
+	c *cache.Cache,
+	params types.CompletionParams,
+	_ *Options,
+) ([]types.CompletionItem, error) {
 	fileURI := params.TextDocument.URI
 
 	lines, currentLine := completionLineHelper(c, fileURI, params.Position.Line)

--- a/internal/lsp/completions/providers/builtins_test.go
+++ b/internal/lsp/completions/providers/builtins_test.go
@@ -1,11 +1,10 @@
 package providers
 
 import (
+	"context"
 	"slices"
 	"strings"
 	"testing"
-
-	"golang.org/x/net/context"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/types"

--- a/internal/lsp/completions/providers/builtins_test.go
+++ b/internal/lsp/completions/providers/builtins_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/types"
 )
@@ -32,7 +34,7 @@ allow if c`
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -67,7 +69,7 @@ allow := c`
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -104,7 +106,7 @@ allow if {
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -139,7 +141,7 @@ allow if gt`
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -172,7 +174,7 @@ allow if c`
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -207,7 +209,7 @@ default allow := f`
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/input.go
+++ b/internal/lsp/completions/providers/input.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -16,7 +17,12 @@ func (*Input) Name() string {
 	return "input"
 }
 
-func (*Input) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+func (*Input) Run(
+	_ context.Context,
+	c *cache.Cache,
+	params types.CompletionParams,
+	_ *Options,
+) ([]types.CompletionItem, error) {
 	fileURI := params.TextDocument.URI
 
 	lines, currentLine := completionLineHelper(c, fileURI, params.Position.Line)

--- a/internal/lsp/completions/providers/input_test.go
+++ b/internal/lsp/completions/providers/input_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -30,7 +31,7 @@ allow if i`
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/packagerefs.go
+++ b/internal/lsp/completions/providers/packagerefs.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -15,7 +16,12 @@ func (*PackageRefs) Name() string {
 	return "packagerefs"
 }
 
-func (*PackageRefs) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+func (*PackageRefs) Run(
+	_ context.Context,
+	c *cache.Cache,
+	params types.CompletionParams,
+	_ *Options,
+) ([]types.CompletionItem, error) {
 	fileURI := params.TextDocument.URI
 
 	lines, currentLine := completionLineHelper(c, fileURI, params.Position.Line)

--- a/internal/lsp/completions/providers/packagerefs_test.go
+++ b/internal/lsp/completions/providers/packagerefs_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -60,7 +61,7 @@ import
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -134,7 +135,7 @@ import
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -53,7 +53,12 @@ func (*Policy) Name() string {
 	return "policy"
 }
 
-func (p *Policy) Run(c *cache.Cache, params types.CompletionParams, opts *Options) ([]types.CompletionItem, error) {
+func (p *Policy) Run(
+	ctx context.Context,
+	c *cache.Cache,
+	params types.CompletionParams,
+	opts *Options,
+) ([]types.CompletionItem, error) {
 	if opts == nil {
 		return nil, errors.New("options must be provided")
 	}
@@ -101,7 +106,7 @@ func (p *Policy) Run(c *cache.Cache, params types.CompletionParams, opts *Option
 		return []types.CompletionItem{}, nil //nolint: nilerr
 	}
 
-	result, err := rego2.QueryRegalBundle(input, p.pq)
+	result, err := rego2.QueryRegalBundle(ctx, input, p.pq)
 	if err != nil {
 		return nil, fmt.Errorf("failed querying regal bundle: %w", err)
 	}

--- a/internal/lsp/completions/providers/policy_test.go
+++ b/internal/lsp/completions/providers/policy_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -59,6 +60,7 @@ allow if {
 	}
 
 	result, err := locals.Run(
+		context.Background(),
 		c,
 		params,
 		&Options{ClientIdentifier: clients.IdentifierGeneric},
@@ -133,6 +135,7 @@ allow if {
 	}
 
 	result, err := locals.Run(
+		context.Background(),
 		c,
 		params,
 		&Options{ClientIdentifier: clients.IdentifierGeneric},

--- a/internal/lsp/completions/providers/rulehead.go
+++ b/internal/lsp/completions/providers/rulehead.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -17,7 +18,12 @@ func (*RuleHead) Name() string {
 	return "rulehead"
 }
 
-func (*RuleHead) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+func (*RuleHead) Run(
+	_ context.Context,
+	c *cache.Cache,
+	params types.CompletionParams,
+	_ *Options,
+) ([]types.CompletionItem, error) {
 	fileURI := params.TextDocument.URI
 
 	lines, currentLine := completionLineHelper(c, fileURI, params.Position.Line)

--- a/internal/lsp/completions/providers/rulehead_test.go
+++ b/internal/lsp/completions/providers/rulehead_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -59,7 +60,7 @@ funckyfunc := true
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/ruleheadkeyword.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword.go
@@ -2,6 +2,7 @@
 package providers
 
 import (
+	"context"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -22,7 +23,12 @@ func (*RuleHeadKeyword) Name() string {
 	return "ruleheadkeyword"
 }
 
-func (*RuleHeadKeyword) Run(c *cache.Cache, params types.CompletionParams, _ *Options) ([]types.CompletionItem, error) {
+func (*RuleHeadKeyword) Run(
+	_ context.Context,
+	c *cache.Cache,
+	params types.CompletionParams,
+	_ *Options,
+) ([]types.CompletionItem, error) {
 	fileURI := params.TextDocument.URI
 
 	_, currentLine := completionLineHelper(c, fileURI, params.Position.Line)

--- a/internal/lsp/completions/providers/ruleheadkeyword_test.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword_test.go
@@ -2,6 +2,7 @@
 package providers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -31,7 +32,7 @@ deny` + " "
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -83,7 +84,7 @@ deny i
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -126,7 +127,7 @@ deny c
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -169,7 +170,7 @@ deny contains message i
 		},
 	}
 
-	completions, err := p.Run(c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, nil)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/rego/builtins.go
+++ b/internal/lsp/rego/builtins.go
@@ -1,6 +1,7 @@
 package rego
 
 import (
+	"maps"
 	"strings"
 	"sync"
 
@@ -23,7 +24,7 @@ func GetBuiltins() map[string]*ast.Builtin {
 	builtInsLock.RLock()
 	defer builtInsLock.RUnlock()
 
-	return builtIns
+	return maps.Clone(builtIns)
 }
 
 func builtinMap(caps *ast.Capabilities) map[string]*ast.Builtin {

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -272,8 +272,8 @@ func SetInputContext(input map[string]any, context map[string]any) map[string]an
 	return input
 }
 
-func QueryRegalBundle(input map[string]any, pq rego.PreparedEvalQuery) (map[string]any, error) {
-	result, err := pq.Eval(context.Background(), rego.EvalInput(input))
+func QueryRegalBundle(ctx context.Context, input map[string]any, pq rego.PreparedEvalQuery) (map[string]any, error) {
+	result, err := pq.Eval(ctx, rego.EvalInput(input))
 	if err != nil {
 		return nil, fmt.Errorf("failed evaluating query: %w", err)
 	}

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -56,6 +56,8 @@ func LocationFromPosition(pos types.Position) *ast.Location {
 func AllBuiltinCalls(module *ast.Module) []BuiltInCall {
 	builtinCalls := make([]BuiltInCall, 0)
 
+	bis := GetBuiltins()
+
 	callVisitor := ast.NewGenericVisitor(func(x interface{}) bool {
 		var terms []*ast.Term
 
@@ -73,8 +75,6 @@ func AllBuiltinCalls(module *ast.Module) []BuiltInCall {
 		if len(terms) == 0 {
 			return false
 		}
-
-		bis := GetBuiltins()
 
 		if b, ok := bis[terms[0].Value.String()]; ok {
 			// Exclude operators and similar builtins

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1471,7 +1471,7 @@ func (l *LanguageServer) handleTextDocumentCodeLens(
 }
 
 func (l *LanguageServer) handleTextDocumentCompletion(
-	_ context.Context,
+	ctx context.Context,
 	_ *jsonrpc2.Conn,
 	req *jsonrpc2.Request,
 ) (any, error) {
@@ -1490,7 +1490,7 @@ func (l *LanguageServer) handleTextDocumentCompletion(
 	}
 
 	// items is allocated here so that the return value is always a non-nil CompletionList
-	items, err := l.completionsManager.Run(params, &providers.Options{
+	items, err := l.completionsManager.Run(ctx, params, &providers.Options{
 		ClientIdentifier: l.clientIdentifier,
 		RootURI:          l.workspaceRootURI,
 	})


### PR DESCRIPTION
This PR is intended to address two issues with the test suite that happen when running tests concurrently:

TestLanguageServerSingleFile fails sometimes as the server logs an error when the context has been cancelled, and it's a panic when logging to t, after the test is over.

https://github.com/StyraInc/regal/actions/runs/10875806798/job/30174833322

TestGetInlayHintsAstTerms will fail when TestLanguageServerSingleFile is running sometimes as [TestLanguageServerSingleFile updates the contents of the map](https://github.com/StyraInc/regal/blob/7bf76856cc72a2d72a1834e5e067c64675c7fc8b/internal/lsp/server.go#L390) while TestGetInlayHintsAstTerms is iterating over it.

https://github.com/StyraInc/regal/actions/runs/10875806798/job/30184826633

Coincidentally, both these issues happened on a recent community PR, which underlines the importance of addressing these as they're a bad contributor experience.

This PR also includes, in a second commit https://github.com/StyraInc/regal/pull/1112/commits/554f6120a575d6cdc9043284261a4eb5afdf12d3, an update to rego.QueryRegalBundle to accept a context. See commit message, but there appears to be a recurring issue here where tests timeout.

* https://github.com/StyraInc/regal/actions/runs/10883075294/job/30195419440?pr=1110
* https://github.com/StyraInc/regal/actions/runs/10883075932/job/30195421353

IO have updated the function an callers to pass a context to this function to allow us to better understand this issue.