### PR TITLE
Allow `regal lint -` to lint from stdin

### DIFF
--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -11,7 +11,9 @@ docs["resolve_url"](url, category) := replace(
 
 merged_config := data.internal.combined_config
 
-capabilities := merged_config.capabilities
+capabilities := object.union(merged_config.capabilities, {"special": special})
+
+special contains "no_filename" if input.regal.file.name == "stdin"
 
 default for_rule(_, _) := {"level": "error"}
 

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
@@ -8,6 +8,12 @@ import data.regal.ast
 import data.regal.config
 import data.regal.result
 
+# METADATA
+# description: disabled when filename is unknown
+# custom:
+#   severity: warn
+notices contains result.notice(rego.metadata.chain()) if "no_filename" in config.capabilities.special
+
 report contains violation if {
 	# get the last n components from file path, where n == count(_pkg_path_values)
 	file_path_length_matched := array.slice(

--- a/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix.rego
+++ b/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix.rego
@@ -5,7 +5,14 @@ package regal.rules.testing["file-missing-test-suffix"]
 import rego.v1
 
 import data.regal.ast
+import data.regal.config
 import data.regal.result
+
+# METADATA
+# description: disabled when filename is unknown
+# custom:
+#   severity: warn
+notices contains result.notice(rego.metadata.chain()) if "no_filename" in config.capabilities.special
 
 report contains violation if {
 	count(ast.tests) > 0

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -64,3 +64,11 @@ to_set(x) := x if is_set(x)
 to_set(x) := {y | some y in x} if not is_set(x)
 
 intersects(s1, s2) if count(intersection({s1, s2})) > 0
+
+# METADATA
+# description: returns the item contained in a single-item set
+single_set_item(s) := item if {
+	count(s) == 1
+
+	some item in s
+}

--- a/pkg/config/filter.go
+++ b/pkg/config/filter.go
@@ -15,6 +15,11 @@ import (
 )
 
 func FilterIgnoredPaths(paths, ignore []string, checkFileExists bool, rootDir string) ([]string, error) {
+	// - special case for stdin, return as is
+	if len(paths) == 1 && paths[0] == "-" {
+		return paths, nil
+	}
+
 	// if set, rootDir is normalized to end with a platform appropriate separator
 	if rootDir != "" && !strings.HasSuffix(rootDir, string(filepath.Separator)) {
 		rootDir += string(filepath.Separator)


### PR DESCRIPTION
And print notices for rules ignored as a result of no filename being known.

```
➜ cat lab/p.rego | go run main.go lint -
1 file linted. No violations found. 2 rules skipped:
- directory-package-mismatch: disabled when filename is unknown
- file-missing-test-suffix: disabled when filename is unknown
```

Fixes #1118

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->