### PR TITLE
linter: support single file aggregate data collection and parameterised aggregate data in Lint()

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -216,15 +216,18 @@ func (l Linter) WithRootDir(rootDir string) Linter {
 	return l
 }
 
-// WithPopulateAggregates enables the population of aggregate data even when
+// WithAlwaysAggregate enables the population of aggregate data even when
 // linting a single file. This is useful when needing to incrementally build
 // aggregate state from multiple different linting runs.
-func (l Linter) WithPopulateAggregates(enabled bool) Linter {
+func (l Linter) WithAlwaysAggregate(enabled bool) Linter {
 	l.populateAggregates = enabled
 
 	return l
 }
 
+// WithAggregates supplies additional aggregate data to a linter instance.
+// Likely generated in a previous run, and used to provide a global context to
+// a subsequent run of a single file lint.
 func (l Linter) WithAggregates(aggregates map[string][]report.Aggregate) Linter {
 	l.additionalAggregates = aggregates
 

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -611,7 +611,7 @@ import data.foo.bar.unresolved
 		WithDisableAll(true).
 		WithEnabledRules("unresolved-import").
 		WithPrintHook(topdown.NewPrintHook(os.Stderr)).
-		WithPopulateAggregates(true).
+		WithAlwaysAggregate(true).
 		WithInputModules(&input)
 
 	result := testutil.Must(linter.Lint(context.Background()))(t)
@@ -639,7 +639,7 @@ import data.foo.bar.unresolved
 		WithDisableAll(true).
 		WithEnabledRules("unresolved-import").
 		WithPrintHook(topdown.NewPrintHook(os.Stderr)).
-		WithPopulateAggregates(true).
+		WithAlwaysAggregate(true).
 		WithInputModules(&input)
 
 	result1 := testutil.Must(linter.Lint(context.Background()))(t)


### PR DESCRIPTION
This change in intended to be a step to being able to externally store and manage aggregate data from the linter to caching between runs.

This PR only adds the basic functionality for such a feature.

Related https://github.com/StyraInc/regal/issues/1133