### PR TITLE
tests: Remove global builtins state

### DIFF
--- a/internal/ast/rule.go
+++ b/internal/ast/rule.go
@@ -5,14 +5,12 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
-
-	"github.com/styrainc/regal/internal/lsp/rego"
 )
 
 // GetRuleDetail returns a short descriptive string value for a given rule stating
 // if the rule is constant, multi-value, single-value etc and the type of the rule's
 // value if known.
-func GetRuleDetail(rule *ast.Rule) string {
+func GetRuleDetail(rule *ast.Rule, builtins map[string]*ast.Builtin) string {
 	if rule.Head.Args != nil {
 		return "function" + rule.Head.Args.String()
 	}
@@ -53,9 +51,7 @@ func GetRuleDetail(rule *ast.Rule) string {
 	case ast.Call:
 		name := v[0].String()
 
-		bis := rego.GetBuiltins()
-
-		if builtin, ok := bis[name]; ok {
+		if builtin, ok := builtins[name]; ok {
 			retType := builtin.Decl.NamedResult().String()
 
 			detail += fmt.Sprintf(" (%s)", simplifyType(retType))

--- a/internal/ast/rule_test.go
+++ b/internal/ast/rule_test.go
@@ -3,6 +3,9 @@ package ast
 import (
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/parse"
 )
 
@@ -47,7 +50,9 @@ func TestGetRuleDetail(t *testing.T) {
 
 			rule := mod.Rules[0]
 
-			result := GetRuleDetail(rule)
+			bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+
+			result := GetRuleDetail(rule, bis)
 			if result != tc.expected {
 				t.Errorf("Expected %s, got %s", tc.expected, result)
 			}

--- a/internal/lsp/completions/providers/builtins.go
+++ b/internal/lsp/completions/providers/builtins.go
@@ -2,11 +2,11 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/hover"
-	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/lsp/types/completion"
 )
@@ -21,8 +21,12 @@ func (*BuiltIns) Run(
 	_ context.Context,
 	c *cache.Cache,
 	params types.CompletionParams,
-	_ *Options,
+	opts *Options,
 ) ([]types.CompletionItem, error) {
+	if opts == nil {
+		return nil, errors.New("builtins provider requires options")
+	}
+
 	fileURI := params.TextDocument.URI
 
 	lines, currentLine := completionLineHelper(c, fileURI, params.Position.Line)
@@ -45,9 +49,7 @@ func (*BuiltIns) Run(
 
 	items := []types.CompletionItem{}
 
-	bis := rego.GetBuiltins()
-
-	for _, builtIn := range bis {
+	for _, builtIn := range opts.Builtins {
 		key := builtIn.Name
 
 		if builtIn.Infix != "" {

--- a/internal/lsp/completions/providers/builtins_test.go
+++ b/internal/lsp/completions/providers/builtins_test.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+
 	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/lsp/types"
 )
 
@@ -33,7 +36,9 @@ allow if c`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -68,7 +73,9 @@ allow := c`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -105,7 +112,9 @@ allow if {
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -140,7 +149,9 @@ allow if gt`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -173,7 +184,9 @@ allow if c`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -208,7 +221,9 @@ default allow := f`
 		},
 	}
 
-	completions, err := p.Run(context.Background(), c, completionParams, nil)
+	completions, err := p.Run(context.Background(), c, completionParams, &Options{
+		Builtins: rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion()),
+	})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/internal/lsp/completions/providers/options.go
+++ b/internal/lsp/completions/providers/options.go
@@ -1,10 +1,15 @@
 package providers
 
 import (
+	"github.com/open-policy-agent/opa/ast"
+
 	"github.com/styrainc/regal/internal/lsp/clients"
 )
 
 type Options struct {
 	ClientIdentifier clients.Identifier
 	RootURI          string
+	// Builtins is a map of built-in functions to their definitions required in
+	// the context of the current completion request.
+	Builtins map[string]*ast.Builtin
 }

--- a/internal/lsp/completions/providers/packagerefs_test.go
+++ b/internal/lsp/completions/providers/packagerefs_test.go
@@ -7,8 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/completions/refs"
+	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/parse"
 )
@@ -42,11 +45,13 @@ import
 
 	c.SetFileContents("file:///bar/file2.rego", fileContents)
 
+	builtins := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+
 	for uri, contents := range regoFiles {
 		mod := parse.MustParseModule(contents)
 		c.SetModule(uri, mod)
 
-		c.SetFileRefs(uri, refs.DefinedInModule(mod))
+		c.SetFileRefs(uri, refs.DefinedInModule(mod, builtins))
 	}
 
 	p := &PackageRefs{}
@@ -116,11 +121,13 @@ import
 
 	c.SetFileContents("file:///file.rego", fileContents)
 
+	builtins := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+
 	for uri, contents := range regoFiles {
 		mod := parse.MustParseModule(contents)
 		c.SetModule(uri, mod)
 
-		c.SetFileRefs(uri, refs.DefinedInModule(mod))
+		c.SetFileRefs(uri, refs.DefinedInModule(mod, builtins))
 	}
 
 	p := &PackageRefs{}

--- a/internal/lsp/completions/providers/rulehead_test.go
+++ b/internal/lsp/completions/providers/rulehead_test.go
@@ -5,8 +5,11 @@ import (
 	"slices"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/completions/refs"
+	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/parse"
 )
@@ -37,6 +40,8 @@ funckyfunc := true
 `,
 	}
 
+	builtins := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+
 	for uri, contents := range regoFiles {
 		mod, err := parse.Module(uri, contents)
 		if err != nil {
@@ -45,7 +50,7 @@ funckyfunc := true
 
 		c.SetFileContents(uri, contents)
 		c.SetModule(uri, mod)
-		c.SetFileRefs(uri, refs.DefinedInModule(mod))
+		c.SetFileRefs(uri, refs.DefinedInModule(mod, builtins))
 	}
 
 	p := &RuleHead{}

--- a/internal/lsp/completions/refs/defined.go
+++ b/internal/lsp/completions/refs/defined.go
@@ -15,7 +15,7 @@ import (
 
 // DefinedInModule returns a map of refs and details about them to be used in completions that
 // were found in the given module.
-func DefinedInModule(module *ast.Module) map[string]types.Ref {
+func DefinedInModule(module *ast.Module, builtins map[string]*ast.Builtin) map[string]types.Ref {
 	modKey := module.Package.Path.String()
 
 	// first, create a reference for the package using the metadata
@@ -92,7 +92,7 @@ func DefinedInModule(module *ast.Module) map[string]types.Ref {
 		items[ruleKey] = types.Ref{
 			Kind:        kind,
 			Label:       ruleKey,
-			Detail:      rast.GetRuleDetail(rs[0]),
+			Detail:      rast.GetRuleDetail(rs[0], builtins),
 			Description: ruleDescription,
 		}
 	}

--- a/internal/lsp/completions/refs/defined_test.go
+++ b/internal/lsp/completions/refs/defined_test.go
@@ -5,6 +5,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/lsp/types"
 	rparse "github.com/styrainc/regal/internal/parse"
 )
@@ -32,7 +35,9 @@ func TestForModule_Package(t *testing.T) {
 package example
 `)
 
-	items := DefinedInModule(mod)
+	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+
+	items := DefinedInModule(mod, bis)
 
 	expectedRefs := map[string]types.Ref{
 		"data.example": {
@@ -121,8 +126,9 @@ deny contains "strings" if true
 
 pi := 3.14
 `)
+	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
 
-	items := DefinedInModule(mod)
+	items := DefinedInModule(mod, bis)
 
 	expectedRefs := map[string]types.Ref{
 		"data.example": {

--- a/internal/lsp/documentsymbol.go
+++ b/internal/lsp/documentsymbol.go
@@ -15,6 +15,7 @@ import (
 func documentSymbols(
 	contents string,
 	module *ast.Module,
+	builtins map[string]*ast.Builtin,
 ) []types.DocumentSymbol {
 	// Only pkgSymbols would likely suffice, but we're keeping docSymbols around in case
 	// we ever want to add more top-level symbols than the package.
@@ -62,7 +63,7 @@ func documentSymbols(
 				SelectionRange: ruleRange,
 			}
 
-			if detail := rast.GetRuleDetail(rule); detail != "" {
+			if detail := rast.GetRuleDetail(rule, builtins); detail != "" {
 				ruleSymbol.Detail = &detail
 			}
 
@@ -88,7 +89,7 @@ func documentSymbols(
 				SelectionRange: groupRange,
 			}
 
-			detail := rast.GetRuleDetail(rules[0])
+			detail := rast.GetRuleDetail(rules[0], builtins)
 			if detail != "" {
 				groupSymbol.Detail = &detail
 			}
@@ -104,7 +105,7 @@ func documentSymbols(
 					SelectionRange: childRange,
 				}
 
-				childDetail := rast.GetRuleDetail(rule)
+				childDetail := rast.GetRuleDetail(rule, builtins)
 				if childDetail != "" {
 					childRule.Detail = &childDetail
 				}

--- a/internal/lsp/documentsymbol_test.go
+++ b/internal/lsp/documentsymbol_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 
+	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/lsp/types/symbols"
 )
@@ -69,7 +70,9 @@ func TestDocumentSymbols(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			syms := documentSymbols(tc.policy, module)
+			bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+
+			syms := documentSymbols(tc.policy, module, bis)
 
 			pkg := syms[0]
 			if pkg.Name != tc.expected.Name {

--- a/internal/lsp/hover/hover.go
+++ b/internal/lsp/hover/hover.go
@@ -135,7 +135,7 @@ func CreateHoverContent(builtin *ast.Builtin) string {
 	return result
 }
 
-func UpdateBuiltinPositions(cache *cache.Cache, uri string) error {
+func UpdateBuiltinPositions(cache *cache.Cache, uri string, builtins map[string]*ast.Builtin) error {
 	module, ok := cache.GetModule(uri)
 	if !ok {
 		return fmt.Errorf("failed to update builtin positions: no parsed module for uri %q", uri)
@@ -143,7 +143,7 @@ func UpdateBuiltinPositions(cache *cache.Cache, uri string) error {
 
 	builtinsOnLine := map[uint][]types2.BuiltinPosition{}
 
-	for _, call := range rego.AllBuiltinCalls(module) {
+	for _, call := range rego.AllBuiltinCalls(module, builtins) {
 		line := uint(call.Location.Row)
 
 		builtinsOnLine[line] = append(builtinsOnLine[line], types2.BuiltinPosition{

--- a/internal/lsp/inlayhint.go
+++ b/internal/lsp/inlayhint.go
@@ -18,10 +18,10 @@ func createInlayTooltip(named *types.NamedType) string {
 	return fmt.Sprintf("%s\n\nType: `%s`", named.Descr, named.Type.String())
 }
 
-func getInlayHints(module *ast.Module) []types2.InlayHint {
+func getInlayHints(module *ast.Module, builtins map[string]*ast.Builtin) []types2.InlayHint {
 	inlayHints := make([]types2.InlayHint, 0)
 
-	for _, call := range rego.AllBuiltinCalls(module) {
+	for _, call := range rego.AllBuiltinCalls(module, builtins) {
 		for i, arg := range call.Builtin.Decl.NamedFuncArgs().Args {
 			if len(call.Args) <= i {
 				// avoid panic if provided a builtin function where the args

--- a/internal/lsp/inlayhint_test.go
+++ b/internal/lsp/inlayhint_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/styrainc/regal/internal/lsp/rego"
 )
 
 // A function call may either be represented as an ast.Call.
@@ -16,7 +18,8 @@ func TestGetInlayHintsAstCall(t *testing.T) {
 
 	module := ast.MustParseModule(policy)
 
-	inlayHints := getInlayHints(module)
+	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+	inlayHints := getInlayHints(module, bis)
 
 	if len(inlayHints) != 2 {
 		t.Fatalf("Expected 2 inlay hints, got %d", len(inlayHints))
@@ -65,7 +68,9 @@ func TestGetInlayHintsAstTerms(t *testing.T) {
 
 	module := ast.MustParseModule(policy)
 
-	inlayHints := getInlayHints(module)
+	bis := rego.BuiltinsForCapabilities(ast.CapabilitiesForThisVersion())
+
+	inlayHints := getInlayHints(module, bis)
 
 	if len(inlayHints) != 1 {
 		t.Fatalf("Expected 1 inlay hints, got %d", len(inlayHints))

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -24,7 +24,13 @@ import (
 // updateParse updates the module cache with the latest parse result for a given URI,
 // if the module cannot be parsed, the parse errors are saved as diagnostics for the
 // URI instead.
-func updateParse(ctx context.Context, cache *cache.Cache, store storage.Store, fileURI string) (bool, error) {
+func updateParse(
+	ctx context.Context,
+	cache *cache.Cache,
+	store storage.Store,
+	fileURI string,
+	builtins map[string]*ast.Builtin,
+) (bool, error) {
 	content, ok := cache.GetFileContents(fileURI)
 	if !ok {
 		return false, fmt.Errorf("failed to get file contents for uri %q", fileURI)
@@ -44,7 +50,7 @@ func updateParse(ctx context.Context, cache *cache.Cache, store storage.Store, f
 			return false, fmt.Errorf("failed to update rego store with parsed module: %w", err)
 		}
 
-		definedRefs := refs.DefinedInModule(module)
+		definedRefs := refs.DefinedInModule(module, builtins)
 
 		cache.SetFileRefs(fileURI, definedRefs)
 

--- a/internal/lsp/rego/builtins.go
+++ b/internal/lsp/rego/builtins.go
@@ -1,35 +1,15 @@
 package rego
 
 import (
-	"maps"
 	"strings"
-	"sync"
 
 	"github.com/open-policy-agent/opa/ast"
 )
 
-var (
-	builtInsLock = &sync.RWMutex{}                              //nolint:gochecknoglobals
-	builtIns     = builtinMap(ast.CapabilitiesForThisVersion()) //nolint:gochecknoglobals
-)
-
-// Update updates the builtins database with the provided capabilities.
-func UpdateBuiltins(caps *ast.Capabilities) {
-	builtInsLock.Lock()
-	builtIns = builtinMap(caps)
-	builtInsLock.Unlock()
-}
-
-func GetBuiltins() map[string]*ast.Builtin {
-	builtInsLock.RLock()
-	defer builtInsLock.RUnlock()
-
-	return maps.Clone(builtIns)
-}
-
-func builtinMap(caps *ast.Capabilities) map[string]*ast.Builtin {
+// BuiltinsForCapabilities returns a list of builtins from the provided capabilities.
+func BuiltinsForCapabilities(capabilities *ast.Capabilities) map[string]*ast.Builtin {
 	m := make(map[string]*ast.Builtin)
-	for _, b := range caps.Builtins {
+	for _, b := range capabilities.Builtins {
 		m[b.Name] = b
 	}
 

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -53,10 +53,8 @@ func LocationFromPosition(pos types.Position) *ast.Location {
 
 // AllBuiltinCalls returns all built-in calls in the module, excluding operators
 // and any other function identified by an infix.
-func AllBuiltinCalls(module *ast.Module) []BuiltInCall {
+func AllBuiltinCalls(module *ast.Module, builtins map[string]*ast.Builtin) []BuiltInCall {
 	builtinCalls := make([]BuiltInCall, 0)
-
-	bis := GetBuiltins()
 
 	callVisitor := ast.NewGenericVisitor(func(x interface{}) bool {
 		var terms []*ast.Term
@@ -76,7 +74,7 @@ func AllBuiltinCalls(module *ast.Module) []BuiltInCall {
 			return false
 		}
 
-		if b, ok := bis[terms[0].Value.String()]; ok {
+		if b, ok := builtins[terms[0].Value.String()]; ok {
 			// Exclude operators and similar builtins
 			if b.Infix != "" {
 				return false


### PR DESCRIPTION
Built ins must now be provided by the caller.

We have been having a number of issues with race conditions in tests where the shared list of builtins was required to be in a different state in different tests. Namely, the single file language server test that updated the config to use a different caps list, and inlay hints which was also based on this data.

After some consideration, it appears to make sense that the built ins, being related to the loaded caps, should be provided when required, rather than being fetched from the global state. This means that the code requiring builtins can continue to operate while needing know knowledge of what the builtins list should be, as that is now a concern of the caller.

I have added field on the server to store the state of builtins for different caps versions which we can use to pass down a list of builtins from when needed in the various server functions.

Related
https://github.com/StyraInc/regal/pull/1101
https://github.com/StyraInc/regal/pull/1102
https://github.com/StyraInc/regal/pull/1112
https://github.com/StyraInc/regal/pull/1121
https://github.com/StyraInc/regal/pull/1129

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->