### PR TITLE
fixer: add --on-conflict flag to support renaming

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -1011,6 +1011,116 @@ Cannot move multiple files to: bar/bar.rego
 	}
 }
 
+func TestFixWithConflictRenaming(t *testing.T) {
+	t.Parallel()
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	td := t.TempDir()
+
+	initialState := map[string]string{
+		".regal/config.yaml": "", // needed to find the root in the right place
+		// this file is in the correct location
+		"foo/foo.rego": `package foo
+
+import rego.v1
+`,
+		// this file is in the correct location
+		"foo/foo_test.rego": `package foo_test
+
+import rego.v1
+`,
+		// this file should be at foo/foo.rego, but that file already exists
+		"quz/foo.rego": `package foo
+
+import rego.v1
+`,
+		// this file should be at foo/foo_test.rego, but that file already exists
+		"quz/foo_test.rego": `package foo_test
+
+import rego.v1
+`,
+		// this file should be at bar/bar.rego and is not a conflict
+		"foo/bar.rego": `package bar
+
+import rego.v1
+`,
+	}
+
+	for file, content := range initialState {
+		mustWriteToFile(t, filepath.Join(td, file), string(content))
+	}
+
+	// --force is required to make the changes when there is no git repo
+	// --conflict=rename will rename inbound files when there is a conflict
+	err := regal(&stdout, &stderr)("fix", "--force", "--on-conflict=rename", td)
+
+	// 0 exit status is expected as all violations should have been fixed
+	expectExitCode(t, err, 0, &stdout, &stderr)
+
+	expStdout := fmt.Sprintf(`3 fixes applied:
+In project root: %[1]s
+foo/bar.rego -> bar/bar.rego:
+- directory-package-mismatch
+quz/foo.rego -> foo/foo_1.rego:
+- directory-package-mismatch
+quz/foo_test.rego -> foo/foo_1_test.rego:
+- directory-package-mismatch
+`, td)
+
+	if act := stdout.String(); expStdout != act {
+		t.Errorf("expected stdout:\n%s\ngot\n%s", expStdout, act)
+	}
+
+	expectedState := map[string]string{
+		".regal/config.yaml": "", // needed to find the root in the right place
+		// unchanged
+		"foo/foo.rego": `package foo
+
+import rego.v1
+`,
+		// renamed to permit its new location
+		"foo/foo_1.rego": `package foo
+
+import rego.v1
+`,
+		// renamed to permit its new location
+		"foo/foo_1_test.rego": `package foo_test
+
+import rego.v1
+`,
+		// unchanged
+		"bar/bar.rego": `package bar
+
+import rego.v1
+`,
+	}
+
+	for file, expectedContent := range expectedState {
+		bs, err := os.ReadFile(filepath.Join(td, file))
+		if err != nil {
+			t.Errorf("failed to read %s: %v", file, err)
+
+			continue
+		}
+
+		if act := string(bs); expectedContent != act {
+			t.Errorf("expected %s contents:\n%s\ngot\n%s", file, expectedContent, act)
+		}
+	}
+
+	expectedMissing := []string{
+		"quz/foo.rego",
+		"quz/foo_test.rego",
+	}
+
+	for _, file := range expectedMissing {
+		if _, err := os.Stat(filepath.Join(td, file)); err == nil {
+			t.Errorf("expected %s to have been removed", file)
+		}
+	}
+}
+
 // verify fix for https://github.com/StyraInc/regal/issues/1082
 func TestLintAnnotationCustomAttributeMultipleItems(t *testing.T) {
 	t.Parallel()

--- a/pkg/fixer/rename.go
+++ b/pkg/fixer/rename.go
@@ -1,0 +1,44 @@
+package fixer
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// renameCandidate takes a filename and produces a new name with an incremented
+// numeric suffix. It correctly handles test files by inserting the increment
+// before the "_test" suffix and preserves the original directory.
+func renameCandidate(oldName string) string {
+	dir := filepath.Dir(oldName)
+	baseWithExt := filepath.Base(oldName)
+
+	ext := filepath.Ext(baseWithExt)
+	base := strings.TrimSuffix(baseWithExt, ext)
+
+	suffix := ""
+	if strings.HasSuffix(base, "_test") {
+		suffix = "_test"
+		base = strings.TrimSuffix(base, "_test")
+	}
+
+	re := regexp.MustCompile(`^(.*)_(\d+)$`)
+	matches := re.FindStringSubmatch(base)
+
+	if len(matches) == 3 {
+		baseName := matches[1]
+		numStr := matches[2]
+		num, _ := strconv.Atoi(numStr)
+		num++
+		base = fmt.Sprintf("%s_%d", baseName, num)
+	} else {
+		base += "_1"
+	}
+
+	newBase := base + suffix + ext
+	newName := filepath.Join(dir, newBase)
+
+	return newName
+}

--- a/pkg/fixer/rename_test.go
+++ b/pkg/fixer/rename_test.go
@@ -1,0 +1,56 @@
+package fixer
+
+import "testing"
+
+func TestRenameCandidate(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		oldName  string
+		expected string
+	}{
+		"rename a policy file": {
+			oldName:  "policy.rego",
+			expected: "policy_1.rego",
+		},
+		"rename a policy file with existing increment": {
+			oldName:  "policy_999.rego",
+			expected: "policy_1000.rego",
+		},
+		"rename a policy file with existing increment and a number in the filename": {
+			oldName:  "policy_123_999.rego",
+			expected: "policy_123_1000.rego",
+		},
+		"rename a policy file in a dir": {
+			oldName:  "/foo/policy.rego",
+			expected: "/foo/policy_1.rego",
+		},
+		"rename a test file": {
+			oldName:  "policy_test.rego",
+			expected: "policy_1_test.rego",
+		},
+		"rename a test file with existing increment": {
+			oldName:  "policy_999_test.rego",
+			expected: "policy_1000_test.rego",
+		},
+		"rename a test file with existing increment and a number in the filename": {
+			oldName:  "/foo/policy_123_999_test.rego",
+			expected: "/foo/policy_123_1000_test.rego",
+		},
+		"rename a test file in a dir": {
+			oldName:  "/foo/policy_test.rego",
+			expected: "/foo/policy_1_test.rego",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := renameCandidate(tc.oldName)
+			if actual != tc.expected {
+				t.Errorf("expected %s, got %s", tc.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a new flag to the fix command, `--on-conflict`. This flag can be used to specify the behavior of the fix command when a file's new name conflicts with an existing file or another file's fixed name.

Setting --on-conflict to "rename" will cause the fix command to rename the file to a different name at the target location. The new name will be generated by appending a number to the end of the file name.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->