### PR TITLE
Fix `detached-metadata` issues

### DIFF
--- a/bundle/regal/rules/style/detached-metadata/detached_metadata.rego
+++ b/bundle/regal/rules/style/detached-metadata/detached_metadata.rego
@@ -9,7 +9,7 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	some block in ast.comments.blocks
+	some i, block in ast.comments.blocks
 
 	startswith(trim_space(block[0].text), "METADATA")
 
@@ -18,8 +18,7 @@ report contains violation if {
 	# no need to +1 the index here as rows start counting from 1
 	trim_space(input.regal.file.lines[last_row]) == ""
 
-	annotation := _annotation_at_row(util.to_location_object(block[0].location).row)
-	annotation.scope != "document"
+	not _allow_detached(last_row, i, ast.comments.blocks, input.regal.file.lines)
 
 	violation := result.fail(rego.metadata.chain(), result.location(block[0]))
 }
@@ -28,4 +27,19 @@ _annotation_at_row(row) := annotation if {
 	some annotation in ast.annotations
 
 	util.to_location_object(annotation.location).row == row
+}
+
+# detached metadata is allowed only if another metadata block follows
+# directly after the metadata block
+_allow_detached(last_row, i, blocks, lines) if {
+	next_block := blocks[i + 1]
+
+	startswith(trim_space(next_block[0].text), "METADATA")
+
+	next_block_row := util.to_location_object(next_block[0].location).row
+	lines_between := array.slice(lines, last_row, next_block_row - 1)
+
+	every line in lines_between {
+		line == ""
+	}
 }

--- a/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
+++ b/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
@@ -61,7 +61,7 @@ allow := true
 	r == set()
 }
 
-test_success_detached_document_scope_ok if {
+test_success_detached_but_more_metadata_on_rule if {
 	r := rule.report with input as ast.with_rego_v1(`
 # METADATA
 # scope: document
@@ -72,6 +72,44 @@ test_success_detached_document_scope_ok if {
 allow := true
 `)
 	r == set()
+}
+
+test_success_detached_but_more_metadata_on_package if {
+	r := rule.report with input as regal.parse_module("p.rego", `
+# METADATA
+# scope: package
+# description: foo
+
+# METADATA
+# title: allow
+# scope: subpackages
+package p
+`)
+	r == set()
+}
+
+test_fail_second_block_detached_first_not_reported if {
+	r := rule.report with input as regal.parse_module("p.rego", `# METADATA
+# scope: package
+# description: foo
+
+# METADATA
+# title: allow
+# scope: subpackages
+
+package p
+`)
+	r == {{
+		"category": "style",
+		"description": "Detached metadata annotation",
+		"level": "error",
+		"location": {"col": 1, "file": "p.rego", "row": 5, "text": "# METADATA"},
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/detached-metadata", "style"),
+		}],
+		"title": "detached-metadata",
+	}}
 }
 
 test_success_not_detached_by_comment_in_different_column if {


### PR DESCRIPTION
Build a more robust system for determining this regardless of scope. Lean in on the OPA parser failing anyway when scope is invalid.

Fixes #1138

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->