### PR TITLE
bundle: Load bundle once

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -2,6 +2,11 @@ package bundle
 
 import (
 	"embed"
+	"sync"
+
+	"github.com/open-policy-agent/opa/bundle"
+
+	rio "github.com/styrainc/regal/internal/io"
 )
 
 // Bundle FS will include the tests as well, but since that has negligible impact on the size of the binary,
@@ -9,3 +14,18 @@ import (
 //
 //go:embed *
 var Bundle embed.FS
+
+//nolint:gochecknoglobals
+var (
+	loadedBundle     bundle.Bundle
+	loadedBundleOnce sync.Once
+)
+
+// LoadedBundle returns the loaded Regal bundle for this version of Regal.
+func LoadedBundle() *bundle.Bundle {
+	loadedBundleOnce.Do(func() {
+		loadedBundle = rio.MustLoadRegalBundleFS(Bundle)
+	})
+
+	return &loadedBundle
+}

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -2,9 +2,6 @@ package bundle
 
 import (
 	"embed"
-	"sync"
-
-	"github.com/open-policy-agent/opa/bundle"
 
 	rio "github.com/styrainc/regal/internal/io"
 )
@@ -15,17 +12,7 @@ import (
 //go:embed *
 var Bundle embed.FS
 
+// LoadedBundle contains the loaded contents of the Bundle.
+//
 //nolint:gochecknoglobals
-var (
-	loadedBundle     bundle.Bundle
-	loadedBundleOnce sync.Once
-)
-
-// LoadedBundle returns the loaded Regal bundle for this version of Regal.
-func LoadedBundle() *bundle.Bundle {
-	loadedBundleOnce.Do(func() {
-		loadedBundle = rio.MustLoadRegalBundleFS(Bundle)
-	})
-
-	return &loadedBundle
-}
+var LoadedBundle = rio.MustLoadRegalBundleFS(Bundle)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -250,7 +250,7 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 	}
 
 	regal := linter.NewEmptyLinter().
-		WithAddedBundle(rbundle.LoadedBundle()).
+		WithAddedBundle(&rbundle.LoadedBundle).
 		WithDisableAll(params.disableAll).
 		WithDisabledCategories(params.disableCategory.v...).
 		WithDisabledRules(params.disable.v...).
@@ -319,7 +319,7 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 		m.Timer(regalmetrics.RegalConfigParse).Stop()
 	}
 
-	go updateCheckAndWarn(params, rbundle.LoadedBundle(), &userConfig)
+	go updateCheckAndWarn(params, &rbundle.LoadedBundle, &userConfig)
 
 	result, err := regal.Lint(ctx)
 	if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -148,7 +148,7 @@ func opaTest(args []string) int {
 		txn,
 		storage.AddOp,
 		storage.MustParsePath("/regal"),
-		rbundle.LoadedBundle().Data["regal"],
+		rbundle.LoadedBundle.Data["regal"],
 	); err != nil {
 		panic(err)
 	}
