### PR TITLE
lsp: Update LSP linting to run incrementally after file change

### DIFF
--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -28,7 +28,7 @@ func init() {
 				ErrorLog: os.Stderr,
 			}
 
-			ls := lsp.NewLanguageServer(opts)
+			ls := lsp.NewLanguageServer(ctx, opts)
 
 			conn := lsp.NewConnectionFromLanguageServer(ctx, ls.Handle, &lsp.ConnectionOptions{
 				LoggingConfig: lsp.ConnectionLoggingConfig{

--- a/docs/rules/imports/prefer-package-imports.md
+++ b/docs/rules/imports/prefer-package-imports.md
@@ -15,7 +15,7 @@ import rego.v1
 # Rule imported directly
 import data.users.first_names
 
-has_waldo {
+has_waldo if {
     # Not obvious where "first_names" comes from
     "Waldo" in first_names
 }
@@ -30,7 +30,7 @@ import rego.v1
 # Package imported rather than rule
 import data.users
 
-has_waldo {
+has_waldo if {
     # Obvious where "first_names" comes from
     "Waldo" in users.first_names
 }

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -89,6 +90,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240820151423-278611b39280 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/internal/lsp/cache/cache_test.go
+++ b/internal/lsp/cache/cache_test.go
@@ -1,0 +1,128 @@
+package cache
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/styrainc/regal/pkg/report"
+)
+
+func TestManageAggregates(t *testing.T) {
+	t.Parallel()
+
+	reportAggregatesFile1 := map[string][]report.Aggregate{
+		"my-rule-name": {
+			{
+				"aggregate_data": map[string]any{
+					"foo": "bar",
+				},
+				"aggregate_source": map[string]any{
+					"file":         "file1.rego",
+					"package_path": []string{"p"},
+				},
+				"rule": map[string]any{
+					"category": "my-rule-category",
+					"title":    "my-rule-name",
+				},
+			},
+			{
+				"aggregate_data": map[string]any{
+					"more": "things",
+				},
+				"aggregate_source": map[string]any{
+					"file":         "file1.rego",
+					"package_path": []string{"p"},
+				},
+				"rule": map[string]any{
+					"category": "my-rule-category",
+					"title":    "my-rule-name",
+				},
+			},
+		},
+	}
+
+	reportAggregatesFile2 := map[string][]report.Aggregate{
+		"my-rule-name": {
+			{
+				"aggregate_data": map[string]any{
+					"foo": "baz",
+				},
+				"aggregate_source": map[string]any{
+					"file":         "file2.rego",
+					"package_path": []string{"p"},
+				},
+				"rule": map[string]any{
+					"category": "my-rule-category",
+					"title":    "my-rule-name",
+				},
+			},
+		},
+		"my-other-rule-name": {
+			{
+				"aggregate_data": map[string]any{
+					"foo": "bax",
+				},
+				"aggregate_source": map[string]any{
+					"file":         "file2.rego",
+					"package_path": []string{"p"},
+				},
+				"rule": map[string]any{
+					"category": "my-other-rule-category",
+					"title":    "my-other-rule-name",
+				},
+			},
+		},
+	}
+
+	c := NewCache()
+
+	c.SetFileAggregates("file1.rego", reportAggregatesFile1)
+	c.SetFileAggregates("file2.rego", reportAggregatesFile2)
+
+	aggs1 := c.GetFileAggregates("file1.rego")
+	if len(aggs1) != 1 { // there is one cat/rule for file1
+		t.Fatalf("unexpected number of aggregates for file1.rego: %d", len(aggs1))
+	}
+
+	aggs2 := c.GetFileAggregates("file2.rego")
+	if len(aggs2) != 2 {
+		t.Fatalf("unexpected number of aggregates for file2.rego: %d", len(aggs2))
+	}
+
+	file1ComplimentAggs := c.GetFileComplimentAggregates("file1.rego")
+
+	if !reflect.DeepEqual(file1ComplimentAggs, aggs2) {
+		t.Fatalf("unexpected compliment aggregates for file1.rego, exp\n%v\ngot\n%v", aggs2, file1ComplimentAggs)
+	}
+
+	allAggs := c.GetFileAggregates()
+
+	if len(allAggs) != 2 {
+		t.Fatalf("unexpected number of aggregates: %d", len(allAggs))
+	}
+
+	if _, ok := allAggs["my-other-rule-category/my-other-rule-name"]; !ok {
+		t.Fatalf("missing aggregate my-other-rule-name")
+	}
+
+	c.SetAggregates(reportAggregatesFile1) // update aggregates to only contain file1.rego's aggregates
+
+	allAggs = c.GetFileAggregates()
+
+	if len(allAggs) != 1 {
+		t.Fatalf("unexpected number of aggregates: %d", len(allAggs))
+	}
+
+	if _, ok := allAggs["my-rule-category/my-rule-name"]; !ok {
+		t.Fatalf("missing aggregate my-rule-name")
+	}
+
+	// remove file1 from the cache
+	c.Delete("file1.rego")
+
+	allAggs = c.GetFileAggregates()
+
+	if len(allAggs) != 0 {
+		t.Fatalf("unexpected number of aggregates: %d", len(allAggs))
+	}
+}

--- a/internal/lsp/completions/manager.go
+++ b/internal/lsp/completions/manager.go
@@ -29,7 +29,7 @@ func NewManager(c *cache.Cache, opts *ManagerOptions) *Manager {
 	return &Manager{c: c, opts: opts}
 }
 
-func NewDefaultManager(c *cache.Cache, store storage.Store) *Manager {
+func NewDefaultManager(ctx context.Context, c *cache.Cache, store storage.Store) *Manager {
 	m := NewManager(c, &ManagerOptions{})
 
 	m.RegisterProvider(&providers.BuiltIns{})
@@ -38,7 +38,7 @@ func NewDefaultManager(c *cache.Cache, store storage.Store) *Manager {
 	m.RegisterProvider(&providers.RuleHeadKeyword{})
 	m.RegisterProvider(&providers.Input{})
 
-	m.RegisterProvider(providers.NewPolicy(store))
+	m.RegisterProvider(providers.NewPolicy(ctx, store))
 
 	return m
 }

--- a/internal/lsp/completions/providers/policy_test.go
+++ b/internal/lsp/completions/providers/policy_test.go
@@ -47,7 +47,7 @@ allow if {
 		},
 	}, inmem.OptRoundTripOnWrite(false))
 
-	locals := NewPolicy(store)
+	locals := NewPolicy(context.Background(), store)
 
 	params := types.CompletionParams{
 		TextDocument: types.TextDocumentIdentifier{
@@ -109,7 +109,7 @@ import data.example
 		},
 	})
 
-	locals := NewPolicy(store)
+	locals := NewPolicy(context.Background(), store)
 	fileEdited := `package example2
 
 import rego.v1

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -14,7 +14,7 @@ import (
 func TestEvalWorkspacePath(t *testing.T) {
 	t.Parallel()
 
-	ls := NewLanguageServer(&LanguageServerOptions{ErrorLog: os.Stderr})
+	ls := NewLanguageServer(context.Background(), &LanguageServerOptions{ErrorLog: os.Stderr})
 
 	policy1 := `package policy1
 

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -148,25 +148,28 @@ func updateFileDiagnostics(
 	ctx context.Context,
 	cache *cache.Cache,
 	regalConfig *config.Config,
-	uri string,
-	rootDir string,
+	fileURI string,
+	workspaceRootURI string,
 ) error {
-	module, ok := cache.GetModule(uri)
+	module, ok := cache.GetModule(fileURI)
 	if !ok {
 		// then there must have been a parse error
 		return nil
 	}
 
-	contents, ok := cache.GetFileContents(uri)
+	contents, ok := cache.GetFileContents(fileURI)
 	if !ok {
-		return fmt.Errorf("failed to get file contents for uri %q", uri)
+		return fmt.Errorf("failed to get file contents for uri %q", fileURI)
 	}
 
-	input := rules.NewInput(map[string]string{uri: contents}, map[string]*ast.Module{uri: module})
+	input := rules.NewInput(map[string]string{fileURI: contents}, map[string]*ast.Module{fileURI: module})
 
 	regalInstance := linter.NewLinter().
+		WithAggregates(cache.GetFileComplimentAggregates(fileURI)).
+		WithAlwaysAggregate(true).
+		WithExportAggregates(true).
 		WithInputModules(&input).
-		WithRootDir(rootDir)
+		WithRootDir(workspaceRootURI)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)
@@ -177,33 +180,29 @@ func updateFileDiagnostics(
 		return fmt.Errorf("failed to lint: %w", err)
 	}
 
-	diags := make([]types.Diagnostic, 0)
+	fileDiags := convertReportToDiagnostics(&rpt, workspaceRootURI)
 
-	for _, item := range rpt.Violations {
-		// here errors are presented as warnings, and warnings as info
-		// to differentiate from parse errors
-		severity := uint(2)
-		if item.Level == "warning" {
-			severity = 3
+	files := cache.GetAllFiles()
+
+	for uri := range files {
+		// if a file has parse errors, continue to show these until they're addressed
+		parseErrs, ok := cache.GetParseErrors(uri)
+		if ok && len(parseErrs) > 0 {
+			continue
 		}
 
-		diags = append(diags, types.Diagnostic{
-			Severity: severity,
-			Range:    getRangeForViolation(item),
-			Message:  item.Description,
-			Source:   "regal/" + item.Category,
-			Code:     item.Title,
-			CodeDescription: &types.CodeDescription{
-				Href: fmt.Sprintf(
-					"https://docs.styra.com/regal/rules/%s/%s",
-					item.Category,
-					item.Title,
-				),
-			},
-		})
+		// For updateFileDiagnostics, we only update the file in question.
+		if uri == fileURI {
+			fd, ok := fileDiags[uri]
+			if !ok {
+				fd = []types.Diagnostic{}
+			}
+
+			cache.SetFileDiagnostics(uri, fd)
+		}
 	}
 
-	cache.SetFileDiagnostics(uri, diags)
+	cache.SetFileAggregates(fileURI, rpt.Aggregates)
 
 	return nil
 }
@@ -212,14 +211,19 @@ func updateAllDiagnostics(
 	ctx context.Context,
 	cache *cache.Cache,
 	regalConfig *config.Config,
-	detachedURI string,
+	workspaceRootURI string,
+	overwriteAggregates bool,
 ) error {
 	modules := cache.GetAllModules()
 	files := cache.GetAllFiles()
 
 	input := rules.NewInput(files, modules)
 
-	regalInstance := linter.NewLinter().WithInputModules(&input).WithRootDir(detachedURI)
+	regalInstance := linter.NewLinter().
+		WithInputModules(&input).
+		WithRootDir(workspaceRootURI).
+		// aggregates need only be exported if they're to be used to overwrite.
+		WithExportAggregates(overwriteAggregates)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)
@@ -230,7 +234,35 @@ func updateAllDiagnostics(
 		return fmt.Errorf("failed to lint: %w", err)
 	}
 
-	aggDiags := make(map[string][]types.Diagnostic)
+	fileDiags := convertReportToDiagnostics(&rpt, workspaceRootURI)
+
+	// Update diagnostics for all files
+	for uri := range files {
+		parseErrs, ok := cache.GetParseErrors(uri)
+		if ok && len(parseErrs) > 0 {
+			continue
+		}
+
+		fd, ok := fileDiags[uri]
+		if !ok {
+			fd = []types.Diagnostic{}
+		}
+
+		cache.SetFileDiagnostics(uri, fd)
+	}
+
+	if overwriteAggregates {
+		// clear all aggregates, and use these ones
+		cache.SetAggregates(rpt.Aggregates)
+	}
+
+	return nil
+}
+
+func convertReportToDiagnostics(
+	rpt *report.Report,
+	workspaceRootURI string,
+) map[string][]types.Diagnostic {
 	fileDiags := make(map[string][]types.Diagnostic)
 
 	for _, item := range rpt.Violations {
@@ -256,53 +288,14 @@ func updateAllDiagnostics(
 			},
 		}
 
-		// TODO(charlieegan3): it'd be nice to be able to only run aggregate rules in some cases, but for now, we
-		// can just run all rules each time.
-		if item.IsAggregate {
-			if item.Location.File == "" {
-				aggDiags[detachedURI] = append(aggDiags[detachedURI], diag)
-			} else {
-				aggDiags[item.Location.File] = append(aggDiags[item.Location.File], diag)
-			}
+		if item.Location.File == "" {
+			fileDiags[workspaceRootURI] = append(fileDiags[workspaceRootURI], diag)
 		} else {
 			fileDiags[item.Location.File] = append(fileDiags[item.Location.File], diag)
 		}
 	}
 
-	// this lint contains authoritative information about all files
-	// all diagnostics are cleared and replaced with the new lint
-	for uri := range files {
-		// if a file has parse errors, then we continue to show these until they're addressed
-		// as if there are lint results they must be based on an old, parsed version of the file
-		parseErrs, ok := cache.GetParseErrors(uri)
-		if ok && len(parseErrs) > 0 {
-			continue
-		}
-
-		ad, ok := aggDiags[uri]
-		if !ok {
-			ad = []types.Diagnostic{}
-		}
-
-		cache.SetAggregateDiagnostics(uri, ad)
-
-		fd, ok := fileDiags[uri]
-		if !ok {
-			fd = []types.Diagnostic{}
-		}
-
-		cache.SetFileDiagnostics(uri, fd)
-	}
-
-	// handle the diagnostics for the workspace, under the detachedURI
-	ad, ok := aggDiags[detachedURI]
-	if !ok {
-		ad = []types.Diagnostic{}
-	}
-
-	cache.SetAggregateDiagnostics(detachedURI, ad)
-
-	return nil
+	return fileDiags
 }
 
 // astError is copied from OPA but drop details as I (charlieegan3) had issues unmarshalling the field.

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -1,0 +1,67 @@
+package lsp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/pkg/report"
+)
+
+func TestConvertReportToDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	violation1 := report.Violation{
+		Level:       "error",
+		Description: "Mock Error",
+		Category:    "mock_category",
+		Title:       "mock_title",
+		Location:    report.Location{File: "file1"},
+		IsAggregate: false,
+	}
+	violation2 := report.Violation{
+		Level:       "warning",
+		Description: "Mock Warning",
+		Category:    "mock_category",
+		Title:       "mock_title",
+		Location:    report.Location{File: ""},
+		IsAggregate: true,
+	}
+
+	rpt := &report.Report{
+		Violations: []report.Violation{violation1, violation2},
+	}
+
+	expectedFileDiags := map[string][]types.Diagnostic{
+		"file1": {
+			{
+				Severity: 2,
+				Range:    getRangeForViolation(violation1),
+				Message:  "Mock Error",
+				Source:   "regal/mock_category",
+				Code:     "mock_title",
+				CodeDescription: &types.CodeDescription{
+					Href: "https://docs.styra.com/regal/rules/mock_category/mock_title",
+				},
+			},
+		},
+		"workspaceRootURI": {
+			{
+				Severity: 3,
+				Range:    getRangeForViolation(violation2),
+				Message:  "Mock Warning",
+				Source:   "regal/mock_category",
+				Code:     "mock_title",
+				CodeDescription: &types.CodeDescription{
+					Href: "https://docs.styra.com/regal/rules/mock_category/mock_title",
+				},
+			},
+		},
+	}
+
+	fileDiags := convertReportToDiagnostics(rpt, "workspaceRootURI")
+
+	if !reflect.DeepEqual(fileDiags, expectedFileDiags) {
+		t.Errorf("Expected file diagnostics: %v, got: %v", expectedFileDiags, fileDiags)
+	}
+}

--- a/internal/lsp/race_off.go
+++ b/internal/lsp/race_off.go
@@ -1,0 +1,8 @@
+//go:build !race
+// +build !race
+
+package lsp
+
+func isRaceEnabled() bool {
+	return false
+}

--- a/internal/lsp/race_on.go
+++ b/internal/lsp/race_on.go
@@ -1,0 +1,8 @@
+//go:build race
+// +build race
+
+package lsp
+
+func isRaceEnabled() bool {
+	return true
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -250,7 +250,6 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case job := <-l.lintFileJobs:
-				fmt.Fprintln(l.errorLog, "file job", filepath.Base(job.URI), job.Reason)
 				bis := l.builtinsForCurrentCapabilities()
 
 				// updateParse will not return an error when the parsing failed,
@@ -363,8 +362,6 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 				if len(l.cache.GetAllFiles()) == 0 {
 					continue
 				}
-
-				fmt.Fprintln(l.errorLog, "workspace job", job.Reason)
 
 				targetRules := l.getEnabledAggregateRules()
 				if !job.AggregateReportOnly {

--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -1,0 +1,508 @@
+package lsp
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anderseknert/roast/pkg/encoding"
+	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/util"
+	"github.com/styrainc/regal/pkg/report"
+)
+
+func TestLanguageServerLintsUsingAggregateState(t *testing.T) {
+	t.Parallel()
+
+	messages := make(map[string]chan []string)
+
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		if req.Method != "textDocument/publishDiagnostics" {
+			t.Log("unexpected request method:", req.Method)
+
+			return struct{}{}, nil
+		}
+
+		var requestData types.FileDiagnostics
+
+		err = encoding.JSON().Unmarshal(*req.Params, &requestData)
+		if err != nil {
+			t.Fatalf("failed to unmarshal diagnostics: %s", err)
+		}
+
+		violations := make([]string, len(requestData.Items))
+		for i, item := range requestData.Items {
+			violations[i] = item.Code
+		}
+
+		slices.Sort(violations)
+
+		messages[filepath.Base(requestData.URI)] <- violations
+
+		return struct{}{}, nil
+	}
+
+	files := map[string]string{
+		"foo.rego": `package foo
+
+import rego.v1
+
+import data.bar
+import data.baz
+`,
+		"bar.rego": `package bar
+
+import rego.v1
+`,
+		"baz.rego": `package baz
+
+import rego.v1
+`,
+		".regal/config.yaml": ``,
+	}
+
+	for _, file := range util.Keys(files) {
+		messages[file] = make(chan []string, 10)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tempDir := t.TempDir()
+
+	_, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	if err != nil {
+		t.Fatalf("failed to create and init language server: %s", err)
+	}
+
+	timeout := time.NewTimer(defaultTimeout)
+	defer timeout.Stop()
+
+	// no unresolved-imports at this stage
+	for {
+		var success bool
+		select {
+		case violations := <-messages["foo.rego"]:
+			if slices.Contains(violations, "unresolved-import") {
+				t.Logf("waiting for violations to not contain unresolved-import")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for expected foo.rego diagnostics")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: fileURIScheme + filepath.Join(tempDir, "bar.rego"),
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package qux
+
+import rego.v1
+`,
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// unresolved-imports is now expected
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["foo.rego"]:
+			if !slices.Contains(violations, "unresolved-import") {
+				t.Log("waiting for violations to contain unresolved-import")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for expected foo.rego diagnostics")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: fileURIScheme + filepath.Join(tempDir, "foo.rego"),
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package foo
+
+import rego.v1
+
+import data.baz
+import data.qux # new name for bar.rego package
+`,
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// unresolved-imports is again not expected
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["foo.rego"]:
+			if slices.Contains(violations, "unresolved-import") {
+				t.Log("waiting for violations to not contain unresolved-import")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for expected foo.rego diagnostics")
+		}
+
+		if success {
+			break
+		}
+	}
+}
+
+func TestLanguageServerUpdatesAggregateState(t *testing.T) {
+	t.Parallel()
+
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		t.Logf("message %s", req.Method)
+
+		return struct{}{}, nil
+	}
+
+	files := map[string]string{
+		"foo.rego": `package foo
+
+import rego.v1
+
+import data.baz
+`,
+		"bar.rego": `package bar
+
+import rego.v1
+
+import data.quz
+`,
+		".regal/config.yaml": ``,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tempDir := t.TempDir()
+
+	ls, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	if err != nil {
+		t.Fatalf("failed to create and init language server: %s", err)
+	}
+
+	// 1. check the Aggregates are set at start up
+	timeout := time.NewTimer(defaultTimeout)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		success := false
+
+		select {
+		case <-ticker.C:
+			aggs := ls.cache.GetFileAggregates()
+			if len(aggs) == 0 {
+				t.Logf("server aggregates %d", len(aggs))
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file aggregates to be set")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	determineImports := func(aggs map[string][]report.Aggregate) []string {
+		imports := []string{}
+
+		unresolvedImportAggs, ok := aggs["imports/unresolved-import"]
+		if !ok {
+			t.Fatalf("expected imports/unresolved-import aggregate data")
+		}
+
+		for _, entry := range unresolvedImportAggs {
+			if aggregateData, ok := entry["aggregate_data"].(map[string]any); ok {
+				if importsList, ok := aggregateData["imports"].([]any); ok {
+					for _, imp := range importsList {
+						if impMap, ok := imp.(map[string]any); ok {
+							if pathList, ok := impMap["path"].([]any); ok {
+								pathParts := []string{}
+
+								for _, p := range pathList {
+									if pathStr, ok := p.(string); ok {
+										pathParts = append(pathParts, pathStr)
+									}
+								}
+
+								imports = append(imports, strings.Join(pathParts, "."))
+							}
+						}
+					}
+				}
+			}
+		}
+
+		slices.Sort(imports)
+
+		return imports
+	}
+
+	imports := determineImports(ls.cache.GetFileAggregates())
+
+	if exp, got := []string{"baz", "quz"}, imports; !slices.Equal(exp, got) {
+		t.Fatalf("global state imports unexpected, got %v exp %v", got, exp)
+	}
+
+	// 2. check the aggregates for a file are updated after an update
+	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: fileURIScheme + filepath.Join(tempDir, "bar.rego"),
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package bar
+
+import rego.v1
+
+import data.qux # changed
+import data.wow # new
+`,
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	timeout.Reset(defaultTimeout)
+
+	for {
+		success := false
+
+		select {
+		case <-ticker.C:
+			imports = determineImports(ls.cache.GetFileAggregates())
+
+			if exp, got := []string{"baz", "qux", "wow"}, imports; !slices.Equal(exp, got) {
+				t.Logf("global state imports unexpected, got %v exp %v", got, exp)
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file aggregates to be set")
+		}
+
+		if success {
+			break
+		}
+	}
+}
+
+// nolint:maintidx
+func TestLanguageServerAggregateViolationFixedAndReintroducedInUnviolatingFileChange(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	tempDir := t.TempDir()
+	files := map[string]string{
+		"foo.rego": `package foo
+
+import rego.v1
+
+import data.bax # initially unresolved-import
+`,
+		"bar.rego": `package bar
+
+import rego.v1
+`,
+		".regal/config.yaml": ``,
+	}
+
+	messages := make(map[string]chan []string)
+	for _, file := range util.Keys(files) {
+		messages[file] = make(chan []string, 10)
+	}
+
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		if req.Method != "textDocument/publishDiagnostics" {
+			t.Log("unexpected request method:", req.Method)
+
+			return struct{}{}, nil
+		}
+
+		var requestData types.FileDiagnostics
+
+		err = encoding.JSON().Unmarshal(*req.Params, &requestData)
+		if err != nil {
+			t.Fatalf("failed to unmarshal diagnostics: %s", err)
+		}
+
+		violations := make([]string, len(requestData.Items))
+		for i, item := range requestData.Items {
+			violations[i] = item.Code
+		}
+
+		slices.Sort(violations)
+
+		messages[filepath.Base(requestData.URI)] <- violations
+
+		return struct{}{}, nil
+	}
+
+	// set up the server and client connections
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	if err != nil {
+		t.Fatalf("failed to create and init language server: %s", err)
+	}
+
+	// wait for foo.rego to have the correct violations
+	timeout := time.NewTimer(defaultTimeout)
+	defer timeout.Stop()
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["foo.rego"]:
+			if !slices.Contains(violations, "unresolved-import") {
+				t.Logf("waiting for violations to contain unresolved-import")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting foo.rego diagnostics")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// update the contents of the bar.rego file to address the unresolved-import
+	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: fileURIScheme + filepath.Join(tempDir, "bar.rego"),
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package bax # package imported in foo.rego
+
+import rego.v1
+`,
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// wait for foo.rego to have the correct violations
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["foo.rego"]:
+			if slices.Contains(violations, "unresolved-import") {
+				t.Logf("waiting for violations to not contain unresolved-import")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting foo.rego diagnostics")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// update the contents of the bar.rego to bring back the violation
+	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: fileURIScheme + filepath.Join(tempDir, "bar.rego"),
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package bar # original package to bring back the violation
+
+import rego.v1
+`,
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// check the violation is back
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["foo.rego"]:
+			if !slices.Contains(violations, "unresolved-import") {
+				t.Logf("waiting for violations to contain unresolved-import")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting foo.rego diagnostics")
+		}
+
+		if success {
+			break
+		}
+	}
+}

--- a/internal/lsp/server_builtins_test.go
+++ b/internal/lsp/server_builtins_test.go
@@ -1,0 +1,32 @@
+package lsp
+
+import (
+	"context"
+	"testing"
+)
+
+// https://github.com/StyraInc/regal/issues/679
+func TestProcessBuiltinUpdateExitsOnMissingFile(t *testing.T) {
+	t.Parallel()
+
+	ls := NewLanguageServer(context.Background(), &LanguageServerOptions{
+		ErrorLog: newTestLogger(t),
+	})
+
+	if err := ls.processHoverContentUpdate(context.Background(), "file://missing.rego", "foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	if l := len(ls.cache.GetAllBuiltInPositions()); l != 0 {
+		t.Errorf("expected builtin positions to be empty, got %d items", l)
+	}
+
+	contents, ok := ls.cache.GetFileContents("file://missing.rego")
+	if ok {
+		t.Errorf("expected file contents to be empty, got %s", contents)
+	}
+
+	if len(ls.cache.GetAllFiles()) != 0 {
+		t.Errorf("expected files to be empty, got %v", ls.cache.GetAllFiles())
+	}
+}

--- a/internal/lsp/server_config_test.go
+++ b/internal/lsp/server_config_test.go
@@ -1,0 +1,135 @@
+package lsp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/anderseknert/roast/pkg/encoding"
+	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/lsp/uri"
+)
+
+// TestLanguageServerParentDirConfig tests that regal config is loaded as it is for the
+// Regal CLI, and that config files in a parent directory are loaded correctly
+// even when the workspace is a child directory.
+func TestLanguageServerParentDirConfig(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	// this is the top level directory for the test
+	tempDir := t.TempDir()
+	// childDir will be the directory that the client is using as its workspace
+
+	childDirName := "child"
+	childDir := filepath.Join(tempDir, childDirName)
+
+	mainRegoContents := `package main
+
+import rego.v1
+allow := true
+`
+
+	files := map[string]string{
+		childDirName + mainRegoFileName: mainRegoContents,
+		".regal/config.yaml": `rules:
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore
+  style:
+    opa-fmt:
+      level: error
+`,
+	}
+
+	// mainRegoFileURI is used throughout the test to refer to the main.rego file
+	// and so it is defined here for convenience
+	mainRegoFileURI := fileURIScheme + childDir + mainRegoFileName
+
+	// set up the server and client connections
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	receivedMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		if req.Method == methodTextDocumentPublishDiagnostics {
+			var requestData types.FileDiagnostics
+
+			if err2 := encoding.JSON().Unmarshal(*req.Params, &requestData); err2 != nil {
+				t.Fatalf("failed to unmarshal diagnostics: %s", err2)
+			}
+
+			receivedMessages <- requestData
+
+			return struct{}{}, nil
+		}
+
+		t.Logf("unexpected request from server: %v", req)
+
+		return struct{}{}, nil
+	}
+
+	ls, _, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	if err != nil {
+		t.Fatalf("failed to create and init language server: %s", err)
+	}
+
+	if got, exp := ls.workspaceRootURI, uri.FromPath(ls.clientIdentifier, tempDir); exp != got {
+		t.Fatalf("expected client root URI to be %s, got %s", exp, got)
+	}
+
+	timeout := time.NewTimer(defaultTimeout)
+	defer timeout.Stop()
+
+	for {
+		var success bool
+		select {
+		case requestData := <-receivedMessages:
+			success = testRequestDataCodes(t, requestData, mainRegoFileURI, []string{"opa-fmt"})
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// User updates config file contents in parent directory that is not
+	// part of the workspace
+	newConfigContents := `rules:
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore
+  style:
+    opa-fmt:
+      level: ignore
+`
+
+	path := filepath.Join(tempDir, ".regal/config.yaml")
+	if err := os.WriteFile(path, []byte(newConfigContents), 0o600); err != nil {
+		t.Fatalf("failed to write new config file: %s", err)
+	}
+
+	// validate that the client received a new, empty diagnostics notification for the file
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case requestData := <-receivedMessages:
+			success = testRequestDataCodes(t, requestData, mainRegoFileURI, []string{})
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+}

--- a/internal/lsp/server_formatting_test.go
+++ b/internal/lsp/server_formatting_test.go
@@ -1,0 +1,78 @@
+package lsp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+func TestFormatting(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+
+	// set up the server and client connections
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		t.Fatalf("unexpected request: %v", req)
+
+		return struct{}{}, nil
+	}
+
+	ls, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, map[string]string{}, clientHandler)
+	if err != nil {
+		t.Fatalf("failed to create and init language server: %s", err)
+	}
+
+	mainRegoURI := fileURIScheme + tempDir + mainRegoFileName
+
+	// Simple as possible — opa fmt should just remove a newline
+	content := `package main
+
+`
+	ls.cache.SetFileContents(mainRegoURI, content)
+
+	bs, err := json.Marshal(&types.DocumentFormattingParams{
+		TextDocument: types.TextDocumentIdentifier{URI: mainRegoURI},
+		Options:      types.FormattingOptions{},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal document formatting params: %v", err)
+	}
+
+	var msg json.RawMessage = bs
+
+	req := &jsonrpc2.Request{Params: &msg}
+
+	res, err := ls.handleTextDocumentFormatting(ctx, connClient, req)
+	if err != nil {
+		t.Fatalf("failed to format document: %s", err)
+	}
+
+	if edits, ok := res.([]types.TextEdit); ok {
+		if len(edits) != 1 {
+			t.Fatalf("expected 1 edit, got %d", len(edits))
+		}
+
+		expectRange := types.Range{
+			Start: types.Position{Line: 1, Character: 0},
+			End:   types.Position{Line: 2, Character: 0},
+		}
+
+		if edits[0].Range != expectRange {
+			t.Fatalf("expected range to be %v, got %v", expectRange, edits[0].Range)
+		}
+
+		if edits[0].NewText != "" {
+			t.Fatalf("expected new text to be empty, got %s", edits[0].NewText)
+		}
+	} else {
+		t.Fatalf("expected edits to be []types.TextEdit, got %T", res)
+	}
+}

--- a/internal/lsp/server_multi_file_test.go
+++ b/internal/lsp/server_multi_file_test.go
@@ -1,0 +1,197 @@
+package lsp
+
+import (
+	"context"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/anderseknert/roast/pkg/encoding"
+	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/util"
+)
+
+// TestLanguageServerMultipleFiles tests that changes to multiple files are handled correctly. When there are multiple
+// files in the workspace, the diagnostics worker also processes aggregate violations, there are also changes to when
+// workspace diagnostics are run, this test validates that the correct diagnostics are sent to the client in this
+// scenario.
+//
+// nolint:maintidx
+func TestLanguageServerMultipleFiles(t *testing.T) {
+	t.Parallel()
+
+	// set up the workspace content with some example rego and regal config
+	tempDir := t.TempDir()
+
+	files := map[string]string{
+		"authz.rego": `package authz
+
+import rego.v1
+
+import data.admins.users
+
+default allow := false
+
+allow if input.user in users
+`,
+		"admins.rego": `package admins
+
+import rego.v1
+
+users = {"alice", "bob"}
+`,
+		"ignored/foo.rego": `package ignored
+
+foo = 1
+`,
+		".regal/config.yaml": `
+rules:
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore
+ignore:
+  files:
+    - ignored/*.rego
+`,
+	}
+
+	messages := make(map[string]chan []string)
+	for _, file := range util.Keys(files) {
+		messages[file] = make(chan []string, 10)
+	}
+
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		if req.Method != "textDocument/publishDiagnostics" {
+			t.Log("unexpected request method:", req.Method)
+
+			return struct{}{}, nil
+		}
+
+		var requestData types.FileDiagnostics
+
+		err = encoding.JSON().Unmarshal(*req.Params, &requestData)
+		if err != nil {
+			t.Fatalf("failed to unmarshal diagnostics: %s", err)
+		}
+
+		violations := make([]string, len(requestData.Items))
+		for i, item := range requestData.Items {
+			violations[i] = item.Code
+		}
+
+		slices.Sort(violations)
+
+		messages[filepath.Base(requestData.URI)] <- violations
+
+		return struct{}{}, nil
+	}
+
+	// set up the server and client connections
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	if err != nil {
+		t.Fatalf("failed to create and init language server: %s", err)
+	}
+
+	// validate that the client received a diagnostics notification for authz.rego
+	timeout := time.NewTimer(defaultTimeout)
+	defer timeout.Stop()
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["authz.rego"]:
+			if !slices.Contains(violations, "prefer-package-imports") {
+				t.Logf("waiting for violations to contain prefer-package-imports")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for authz.rego diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// validate that the client received a diagnostics notification admins.rego
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["admins.rego"]:
+			if !slices.Contains(violations, "use-assignment-operator") {
+				t.Logf("waiting for violations to contain use-assignment-operator")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for admins.rego diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// 3. Client sends textDocument/didChange notification with new contents for authz.rego
+	// no response to the call is expected
+	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: fileURIScheme + filepath.Join(tempDir, "authz.rego"),
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package authz
+
+import rego.v1
+
+import data.admins # fixes prefer-package-imports
+
+default allow := false
+
+# METADATA
+# description: Allow only admins
+# entrypoint: true # fixes no-defined-entrypoint
+allow if input.user in admins.users
+`,
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// authz.rego should now have no violations
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case violations := <-messages["authz.rego"]:
+			if len(violations) > 0 {
+				t.Logf("waiting for violations to be empty for authz.rego")
+
+				continue
+			}
+
+			success = true
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for authz.rego diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+}

--- a/internal/lsp/server_rename_test.go
+++ b/internal/lsp/server_rename_test.go
@@ -1,0 +1,79 @@
+package lsp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/cache"
+	"github.com/styrainc/regal/internal/lsp/clients"
+	"github.com/styrainc/regal/pkg/config"
+	"github.com/styrainc/regal/pkg/fixer/fixes"
+)
+
+func TestLanguageServerFixRenameParams(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, "workspace/foo/bar"), 0o755); err != nil {
+		t.Fatalf("failed to create directory: %s", err)
+	}
+
+	ctx := context.Background()
+
+	l := NewLanguageServer(ctx, &LanguageServerOptions{ErrorLog: newTestLogger(t)})
+	c := cache.NewCache()
+	f := &fixes.DirectoryPackageMismatch{}
+
+	fileURL := fmt.Sprintf("file://%s/workspace/foo/bar/policy.rego", tmpDir)
+
+	c.SetFileContents(fileURL, "package authz.main.rules")
+
+	l.clientIdentifier = clients.IdentifierVSCode
+	l.workspaceRootURI = fmt.Sprintf("file://%s/workspace", tmpDir)
+	l.cache = c
+	l.loadedConfig = &config.Config{
+		Rules: map[string]config.Category{
+			"idiomatic": {
+				"directory-package-mismatch": config.Rule{
+					Level: "ignore",
+					Extra: map[string]any{
+						"exclude-test-suffix": true,
+					},
+				},
+			},
+		},
+	}
+
+	params, err := l.fixRenameParams("fix my file!", f, fileURL)
+	if err != nil {
+		t.Fatalf("failed to fix rename params: %s", err)
+	}
+
+	if params.Label != "fix my file!" {
+		t.Fatalf("expected label to be 'Fix my file!', got %s", params.Label)
+	}
+
+	if len(params.Edit.DocumentChanges) != 1 {
+		t.Fatalf("expected 1 document change, got %d", len(params.Edit.DocumentChanges))
+	}
+
+	change := params.Edit.DocumentChanges[0]
+
+	if change.Kind != "rename" {
+		t.Fatalf("expected kind to be 'rename', got %s", change.Kind)
+	}
+
+	if change.OldURI != fileURL {
+		t.Fatalf("expected old URI to be %s, got %s", fileURL, change.OldURI)
+	}
+
+	expectedNewURI := fmt.Sprintf("file://%s/workspace/authz/main/rules/policy.rego", tmpDir)
+
+	if change.NewURI != expectedNewURI {
+		t.Fatalf("expected new URI to be %s, got %s", expectedNewURI, change.NewURI)
+	}
+}

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -308,8 +308,9 @@ allow := neo4j.q
 		select {
 		case <-ticker.C:
 			// Create a new context with timeout for each request, this is
-			// timed out after 1s as GHA runner sometimes takes a while.
-			reqCtx, reqCtxCancel := context.WithTimeout(ctx, time.Second)
+			// timed out after using the default as the GHA runner is super
+			// slow in the race detector
+			reqCtx, reqCtxCancel := context.WithTimeout(ctx, determineTimeout())
 
 			resp := make(map[string]any)
 			err := connClient.Call(reqCtx, "textDocument/completion", types.CompletionParams{

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -1,0 +1,348 @@
+package lsp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/anderseknert/roast/pkg/encoding"
+	"github.com/sourcegraph/jsonrpc2"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+// TestLanguageServerSingleFile tests that changes to a single file and Regal config are handled correctly by the
+// language server by making updates to both and validating that the correct diagnostics are sent to the client.
+//
+// This test also ensures that updating the config to point to a non-default engine and capabilities version works
+// and causes that engine's builtins to work with completions.
+//
+//nolint:maintidx
+func TestLanguageServerSingleFile(t *testing.T) {
+	t.Parallel()
+
+	// set up the workspace content with some example rego and regal config
+	tempDir := t.TempDir()
+	mainRegoURI := fileURIScheme + tempDir + mainRegoFileName
+
+	if err := os.MkdirAll(filepath.Join(tempDir, ".regal"), 0o755); err != nil {
+		t.Fatalf("failed to create .regal directory: %s", err)
+	}
+
+	mainRegoContents := `package main
+
+import rego.v1
+allow = true
+`
+
+	files := map[string]string{
+		"main.rego": mainRegoContents,
+		".regal/config.yaml": `
+rules:
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore`,
+	}
+
+	for f, fc := range files {
+		if err := os.WriteFile(filepath.Join(tempDir, f), []byte(fc), 0o600); err != nil {
+			t.Fatalf("failed to write file %s: %s", f, err)
+		}
+	}
+
+	receivedMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
+	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
+		if req.Method == methodTextDocumentPublishDiagnostics {
+			var requestData types.FileDiagnostics
+
+			if err := encoding.JSON().Unmarshal(*req.Params, &requestData); err != nil {
+				t.Fatalf("failed to unmarshal diagnostics: %s", err)
+			}
+
+			receivedMessages <- requestData
+
+			return struct{}{}, nil
+		}
+
+		t.Fatalf("unexpected request: %v", req)
+
+		return struct{}{}, nil
+	}
+
+	// set up the server and client connections
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	_, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	if err != nil {
+		t.Fatalf("failed to create and init language server: %s", err)
+	}
+
+	// validate that the client received a diagnostics notification for the file
+	timeout := time.NewTimer(defaultTimeout)
+	defer timeout.Stop()
+
+	for {
+		var success bool
+		select {
+		case requestData := <-receivedMessages:
+			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{"opa-fmt", "use-assignment-operator"})
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// Client sends textDocument/didChange notification with new contents for main.rego
+	// no response to the call is expected
+	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: mainRegoURI,
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package main
+import rego.v1
+allow := true
+`,
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// validate that the client received a new diagnostics notification for the file
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case requestData := <-receivedMessages:
+			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{"opa-fmt"})
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// Client sends workspace/didChangeWatchedFiles notification with new config
+	newConfigContents := `
+rules:
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore
+  style:
+    opa-fmt:
+      level: ignore
+`
+
+	if err := os.WriteFile(filepath.Join(tempDir, ".regal/config.yaml"), []byte(newConfigContents), 0o600); err != nil {
+		t.Fatalf("failed to write new config file: %s", err)
+	}
+
+	// validate that the client received a new, empty diagnostics notification for the file
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case requestData := <-receivedMessages:
+			if requestData.URI != mainRegoURI {
+				t.Logf("expected diagnostics to be sent for main.rego, got %s", requestData.URI)
+
+				break
+			}
+
+			if len(requestData.Items) != 0 {
+				t.Logf("expected 0 diagnostic, got %d", len(requestData.Items))
+
+				break
+			}
+
+			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// Client sends new config with an EOPA capabilities file specified.
+	newConfigContents = `
+rules:
+  style:
+    opa-fmt:
+      level: ignore
+  idiomatic:
+    directory-package-mismatch:
+      level: ignore
+capabilities:
+  from:
+    engine: eopa
+    version: v1.23.0
+`
+
+	if err := os.WriteFile(filepath.Join(tempDir, ".regal/config.yaml"), []byte(newConfigContents), 0o600); err != nil {
+		t.Fatalf("failed to write new config file: %s", err)
+	}
+
+	// validate that the client received a new, empty diagnostics notification for the file
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case requestData := <-receivedMessages:
+			if requestData.URI != mainRegoURI {
+				t.Logf("expected diagnostics to be sent for main.rego, got %s", requestData.URI)
+
+				break
+			}
+
+			if len(requestData.Items) != 0 {
+				t.Logf("expected 0 diagnostic, got %d", len(requestData.Items))
+
+				break
+			}
+
+			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// Client sends textDocument/didChange notification with new
+	// contents for main.rego no response to the call is expected. We added
+	// the start of an EOPA-specific call, so if the capabilities were
+	// loaded correctly, we should see a completion later after we ask for
+	// it.
+	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: mainRegoURI,
+		},
+		ContentChanges: []types.TextDocumentContentChangeEvent{
+			{
+				Text: `package main
+import rego.v1
+
+# METADATA
+# entrypoint: true
+allow := neo4j.q
+`,
+			},
+		},
+	}, nil); err != nil {
+		t.Fatalf("failed to send didChange notification: %s", err)
+	}
+
+	// validate that the client received a new diagnostics notification for the file
+	timeout.Reset(defaultTimeout)
+
+	for {
+		var success bool
+		select {
+		case requestData := <-receivedMessages:
+			if requestData.URI != mainRegoURI {
+				t.Logf("expected diagnostics to be sent for main.rego, got %s", requestData.URI)
+
+				break
+			}
+
+			if len(requestData.Items) != 0 {
+				t.Logf("expected 0 diagnostic, got %d", len(requestData.Items))
+
+				break
+			}
+
+			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file diagnostics to be sent")
+		}
+
+		if success {
+			break
+		}
+	}
+
+	// 7. With our new config applied, and the file updated, we can ask the
+	// LSP for a completion. We expect to see neo4j.query show up. Since
+	// neo4j.query is an EOPA-specific builtin, it should never appear if
+	// we're using the normal OPA capabilities file.
+	timeout.Reset(defaultTimeout)
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		foundNeo4j := false
+
+		select {
+		case <-ticker.C:
+			// Create a new context with timeout for each request, this is
+			// timed out after 1s as GHA runner sometimes takes a while.
+			reqCtx, reqCtxCancel := context.WithTimeout(ctx, time.Second)
+
+			resp := make(map[string]any)
+			err := connClient.Call(reqCtx, "textDocument/completion", types.CompletionParams{
+				TextDocument: types.TextDocumentIdentifier{
+					URI: mainRegoURI,
+				},
+				Position: types.Position{
+					Line:      5,
+					Character: 16,
+				},
+			}, &resp)
+
+			reqCtxCancel()
+
+			if err != nil {
+				t.Fatalf("failed to send completion request: %s", err)
+			}
+
+			itemsList, ok := resp["items"].([]any)
+			if !ok {
+				t.Fatalf("failed to cast resp[items] to []any")
+			}
+
+			for _, itemI := range itemsList {
+				item, ok := itemI.(map[string]any)
+				if !ok {
+					t.Fatalf("completion item '%+v' was not a JSON object", itemI)
+				}
+
+				label, ok := item["label"].(string)
+				if !ok {
+					t.Fatalf("completion item label is not a string: %+v", item["label"])
+				}
+
+				if label == "neo4j.query" {
+					foundNeo4j = true
+
+					break
+				}
+			}
+
+			t.Logf("waiting for neo4j.query in completion results for neo4j.q, got %v", itemsList)
+		case <-timeout.C:
+			t.Fatalf("timed out waiting for file completion to correct")
+		}
+
+		if foundNeo4j {
+			break
+		}
+	}
+}

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -163,7 +163,7 @@ func TestNewFileTemplating(t *testing.T) {
 	go ls.StartTemplateWorker(ctx)
 
 	// wait for the server to load it's config
-	timeout := time.NewTimer(defaultTimeout)
+	timeout := time.NewTimer(determineTimeout())
 	select {
 	case <-timeout.C:
 		t.Fatalf("timed out waiting for server to load config")
@@ -200,7 +200,7 @@ func TestNewFileTemplating(t *testing.T) {
 	}
 
 	// Validate that the client received a workspace edit
-	timeout.Reset(defaultTimeout)
+	timeout.Reset(determineTimeout())
 
 	expectedMessage := fmt.Sprintf(`{
   "edit": {

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -110,9 +110,17 @@ func createAndInitServer(
 		}
 	}
 
+	// This is set due to eventing being so slow in go test -race that we
+	// get flakes. TODO, work out how to avoid needing this in lsp tests.
+	pollingInterval := time.Duration(0)
+	if isRaceEnabled() {
+		pollingInterval = 10 * time.Second
+	}
+
 	// set up the server and client connections
 	ls := NewLanguageServer(ctx, &LanguageServerOptions{
-		ErrorLog: logger,
+		ErrorLog:                 logger,
+		WorkspaceDiagnosticsPoll: pollingInterval,
 	})
 
 	go ls.StartDiagnosticsWorker(ctx)

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,14 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/anderseknert/roast/pkg/encoding"
 	"github.com/sourcegraph/jsonrpc2"
 
-	"github.com/styrainc/regal/internal/lsp/cache"
-	"github.com/styrainc/regal/internal/lsp/clients"
 	"github.com/styrainc/regal/internal/lsp/types"
-	"github.com/styrainc/regal/pkg/config"
-	"github.com/styrainc/regal/pkg/fixer/fixes"
 )
 
 const mainRegoFileName = "/main.rego"
@@ -36,997 +30,6 @@ const defaultTimeout = 20 * time.Second
 const defaultBufferedChannelSize = 5
 
 const fileURIScheme = "file://"
-
-// TestLanguageServerSingleFile tests that changes to a single file and Regal config are handled correctly by the
-// language server by making updates to both and validating that the correct diagnostics are sent to the client.
-//
-// This test also ensures that updating the config to point to a non-default engine and capabilities version works
-// and causes that engine's builtins to work with completions.
-//
-//nolint:maintidx
-func TestLanguageServerSingleFile(t *testing.T) {
-	t.Parallel()
-
-	// set up the workspace content with some example rego and regal config
-	tempDir := t.TempDir()
-	mainRegoURI := fileURIScheme + tempDir + mainRegoFileName
-
-	if err := os.MkdirAll(filepath.Join(tempDir, ".regal"), 0o755); err != nil {
-		t.Fatalf("failed to create .regal directory: %s", err)
-	}
-
-	mainRegoContents := `package main
-
-import rego.v1
-allow = true
-`
-
-	files := map[string]string{
-		"main.rego": mainRegoContents,
-		".regal/config.yaml": `
-rules:
-  idiomatic:
-    directory-package-mismatch:
-      level: ignore`,
-	}
-
-	for f, fc := range files {
-		if err := os.WriteFile(filepath.Join(tempDir, f), []byte(fc), 0o600); err != nil {
-			t.Fatalf("failed to write file %s: %s", f, err)
-		}
-	}
-
-	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ls := NewLanguageServer(&LanguageServerOptions{
-		ErrorLog: newTestLogger(t),
-	})
-	go ls.StartDiagnosticsWorker(ctx)
-	go ls.StartConfigWorker(ctx)
-
-	receivedMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
-	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-		if req.Method == methodTextDocumentPublishDiagnostics {
-			var requestData types.FileDiagnostics
-
-			if err := encoding.JSON().Unmarshal(*req.Params, &requestData); err != nil {
-				t.Fatalf("failed to unmarshal diagnostics: %s", err)
-			}
-
-			receivedMessages <- requestData
-
-			return struct{}{}, nil
-		}
-
-		t.Fatalf("unexpected request: %v", req)
-
-		return struct{}{}, nil
-	}
-
-	connServer, connClient := createConnections(ctx, ls.Handle, clientHandler)
-
-	ls.SetConn(connServer)
-
-	// 1. Client sends initialize request
-	request := types.InitializeParams{
-		RootURI:    fileURIScheme + tempDir,
-		ClientInfo: types.Client{Name: "go test"},
-	}
-
-	var response types.InitializeResult
-
-	if err := connClient.Call(ctx, "initialize", request, &response); err != nil {
-		t.Fatalf("failed to send initialize request: %s", err)
-	}
-
-	// validate that the server responded with the correct capabilities, and that the correct root URI was set on the
-	// server
-	if response.Capabilities.DiagnosticProvider.Identifier != "rego" {
-		t.Fatalf(
-			"expected diagnostic provider identifier to be rego, got %s",
-			response.Capabilities.DiagnosticProvider.Identifier,
-		)
-	}
-
-	if ls.workspaceRootURI != request.RootURI {
-		t.Fatalf("expected client root URI to be %s, got %s", request.RootURI, ls.workspaceRootURI)
-	}
-
-	// validate that the file contents from the workspace are loaded during the initialize request
-	contents, ok := ls.cache.GetFileContents(mainRegoURI)
-	if !ok {
-		t.Fatalf("expected file contents to be cached")
-	}
-
-	if contents != mainRegoContents {
-		t.Fatalf("expected file contents to be %s, got %s", mainRegoContents, contents)
-	}
-
-	_, ok = ls.cache.GetModule(mainRegoURI)
-	if !ok {
-		t.Fatalf("expected module to have been parsed and cached for main.rego")
-	}
-
-	// 2. Client sends initialized notification
-	// no response to the call is expected
-	if err := connClient.Call(ctx, "initialized", struct{}{}, nil); err != nil {
-		t.Fatalf("failed to send initialized notification: %s", err)
-	}
-
-	// validate that the client received a diagnostics notification for the file
-	timeout := time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-receivedMessages:
-			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{"opa-fmt", "use-assignment-operator"})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// 3. Client sends textDocument/didChange notification with new contents for main.rego
-	// no response to the call is expected
-	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
-		TextDocument: types.TextDocumentIdentifier{
-			URI: mainRegoURI,
-		},
-		ContentChanges: []types.TextDocumentContentChangeEvent{
-			{
-				Text: `package main
-import rego.v1
-allow := true
-`,
-			},
-		},
-	}, nil); err != nil {
-		t.Fatalf("failed to send didChange notification: %s", err)
-	}
-
-	// validate that the client received a new diagnostics notification for the file
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-receivedMessages:
-			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{"opa-fmt"})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// 4. Client sends workspace/didChangeWatchedFiles notification with new config
-	newConfigContents := `
-rules:
-  idiomatic:
-    directory-package-mismatch:
-      level: ignore
-  style:
-    opa-fmt:
-      level: ignore
-`
-
-	if err := os.WriteFile(filepath.Join(tempDir, ".regal/config.yaml"), []byte(newConfigContents), 0o600); err != nil {
-		t.Fatalf("failed to write new config file: %s", err)
-	}
-
-	// validate that the client received a new, empty diagnostics notification for the file
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-receivedMessages:
-			if requestData.URI != mainRegoURI {
-				t.Logf("expected diagnostics to be sent for main.rego, got %s", requestData.URI)
-
-				break
-			}
-
-			if len(requestData.Items) != 0 {
-				t.Logf("expected 0 diagnostic, got %d", len(requestData.Items))
-
-				break
-			}
-
-			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// 5. Client sends new config with an EOPA capabilities file specified.
-	newConfigContents = `
-rules:
-  style:
-    opa-fmt:
-      level: ignore
-  idiomatic:
-    directory-package-mismatch:
-      level: ignore
-capabilities:
-  from:
-    engine: eopa
-    version: v1.23.0
-`
-
-	if err := os.WriteFile(filepath.Join(tempDir, ".regal/config.yaml"), []byte(newConfigContents), 0o600); err != nil {
-		t.Fatalf("failed to write new config file: %s", err)
-	}
-
-	// validate that the client received a new, empty diagnostics notification for the file
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-receivedMessages:
-			if requestData.URI != mainRegoURI {
-				t.Logf("expected diagnostics to be sent for main.rego, got %s", requestData.URI)
-
-				break
-			}
-
-			if len(requestData.Items) != 0 {
-				t.Logf("expected 0 diagnostic, got %d", len(requestData.Items))
-
-				break
-			}
-
-			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// 6. Client sends textDocument/didChange notification with new
-	// contents for main.rego no response to the call is expected. We added
-	// the start of an EOPA-specific call, so if the capabilities were
-	// loaded correctly, we should see a completion later after we ask for
-	// it.
-	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
-		TextDocument: types.TextDocumentIdentifier{
-			URI: mainRegoURI,
-		},
-		ContentChanges: []types.TextDocumentContentChangeEvent{
-			{
-				Text: `package main
-import rego.v1
-allow := neo4j.q
-`,
-			},
-		},
-	}, nil); err != nil {
-		t.Fatalf("failed to send didChange notification: %s", err)
-	}
-
-	// validate that the client received a new diagnostics notification for the file
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-receivedMessages:
-			if requestData.URI != mainRegoURI {
-				t.Logf("expected diagnostics to be sent for main.rego, got %s", requestData.URI)
-
-				break
-			}
-
-			if len(requestData.Items) != 0 {
-				t.Logf("expected 0 diagnostic, got %d", len(requestData.Items))
-
-				break
-			}
-
-			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// 7. With our new config applied, and the file updated, we can ask the
-	// LSP for a completion. We expect to see neo4j.query show up. Since
-	// neo4j.query is an EOPA-specific builtin, it should never appear if
-	// we're using the normal OPA capabilities file.
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	ticker := time.NewTicker(500 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		foundNeo4j := false
-
-		select {
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file completion to correct")
-		case <-ticker.C:
-			// Create a new context with timeout for each request
-			reqCtx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
-
-			resp := make(map[string]any)
-			err := connClient.Call(reqCtx, "textDocument/completion", types.CompletionParams{
-				TextDocument: types.TextDocumentIdentifier{
-					URI: mainRegoURI,
-				},
-				Position: types.Position{
-					Line:      2,
-					Character: 16,
-				},
-			}, &resp)
-
-			cancel()
-
-			if err != nil {
-				t.Fatalf("failed to send completion notification: %s", err)
-			}
-
-			itemsList, ok := resp["items"].([]any)
-			if !ok {
-				t.Fatalf("failed to cast resp[items] to []any")
-			}
-
-			for _, itemI := range itemsList {
-				item, ok := itemI.(map[string]any)
-				if !ok {
-					t.Fatalf("completion item '%+v' was not a JSON object", itemI)
-				}
-
-				label, ok := item["label"].(string)
-				if !ok {
-					t.Fatalf("completion item label is not a string: %+v", item["label"])
-				}
-
-				if label == "neo4j.query" {
-					foundNeo4j = true
-
-					break
-				}
-			}
-
-			t.Logf("waiting for neo4j.query in completion results for neo4j.q, got %v", itemsList)
-		}
-
-		if foundNeo4j {
-			break
-		}
-	}
-}
-
-// TestLanguageServerMultipleFiles tests that changes to multiple files are handled correctly. When there are multiple
-// files in the workspace, the diagnostics worker also processes aggregate violations, there are also changes to when
-// workspace diagnostics are run, this test validates that the correct diagnostics are sent to the client in this
-// scenario.
-//
-// nolint:maintidx
-func TestLanguageServerMultipleFiles(t *testing.T) {
-	t.Parallel()
-
-	// set up the workspace content with some example rego and regal config
-	tempDir := t.TempDir()
-	authzRegoURI := fileURIScheme + tempDir + "/authz.rego"
-	adminsRegoURI := fileURIScheme + tempDir + "/admins.rego"
-	ignoredRegoURI := fileURIScheme + tempDir + "/ignored/foo.rego"
-
-	files := map[string]string{
-		"authz.rego": `package authz
-
-import rego.v1
-
-import data.admins.users
-
-default allow := false
-
-allow if input.user in users
-`,
-		"admins.rego": `package admins
-
-import rego.v1
-
-users = {"alice", "bob"}
-`,
-		"ignored/foo.rego": `package ignored
-
-foo = 1
-`,
-		".regal/config.yaml": `
-rules:
-  idiomatic:
-    directory-package-mismatch:
-      level: ignore
-ignore:
-  files:
-    - ignored/*.rego
-`,
-	}
-
-	if err := os.MkdirAll(filepath.Join(tempDir, ".regal"), 0o755); err != nil {
-		t.Fatalf("failed to create .regal directory: %s", err)
-	}
-
-	if err := os.MkdirAll(filepath.Join(tempDir, "ignored"), 0o755); err != nil {
-		t.Fatalf("failed to create ignored directory: %s", err)
-	}
-
-	for f, fc := range files {
-		if err := os.WriteFile(filepath.Join(tempDir, f), []byte(fc), 0o600); err != nil {
-			t.Fatalf("failed to write file %s: %s", f, err)
-		}
-	}
-
-	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ls := NewLanguageServer(&LanguageServerOptions{ErrorLog: newTestLogger(t)})
-	go ls.StartDiagnosticsWorker(ctx)
-	go ls.StartConfigWorker(ctx)
-
-	authzFileMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
-	adminsFileMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
-	ignoredFileMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
-	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-		if req.Method != "textDocument/publishDiagnostics" {
-			t.Log("unexpected request method:", req.Method)
-
-			return struct{}{}, nil
-		}
-
-		var requestData types.FileDiagnostics
-		if err := encoding.JSON().Unmarshal(*req.Params, &requestData); err != nil {
-			t.Fatalf("failed to unmarshal diagnostics: %s", err)
-		}
-
-		switch requestData.URI {
-		case authzRegoURI:
-			authzFileMessages <- requestData
-		case adminsRegoURI:
-			adminsFileMessages <- requestData
-		case ignoredRegoURI:
-			ignoredFileMessages <- requestData
-		default:
-			t.Logf("unexpected diagnostics for file: %s", requestData.URI)
-		}
-
-		return struct{}{}, nil
-	}
-
-	connServer, connClient := createConnections(ctx, ls.Handle, clientHandler)
-
-	ls.SetConn(connServer)
-
-	// 1. Client sends initialize request
-	request := types.InitializeParams{
-		RootURI:    fileURIScheme + tempDir,
-		ClientInfo: types.Client{Name: "go test"},
-	}
-
-	var response types.InitializeResult
-
-	if err := connClient.Call(ctx, "initialize", request, &response); err != nil {
-		t.Fatalf("failed to send initialize request: %s", err)
-	}
-
-	// 2. Client sends initialized notification
-	// no response to the call is expected
-	if err := connClient.Call(ctx, "initialized", struct{}{}, nil); err != nil {
-		t.Fatalf("failed to send initialized notification: %s", err)
-	}
-
-	// validate that the client received a diagnostics notification for authz.rego
-	timeout := time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case diags := <-authzFileMessages:
-			success = testRequestDataCodes(t, diags, authzRegoURI, []string{"prefer-package-imports"})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for authz.rego diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// validate that the client received a diagnostics notification admins.rego
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case diags := <-adminsFileMessages:
-			success = testRequestDataCodes(t, diags, adminsRegoURI, []string{"use-assignment-operator"})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for admins.rego diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// 3. Client sends textDocument/didChange notification with new contents for authz.rego
-	// no response to the call is expected
-	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
-		TextDocument: types.TextDocumentIdentifier{
-			URI: authzRegoURI,
-		},
-		ContentChanges: []types.TextDocumentContentChangeEvent{
-			{
-				Text: `package authz
-
-import rego.v1
-
-import data.admins
-
-default allow := false
-
-allow if input.user in admins.users
-`,
-			},
-		},
-	}, nil); err != nil {
-		t.Fatalf("failed to send didChange notification: %s", err)
-	}
-
-	// authz.rego should now have no violations
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case diags := <-authzFileMessages:
-			success = testRequestDataCodes(t, diags, authzRegoURI, []string{})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for authz.rego diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// we should also receive a diagnostics notification for admins.rego, since it is in the workspace, but it has not
-	// been changed, so the violations should be the same.
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-adminsFileMessages:
-			success = testRequestDataCodes(t, requestData, adminsRegoURI, []string{"use-assignment-operator"})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for admins.rego diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-}
-
-// https://github.com/StyraInc/regal/issues/679
-func TestProcessBuiltinUpdateExitsOnMissingFile(t *testing.T) {
-	t.Parallel()
-
-	ls := NewLanguageServer(&LanguageServerOptions{
-		ErrorLog: newTestLogger(t),
-	})
-
-	if err := ls.processHoverContentUpdate(context.Background(), "file://missing.rego", "foo"); err != nil {
-		t.Fatal(err)
-	}
-
-	if l := len(ls.cache.GetAllBuiltInPositions()); l != 0 {
-		t.Errorf("expected builtin positions to be empty, got %d items", l)
-	}
-
-	contents, ok := ls.cache.GetFileContents("file://missing.rego")
-	if ok {
-		t.Errorf("expected file contents to be empty, got %s", contents)
-	}
-
-	if len(ls.cache.GetAllFiles()) != 0 {
-		t.Errorf("expected files to be empty, got %v", ls.cache.GetAllFiles())
-	}
-}
-
-func TestFormatting(t *testing.T) {
-	t.Parallel()
-
-	tempDir := t.TempDir()
-
-	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ls := NewLanguageServer(&LanguageServerOptions{
-		ErrorLog: newTestLogger(t),
-	})
-	go ls.StartConfigWorker(ctx)
-
-	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-		t.Fatalf("unexpected request: %v", req)
-
-		return struct{}{}, nil
-	}
-
-	connServer, connClient := createConnections(ctx, ls.Handle, clientHandler)
-
-	ls.SetConn(connServer)
-
-	// 1. Client sends initialize request
-	request := types.InitializeParams{
-		RootURI:    fileURIScheme + tempDir,
-		ClientInfo: types.Client{Name: "go test"},
-	}
-
-	var response types.InitializeResult
-
-	if err := connClient.Call(ctx, "initialize", request, &response); err != nil {
-		t.Fatalf("failed to send initialize request: %s", err)
-	}
-
-	mainRegoURI := fileURIScheme + tempDir + mainRegoFileName
-
-	// Simple as possible — opa fmt should just remove a newline
-	content := `package main
-
-`
-	ls.cache.SetFileContents(mainRegoURI, content)
-
-	bs, err := json.Marshal(&types.DocumentFormattingParams{
-		TextDocument: types.TextDocumentIdentifier{URI: mainRegoURI},
-		Options:      types.FormattingOptions{},
-	})
-	if err != nil {
-		t.Fatalf("failed to marshal document formatting params: %v", err)
-	}
-
-	var msg json.RawMessage = bs
-
-	req := &jsonrpc2.Request{Params: &msg}
-
-	res, err := ls.handleTextDocumentFormatting(ctx, connClient, req)
-	if err != nil {
-		t.Fatalf("failed to format document: %s", err)
-	}
-
-	if edits, ok := res.([]types.TextEdit); ok {
-		if len(edits) != 1 {
-			t.Fatalf("expected 1 edit, got %d", len(edits))
-		}
-
-		expectRange := types.Range{
-			Start: types.Position{Line: 1, Character: 0},
-			End:   types.Position{Line: 2, Character: 0},
-		}
-
-		if edits[0].Range != expectRange {
-			t.Fatalf("expected range to be %v, got %v", expectRange, edits[0].Range)
-		}
-
-		if edits[0].NewText != "" {
-			t.Fatalf("expected new text to be empty, got %s", edits[0].NewText)
-		}
-	} else {
-		t.Fatalf("expected edits to be []types.TextEdit, got %T", res)
-	}
-}
-
-// TestLanguageServerParentDirConfig tests that regal config is loaded as it is for the
-// Regal CLI, and that config files in a parent directory are loaded correctly
-// even when the workspace is a child directory.
-func TestLanguageServerParentDirConfig(t *testing.T) {
-	t.Parallel()
-
-	var err error
-
-	// this is the top level directory for the test
-	parentDir := t.TempDir()
-	// childDir will be the directory that the client is using as its workspace
-	childDirName := "child"
-	childDir := filepath.Join(parentDir, childDirName)
-
-	for _, dir := range []string{childDirName, ".regal"} {
-		err = os.MkdirAll(filepath.Join(parentDir, dir), 0o755)
-		if err != nil {
-			t.Fatalf("failed to create %q directory under parent: %s", dir, err)
-		}
-	}
-
-	mainRegoContents := `package main
-
-import rego.v1
-allow := true
-`
-
-	files := map[string]string{
-		childDirName + mainRegoFileName: mainRegoContents,
-		".regal/config.yaml": `rules:
-  idiomatic:
-    directory-package-mismatch:
-      level: ignore
-  style:
-    opa-fmt:
-      level: error
-`,
-	}
-
-	for f, fc := range files {
-		if err := os.WriteFile(filepath.Join(parentDir, f), []byte(fc), 0o600); err != nil {
-			t.Fatalf("failed to write file %s: %s", f, err)
-		}
-	}
-
-	// mainRegoFileURI is used throughout the test to refer to the main.rego file
-	// and so it is defined here for convenience
-	mainRegoFileURI := fileURIScheme + childDir + mainRegoFileName
-
-	// set up the server and client connections
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	ls := NewLanguageServer(&LanguageServerOptions{
-		ErrorLog: newTestLogger(t),
-	})
-	go ls.StartDiagnosticsWorker(ctx)
-	go ls.StartConfigWorker(ctx)
-
-	receivedMessages := make(chan types.FileDiagnostics, defaultBufferedChannelSize)
-	clientHandler := func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
-		if req.Method == methodTextDocumentPublishDiagnostics {
-			var requestData types.FileDiagnostics
-
-			if err2 := encoding.JSON().Unmarshal(*req.Params, &requestData); err2 != nil {
-				t.Fatalf("failed to unmarshal diagnostics: %s", err2)
-			}
-
-			receivedMessages <- requestData
-
-			return struct{}{}, nil
-		}
-
-		t.Logf("unexpected request from server: %v", req)
-
-		return struct{}{}, nil
-	}
-
-	connServer, connClient := createConnections(ctx, ls.Handle, clientHandler)
-
-	ls.SetConn(connServer)
-
-	// Client sends initialize request
-	request := types.InitializeParams{
-		RootURI:    fileURIScheme + childDir,
-		ClientInfo: types.Client{Name: "go test"},
-	}
-
-	var response types.InitializeResult
-
-	if err := connClient.Call(ctx, "initialize", request, &response); err != nil {
-		t.Fatalf("failed to send initialize request: %s", err)
-	}
-
-	if ls.workspaceRootURI != request.RootURI {
-		t.Fatalf("expected client root URI to be %s, got %s", request.RootURI, ls.workspaceRootURI)
-	}
-
-	// Client sends initialized notification
-	// the response to the call is expected to be empty and is ignored
-	if err := connClient.Call(ctx, "initialized", struct{}{}, nil); err != nil {
-		t.Fatalf("failed to send initialized notification: %s", err)
-	}
-
-	timeout := time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-receivedMessages:
-			success = testRequestDataCodes(t, requestData, mainRegoFileURI, []string{"opa-fmt"})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-
-	// User updates config file contents in parent directory that is not
-	// part of the workspace
-	newConfigContents := `rules:
-  idiomatic:
-    directory-package-mismatch:
-      level: ignore
-  style:
-    opa-fmt:
-      level: ignore
-`
-
-	path := filepath.Join(parentDir, ".regal/config.yaml")
-	if err := os.WriteFile(path, []byte(newConfigContents), 0o600); err != nil {
-		t.Fatalf("failed to write new config file: %s", err)
-	}
-
-	// validate that the client received a new, empty diagnostics notification for the file
-	timeout = time.NewTimer(defaultTimeout)
-	defer timeout.Stop()
-
-	for {
-		var success bool
-		select {
-		case requestData := <-receivedMessages:
-			success = testRequestDataCodes(t, requestData, mainRegoFileURI, []string{})
-		case <-timeout.C:
-			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
-		}
-	}
-}
-
-func TestLanguageServerFixRenameParams(t *testing.T) {
-	t.Parallel()
-
-	tmpDir := t.TempDir()
-
-	if err := os.MkdirAll(filepath.Join(tmpDir, "workspace/foo/bar"), 0o755); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-
-	l := NewLanguageServer(&LanguageServerOptions{ErrorLog: newTestLogger(t)})
-	c := cache.NewCache()
-	f := &fixes.DirectoryPackageMismatch{}
-
-	fileURL := fmt.Sprintf("file://%s/workspace/foo/bar/policy.rego", tmpDir)
-
-	c.SetFileContents(fileURL, "package authz.main.rules")
-
-	l.clientIdentifier = clients.IdentifierVSCode
-	l.workspaceRootURI = fmt.Sprintf("file://%s/workspace", tmpDir)
-	l.cache = c
-	l.loadedConfig = &config.Config{
-		Rules: map[string]config.Category{
-			"idiomatic": {
-				"directory-package-mismatch": config.Rule{
-					Level: "ignore",
-					Extra: map[string]any{
-						"exclude-test-suffix": true,
-					},
-				},
-			},
-		},
-	}
-
-	params, err := l.fixRenameParams("fix my file!", f, fileURL)
-	if err != nil {
-		t.Fatalf("failed to fix rename params: %s", err)
-	}
-
-	if params.Label != "fix my file!" {
-		t.Fatalf("expected label to be 'Fix my file!', got %s", params.Label)
-	}
-
-	if len(params.Edit.DocumentChanges) != 1 {
-		t.Fatalf("expected 1 document change, got %d", len(params.Edit.DocumentChanges))
-	}
-
-	change := params.Edit.DocumentChanges[0]
-
-	if change.Kind != "rename" {
-		t.Fatalf("expected kind to be 'rename', got %s", change.Kind)
-	}
-
-	if change.OldURI != fileURL {
-		t.Fatalf("expected old URI to be %s, got %s", fileURL, change.OldURI)
-	}
-
-	expectedNewURI := fmt.Sprintf("file://%s/workspace/authz/main/rules/policy.rego", tmpDir)
-
-	if change.NewURI != expectedNewURI {
-		t.Fatalf("expected new URI to be %s, got %s", expectedNewURI, change.NewURI)
-	}
-}
-
-func testRequestDataCodes(t *testing.T, requestData types.FileDiagnostics, fileURI string, codes []string) bool {
-	t.Helper()
-
-	if requestData.URI != fileURI {
-		t.Log("expected diagnostics to be sent for", fileURI, "got", requestData.URI)
-
-		return false
-	}
-
-	// Extract the codes from requestData.Items
-	requestCodes := make([]string, len(requestData.Items))
-	for i, item := range requestData.Items {
-		requestCodes[i] = item.Code
-	}
-
-	// Sort both slices
-	sort.Strings(requestCodes)
-	sort.Strings(codes)
-
-	if !slices.Equal(requestCodes, codes) {
-		t.Logf("waiting for items: %v, got: %v", codes, requestCodes)
-
-		return false
-	}
-
-	t.Logf("got expected items")
-
-	return true
-}
-
-func createConnections(
-	ctx context.Context,
-	serverHandler, clientHandler func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error),
-) (*jsonrpc2.Conn, *jsonrpc2.Conn) {
-	netConnServer, netConnClient := net.Pipe()
-
-	connServer := jsonrpc2.NewConn(
-		ctx,
-		jsonrpc2.NewBufferedStream(netConnServer, jsonrpc2.VSCodeObjectCodec{}),
-		jsonrpc2.HandlerWithError(serverHandler),
-	)
-
-	connClient := jsonrpc2.NewConn(
-		ctx,
-		jsonrpc2.NewBufferedStream(netConnClient, jsonrpc2.VSCodeObjectCodec{}),
-		jsonrpc2.HandlerWithError(clientHandler),
-	)
-
-	go func() {
-		<-ctx.Done()
-		// we need only close the pipe connections as the jsonrpc2.Conn accept
-		// the ctx
-		_ = netConnClient.Close()
-		_ = netConnServer.Close()
-	}()
-
-	return connServer, connClient
-}
 
 // NewTestLogger returns an io.Writer that logs to the given testing.T.
 // This is helpful as it can be used to have the server log to the test logger
@@ -1065,4 +68,113 @@ func (tl *testLogger) Write(p []byte) (n int, err error) {
 	tl.t.Log(strings.TrimSpace(string(p)))
 
 	return len(p), nil
+}
+
+func createAndInitServer(
+	ctx context.Context,
+	logger io.Writer,
+	tempDir string,
+	files map[string]string,
+	clientHandler func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error),
+) (
+	*LanguageServer,
+	*jsonrpc2.Conn,
+	error,
+) {
+	var err error
+
+	for f, fc := range files {
+		err = os.MkdirAll(filepath.Dir(filepath.Join(tempDir, f)), 0o755)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		err = os.WriteFile(filepath.Join(tempDir, f), []byte(fc), 0o600)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to write file: %w", err)
+		}
+	}
+
+	// set up the server and client connections
+	ls := NewLanguageServer(ctx, &LanguageServerOptions{
+		ErrorLog: logger,
+	})
+
+	go ls.StartDiagnosticsWorker(ctx)
+	go ls.StartConfigWorker(ctx)
+
+	netConnServer, netConnClient := net.Pipe()
+
+	connServer := jsonrpc2.NewConn(
+		ctx,
+		jsonrpc2.NewBufferedStream(netConnServer, jsonrpc2.VSCodeObjectCodec{}),
+		jsonrpc2.HandlerWithError(ls.Handle),
+	)
+
+	connClient := jsonrpc2.NewConn(
+		ctx,
+		jsonrpc2.NewBufferedStream(netConnClient, jsonrpc2.VSCodeObjectCodec{}),
+		jsonrpc2.HandlerWithError(clientHandler),
+	)
+
+	go func() {
+		<-ctx.Done()
+		// we need only close the pipe connections as the jsonrpc2.Conn accept
+		// the ctx
+		_ = netConnClient.Close()
+		_ = netConnServer.Close()
+	}()
+
+	ls.SetConn(connServer)
+
+	request := types.InitializeParams{
+		RootURI:    fileURIScheme + tempDir,
+		ClientInfo: types.Client{Name: "go test"},
+	}
+
+	var response types.InitializeResult
+
+	err = connClient.Call(ctx, "initialize", request, &response)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize %w", err)
+	}
+
+	// 2. Client sends initialized notification
+	// no response to the call is expected
+	err = connClient.Call(ctx, "initialized", struct{}{}, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to complete initialized %w", err)
+	}
+
+	return ls, connClient, nil
+}
+
+func testRequestDataCodes(t *testing.T, requestData types.FileDiagnostics, fileURI string, codes []string) bool {
+	t.Helper()
+
+	if requestData.URI != fileURI {
+		t.Log("expected diagnostics to be sent for", fileURI, "got", requestData.URI)
+
+		return false
+	}
+
+	// Extract the codes from requestData.Items
+	requestCodes := make([]string, len(requestData.Items))
+	for i, item := range requestData.Items {
+		requestCodes[i] = item.Code
+	}
+
+	// Sort both slices
+	sort.Strings(requestCodes)
+	sort.Strings(codes)
+
+	if !slices.Equal(requestCodes, codes) {
+		t.Logf("waiting for items: %v, got: %v", codes, requestCodes)
+
+		return false
+	}
+
+	t.Logf("got expected items")
+
+	return true
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"embed"
 	"path/filepath"
+	"slices"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/topdown"
@@ -14,6 +17,7 @@ import (
 	"github.com/styrainc/regal/internal/test"
 	"github.com/styrainc/regal/internal/testutil"
 	"github.com/styrainc/regal/pkg/config"
+	"github.com/styrainc/regal/pkg/report"
 	"github.com/styrainc/regal/pkg/rules"
 )
 
@@ -597,7 +601,79 @@ func TestEnabledRules(t *testing.T) {
 	}
 }
 
-func TestLintWithAlwaysAggregate(t *testing.T) {
+func TestEnabledRulesWithConfig(t *testing.T) {
+	t.Parallel()
+
+	configFileBs := []byte(`
+rules:
+  style:
+    opa-fmt:
+      level: ignore # go rule
+  imports:
+    unresolved-import: # agg rule
+      level: ignore
+  idiomatic:
+    directory-package-mismatch: # non agg rule
+      level: ignore
+`)
+
+	var userConfig config.Config
+
+	if err := yaml.Unmarshal(configFileBs, &userConfig); err != nil {
+		t.Fatalf("failed to load config: %s", err)
+	}
+
+	linter := NewLinter().WithUserConfig(userConfig)
+
+	enabledRules, err := linter.DetermineEnabledRules(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	enabledAggRules, err := linter.DetermineEnabledAggregateRules(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(enabledRules) == 0 {
+		t.Fatalf("expected enabledRules, got none")
+	}
+
+	if slices.Contains(enabledRules, "directory-package-mismatch") {
+		t.Errorf("did not expect directory-package-mismatch to be in enabled rules")
+	}
+
+	if slices.Contains(enabledRules, "opa-fmt") {
+		t.Errorf("did not expect opa-fmt to be in enabled rules")
+	}
+
+	if slices.Contains(enabledAggRules, "unresolved-import") {
+		t.Errorf("did not expect unresolved-import to be in enabled aggregate rules")
+	}
+}
+
+func TestEnabledAggregateRules(t *testing.T) {
+	t.Parallel()
+
+	linter := NewLinter().
+		WithDisableAll(true).
+		WithEnabledRules("opa-fmt", "unresolved-import", "use-assignment-operator")
+
+	enabledRules, err := linter.DetermineEnabledAggregateRules(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if len(enabledRules) != 1 {
+		t.Fatalf("expected 1 enabled rules, got %d", len(enabledRules))
+	}
+
+	if enabledRules[0] != "unresolved-import" {
+		t.Errorf("expected first enabled rule to be 'unresolved-import', got %q", enabledRules[0])
+	}
+}
+
+func TestLintWithCollectQuery(t *testing.T) {
 	t.Parallel()
 
 	input := test.InputPolicy("p.rego", `package p
@@ -608,7 +684,7 @@ import data.foo.bar.unresolved
 	linter := NewLinter().
 		WithDisableAll(true).
 		WithEnabledRules("unresolved-import").
-		WithAlwaysAggregate(true).  // needed since we have a single file input
+		WithCollectQuery(true).     // needed since we have a single file input
 		WithExportAggregates(true). // needed to be able to test the aggregates are set
 		WithInputModules(&input)
 
@@ -623,40 +699,64 @@ import data.foo.bar.unresolved
 	}
 }
 
-func TestLintWithAlwaysAggregateAndAggregates(t *testing.T) {
+func TestLintWithCollectQueryAndAggregates(t *testing.T) {
 	t.Parallel()
 
-	contents := `package p
+	files := map[string]string{
+		"foo.rego": `package foo
 
-import data.foo.bar.unresolved
-`
+import data.unresolved`,
+		"bar.rego": `package foo
 
-	input := test.InputPolicy("p.rego", contents)
+import data.unresolved`,
+		"baz.rego": `package foo
+
+import data.unresolved`,
+	}
+
+	allAggregates := make(map[string][]report.Aggregate)
+
+	for file, content := range files {
+		input := test.InputPolicy(file, content)
+
+		linter := NewLinter().
+			WithDisableAll(true).
+			WithEnabledRules("unresolved-import").
+			WithCollectQuery(true). // runs collect for a single file input
+			WithExportAggregates(true).
+			WithInputModules(&input)
+
+		result := testutil.Must(linter.Lint(context.Background()))(t)
+
+		for k, aggs := range result.Aggregates {
+			allAggregates[k] = append(allAggregates[k], aggs...)
+		}
+	}
 
 	linter := NewLinter().
 		WithDisableAll(true).
 		WithEnabledRules("unresolved-import").
-		WithAlwaysAggregate(true).
-		WithExportAggregates(true).
-		WithInputModules(&input)
+		WithAggregates(allAggregates)
 
-	result1 := testutil.Must(linter.Lint(context.Background()))(t)
+	result := testutil.Must(linter.Lint(context.Background()))(t)
 
-	linter2 := NewLinter().
-		WithDisableAll(true).
-		WithEnabledRules("unresolved-import").
-		WithAggregates(result1.Aggregates).
-		WithInputModules(&input)
-
-	result := testutil.Must(linter2.Lint(context.Background()))(t)
-
-	if len(result.Violations) != 1 {
+	if len(result.Violations) != 3 {
 		t.Fatalf("expected one violation, got %d", len(result.Violations))
 	}
 
-	violation := result.Violations[0]
+	foundFiles := []string{}
 
-	if violation.Title != "unresolved-import" {
-		t.Errorf("expected violation to be 'unresolved-import', got %q", violation.Title)
+	for _, v := range result.Violations {
+		if v.Title != "unresolved-import" {
+			t.Errorf("unexpected title: %s", v.Title)
+		}
+
+		foundFiles = append(foundFiles, v.Location.File)
+	}
+
+	slices.Sort(foundFiles)
+
+	if exp, got := []string{"bar.rego", "baz.rego", "foo.rego"}, foundFiles; !slices.Equal(exp, got) {
+		t.Fatalf("unexpected files: %v", got)
 	}
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"embed"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -598,7 +597,7 @@ func TestEnabledRules(t *testing.T) {
 	}
 }
 
-func TestLintWithPopulateAggregates(t *testing.T) {
+func TestLintWithAlwaysAggregate(t *testing.T) {
 	t.Parallel()
 
 	input := test.InputPolicy("p.rego", `package p
@@ -609,8 +608,8 @@ import data.foo.bar.unresolved
 	linter := NewLinter().
 		WithDisableAll(true).
 		WithEnabledRules("unresolved-import").
-		WithPrintHook(topdown.NewPrintHook(os.Stderr)).
-		WithAlwaysAggregate(true).
+		WithAlwaysAggregate(true).  // needed since we have a single file input
+		WithExportAggregates(true). // needed to be able to test the aggregates are set
 		WithInputModules(&input)
 
 	result := testutil.Must(linter.Lint(context.Background()))(t)
@@ -624,7 +623,7 @@ import data.foo.bar.unresolved
 	}
 }
 
-func TestLintWithAggregates(t *testing.T) {
+func TestLintWithAlwaysAggregateAndAggregates(t *testing.T) {
 	t.Parallel()
 
 	contents := `package p
@@ -637,8 +636,8 @@ import data.foo.bar.unresolved
 	linter := NewLinter().
 		WithDisableAll(true).
 		WithEnabledRules("unresolved-import").
-		WithPrintHook(topdown.NewPrintHook(os.Stderr)).
 		WithAlwaysAggregate(true).
+		WithExportAggregates(true).
 		WithInputModules(&input)
 
 	result1 := testutil.Must(linter.Lint(context.Background()))(t)
@@ -646,7 +645,6 @@ import data.foo.bar.unresolved
 	linter2 := NewLinter().
 		WithDisableAll(true).
 		WithEnabledRules("unresolved-import").
-		WithPrintHook(topdown.NewPrintHook(os.Stderr)).
 		WithAggregates(result1.Aggregates).
 		WithInputModules(&input)
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -61,6 +61,42 @@ type Notice struct {
 // while working with large Rego code repositories.
 type Aggregate map[string]any
 
+func (a Aggregate) SourceFile() string {
+	source, ok := a["aggregate_source"].(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	file, ok := source["file"].(string)
+	if !ok {
+		return ""
+	}
+
+	return file
+}
+
+// IndexKey is the category/title of the rule that generated the aggregate.
+// This key is generated in Rego during linting, this function replicates the
+// functionality in Go for use in the cache when indexing aggregates.
+func (a Aggregate) IndexKey() string {
+	rule, ok := a["rule"].(map[string]any)
+	if !ok {
+		return ""
+	}
+
+	cat, ok := rule["category"].(string)
+	if !ok {
+		return ""
+	}
+
+	title, ok := rule["title"].(string)
+	if !ok {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/%s", cat, title)
+}
+
 type Summary struct {
 	FilesScanned  int `json:"files_scanned"`
 	FilesFailed   int `json:"files_failed"`


### PR DESCRIPTION
Fixes to https://github.com/StyraInc/regal/issues/1133

This PR is a large refactoring of the language server diagnostics loops. Changes:

- when the contents of a file with aggregate violations changes, this no longer triggers a full workspace lint
- when the contents of any file changes, the aggregate rule state is now cached on the server and the results of this update, in addition to the full global state, is used to perform a linting run of all files but only linting for aggregate rules.
- new tests have been added to cover this functionality and the underlying functionality which these server changes depend on in the linter.
- server tests moved to new files since they are very long.
- increased timeouts for go test when running in go test -race https://go.dev/doc/articles/race_detector#Runtime_Overheads
- updated the cache to allow partial updating of diagnostics based on the relevant rules.