### PR TITLE
fix: fix var name for commit hash used for `version` subcommand

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -11,7 +11,7 @@ var Version = ""
 
 // Additional Regal metadata to be injected at build time.
 var (
-	Vcs       = ""
+	Commit    = ""
 	Timestamp = ""
 	Hostname  = ""
 )
@@ -54,7 +54,7 @@ func New() Info {
 		Version:   unknownString(Version),
 		GoVersion: goVersion,
 		Platform:  platform,
-		Commit:    unknownString(Vcs),
+		Commit:    unknownString(Commit),
 		Timestamp: unknownString(Timestamp),
 		Hostname:  unknownString(Hostname),
 	}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->

I found that `regal version` subcommand does not show commit hash.

```bash
❯ ./regal version             
Version:    0.27.0
Go Version: go1.22.5
Platform:   linux/amd64
Commit:     unknown
Timestamp:  2024-09-17T15:00:44Z
Hostname:   github.actions.local
```

This is because the build time information is passed to `pkg/version.Commit` variable, but it does not exist there.
https://github.com/StyraInc/regal/blob/e205cd9e4a9f27c52d7d0a6e7ac250c12113def8/.goreleaser.yaml#L24

I fixed this problem by renaming `pkg/version.Vcs` to `pkg/version.Commit`.

```bash
❯ go build -ldflags='-X github.com/styrainc/regal/pkg/version.Commit=my-commit'

❯ ./regal version
Version:    unknown
Go Version: go1.22.7
Platform:   linux/amd64
Commit:     my-commit
Timestamp:  unknown
Hostname:   unknown

```