@@ -170,7 +170,7 @@ func opaTest(args []string) int {
 		WithEnablePrintStatements(!testParams.benchmark).
 		WithSchemas(compile.RegalSchemaSet()).
 		WithUseTypeCheckAnnotations(true).
-		WithModuleLoader(moduleLoader(rbundle.LoadedBundle())).
+		WithModuleLoader(moduleLoader(&rbundle.LoadedBundle)).
 		WithRewriteTestRules(testParams.varValues)
 
 	if testParams.threshold > 0 && !testParams.coverage {

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	"github.com/open-policy-agent/opa/ast"
-	"github.com/open-policy-agent/opa/bundle"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown"
@@ -27,13 +26,6 @@ import (
 type Policy struct {
 	pq rego.PreparedEvalQuery
 }
-
-//nolint:gochecknoglobals
-var regalRules = func() bundle.Bundle {
-	regalRules := rio.MustLoadRegalBundleFS(rbundle.Bundle)
-
-	return regalRules
-}()
 
 // NewPolicy creates a new Policy provider. This provider is distinctly different from the other providers
 // as it acts like the entrypoint for all Rego-based providers, and not a single provider "function" like
@@ -151,7 +143,7 @@ func prepareRegoArgs(store storage.Store, query ast.Body) []func(*rego.Rego) {
 	return []func(*rego.Rego){
 		rego.Store(store),
 		rego.ParsedQuery(query),
-		rego.ParsedBundle("regal", &regalRules),
+		rego.ParsedBundle("regal", rbundle.LoadedBundle()),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 		rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
 		// TODO: remove later

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -143,7 +143,7 @@ func prepareRegoArgs(store storage.Store, query ast.Body) []func(*rego.Rego) {
 	return []func(*rego.Rego){
 		rego.Store(store),
 		rego.ParsedQuery(query),
-		rego.ParsedBundle("regal", rbundle.LoadedBundle()),
+		rego.ParsedBundle("regal", &rbundle.LoadedBundle),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 		rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
 		// TODO: remove later

--- a/internal/lsp/completions/refs/used.go
+++ b/internal/lsp/completions/refs/used.go
@@ -47,7 +47,7 @@ func initialize() {
 	}
 
 	regoArgs := []func(*rego.Rego){
-		rego.ParsedBundle("regal", rbundle.LoadedBundle()),
+		rego.ParsedBundle("regal", &rbundle.LoadedBundle),
 		rego.ParsedBundle("internal", &dataBundle),
 		rego.Query(`data.regal.lsp.completion.ref_names`),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),

--- a/internal/lsp/completions/refs/used.go
+++ b/internal/lsp/completions/refs/used.go
@@ -32,8 +32,6 @@ var pqInitOnce sync.Once
 // This function is only used by language server code paths and so init() is not
 // used.
 func initialize() {
-	regalRules := rio.MustLoadRegalBundleFS(rbundle.Bundle)
-
 	dataBundle := bundle.Bundle{
 		Manifest: bundle.Manifest{
 			Roots:    &[]string{"internal"},
@@ -49,7 +47,7 @@ func initialize() {
 	}
 
 	regoArgs := []func(*rego.Rego){
-		rego.ParsedBundle("regal", &regalRules),
+		rego.ParsedBundle("regal", rbundle.LoadedBundle()),
 		rego.ParsedBundle("internal", &dataBundle),
 		rego.Query(`data.regal.lsp.completion.ref_names`),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -114,7 +114,7 @@ type policy struct {
 func initialize() {
 	createArgs := func(args ...func(*rego.Rego)) []func(*rego.Rego) {
 		return append([]func(*rego.Rego){
-			rego.ParsedBundle("regal", rbundle.LoadedBundle()),
+			rego.ParsedBundle("regal", &rbundle.LoadedBundle),
 			rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 			rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
 		}, args...)

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -112,11 +112,9 @@ type policy struct {
 }
 
 func initialize() {
-	regalRules := rio.MustLoadRegalBundleFS(rbundle.Bundle)
-
 	createArgs := func(args ...func(*rego.Rego)) []func(*rego.Rego) {
 		return append([]func(*rego.Rego){
-			rego.ParsedBundle("regal", &regalRules),
+			rego.ParsedBundle("regal", rbundle.LoadedBundle()),
 			rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 			rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
 		}, args...)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -24,7 +24,7 @@ import (
 	"github.com/open-policy-agent/opa/format"
 	"github.com/open-policy-agent/opa/storage"
 
-	"github.com/styrainc/regal/bundle"
+	rbundle "github.com/styrainc/regal/bundle"
 	"github.com/styrainc/regal/internal/capabilities"
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/internal/lsp/bundles"
@@ -334,8 +334,6 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 		return
 	}
 
-	regalRules := bundle.LoadedBundle()
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -357,7 +355,7 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 				return
 			}
 
-			mergedConfig, err := config.LoadConfigWithDefaultsFromBundle(regalRules, &userConfig)
+			mergedConfig, err := config.LoadConfigWithDefaultsFromBundle(&rbundle.LoadedBundle, &userConfig)
 			if err != nil {
 				l.logError(fmt.Errorf("failed to load config: %w", err))
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -334,12 +334,7 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 		return
 	}
 
-	regalRules, err := rio.LoadRegalBundleFS(bundle.Bundle)
-	if err != nil {
-		l.logError(fmt.Errorf("failed to load regal bundle for defaulting of user config: %w", err))
-
-		return
-	}
+	regalRules := bundle.LoadedBundle()
 
 	for {
 		select {
@@ -362,7 +357,7 @@ func (l *LanguageServer) StartConfigWorker(ctx context.Context) {
 				return
 			}
 
-			mergedConfig, err := config.LoadConfigWithDefaultsFromBundle(&regalRules, &userConfig)
+			mergedConfig, err := config.LoadConfigWithDefaultsFromBundle(regalRules, &userConfig)
 			if err != nil {
 				l.logError(fmt.Errorf("failed to load config: %w", err))
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -74,7 +74,7 @@ var (
 // NewLinter creates a new Regal linter.
 func NewLinter() Linter {
 	return Linter{
-		ruleBundles: []*bundle.Bundle{rbundle.LoadedBundle()},
+		ruleBundles: []*bundle.Bundle{&rbundle.LoadedBundle},
 	}
 }
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -73,10 +73,8 @@ var (
 
 // NewLinter creates a new Regal linter.
 func NewLinter() Linter {
-	regalRules := rio.MustLoadRegalBundleFS(rbundle.Bundle)
-
 	return Linter{
-		ruleBundles: []*bundle.Bundle{&regalRules},
+		ruleBundles: []*bundle.Bundle{rbundle.LoadedBundle()},
 	}
 }
 
@@ -102,8 +100,8 @@ func (l Linter) WithInputModules(input *rules.Input) Linter {
 }
 
 // WithAddedBundle adds a bundle of rules and data to include in evaluation.
-func (l Linter) WithAddedBundle(b bundle.Bundle) Linter {
-	l.ruleBundles = append(l.ruleBundles, &b)
+func (l Linter) WithAddedBundle(b *bundle.Bundle) Linter {
+	l.ruleBundles = append(l.ruleBundles, b)
 
 	return l
 }


### PR DESCRIPTION
Previously, loading of the bundle happened many times, each time it takes around 20ms. This improves the performance of the language server by loading the bundle once and reusing it since the bundle is never changed once a binary is running.



before

https://github.com/user-attachments/assets/7a23a92c-e489-436d-96c7-e67b9ce9b91d

after

https://github.com/user-attachments/assets/ca1d2c5f-b043-44b0-abd1-aea3a4909ecf
