### PR TITLE
Adapt to new location format

### DIFF
--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -133,17 +133,17 @@ allow := true
 `
 
 	module := regal.parse_module("p.rego", policy)
-	blocks := ast.comment_blocks(module.comments)
+	blocks := ast.comment_blocks(module.comments) with input as module
 	blocks == [
 		[
-			{"location": "3:1:IyBNRVRBREFUQQojIHRpdGxlOiBmb28KIyBiYXI6IGludmFsaWQ=", "text": "IE1FVEFEQVRB"},
-			{"location": "4:1:IyB0aXRsZTogZm9v", "text": "IHRpdGxlOiBmb28="},
-			{"location": "5:1:IyBiYXI6IGludmFsaWQ=", "text": "IGJhcjogaW52YWxpZA=="},
+			{"location": "3:1:5:15", "text": "IE1FVEFEQVRB"},
+			{"location": "4:1:4:13", "text": "IHRpdGxlOiBmb28="},
+			{"location": "5:1:5:15", "text": "IGJhcjogaW52YWxpZA=="},
 		],
-		[{"location": "8:1:IyBub3QgbWV0YWRhdGE=", "text": "IG5vdCBtZXRhZGF0YQ=="}],
+		[{"location": "8:1:8:15", "text": "IG5vdCBtZXRhZGF0YQ=="}],
 		[
-			{"location": "10:1:IyBhbm90aGVy", "text": "IGFub3RoZXI="},
-			{"location": "11:1:IyBibG9jaw==", "text": "IGJsb2Nr"},
+			{"location": "10:1:10:10", "text": "IGFub3RoZXI="},
+			{"location": "11:1:11:8", "text": "IGJsb2Nr"},
 		],
 	]
 }

--- a/bundle/regal/ast/keywords_test.rego
+++ b/bundle/regal/ast/keywords_test.rego
@@ -133,13 +133,13 @@ test_keywords_some_no_body if {
 	_keyword_on_row(
 		kwds,
 		6,
-		{"name": "some", "location": {"row": 6, "col": 2}},
+		{"name": "some", "location": {"row": 6, "col": 2, "end": {"col": 6, "row": 6}, "text": "some"}},
 	)
 
 	_keyword_on_row(
 		kwds,
 		6,
-		{"name": "in", "location": {"row": 6, "col": 9}},
+		{"name": "in", "location": {"row": 6, "col": 9, "end": {"col": 11, "row": 6}, "text": "in"}},
 	)
 }
 
@@ -193,7 +193,6 @@ test_keywords_every if {
 allow if {
 	every k in [1,2,3] {
 		k == "foo"
-		v == 1
 	}
 }`)
 
@@ -204,13 +203,13 @@ allow if {
 	_keyword_on_row(
 		kwds,
 		7,
-		{"name": "every", "location": {"row": 7, "col": 2}},
+		{"name": "every", "location": {"row": 7, "col": 2, "end": {"col": 7, "row": 7}}},
 	)
 
 	_keyword_on_row(
 		kwds,
 		7,
-		{"name": "in", "location": {"row": 7, "col": 10}},
+		{"name": "in", "location": {"row": 7, "col": 10, "end": {"col": 12, "row": 7}}},
 	)
 }
 

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -255,7 +255,7 @@ find_vars_in_local_scope(rule, location) := [var |
 
 _end_location(location) := end if {
 	loc := util.to_location_object(location)
-	lines := split(base64.decode(loc.text), "\n")
+	lines := split(loc.text, "\n")
 	end := {
 		"row": (loc.row + count(lines)) - 1,
 		"col": loc.col + count(regal.last(lines)),

--- a/bundle/regal/lsp/codelens/codelens.rego
+++ b/bundle/regal/lsp/codelens/codelens.rego
@@ -23,7 +23,7 @@ lenses := array.concat(
 )
 
 _eval_lenses contains {
-	"range": location.to_range(result.ranged_location_from_text(input["package"]).location),
+	"range": location.to_range(result.location(input["package"]).location),
 	"command": {
 		"title": "Evaluate",
 		"command": "regal.eval",
@@ -40,7 +40,7 @@ _eval_lenses contains _rule_lens(rule, "regal.eval", "Evaluate") if {
 }
 
 _debug_lenses contains {
-	"range": location.to_range(result.ranged_location_from_text(input["package"]).location),
+	"range": location.to_range(result.location(input["package"]).location),
 	"command": {
 		"title": "Debug",
 		"command": "regal.debug",
@@ -60,7 +60,7 @@ _debug_lenses contains _rule_lens(rule, "regal.debug", "Debug") if {
 }
 
 _rule_lens(rule, command, title) := {
-	"range": location.to_range(result.ranged_location_from_text(rule).location),
+	"range": location.to_range(result.location(rule).location),
 	"command": {
 		"title": title,
 		"command": command,

--- a/bundle/regal/lsp/completion/location/location.rego
+++ b/bundle/regal/lsp/completion/location/location.rego
@@ -45,7 +45,7 @@ from_start_of_line_to_position(position) := {
 #   estimate where the location "ends" based on its text attribute,
 #   both line and column
 end_location_estimate(location) := end if {
-	lines := split(base64.decode(location.text), "\n")
+	lines := split(location.text, "\n")
 	end := {
 		"row": (location.row + count(lines)) - 1,
 		"col": count(regal.last(lines)),
@@ -71,7 +71,10 @@ find_rule(rules, location) := [rule |
 #   find local variables (declared via function arguments, some/every
 #   declarations or assignment) at the given location. note that this expects
 #   `location` as a map, not a string
-find_locals(rules, location) := ast.find_names_in_local_scope(find_rule(rules, location), location)
+find_locals(rules, location) := tmp if {
+	rul := find_rule(rules, location)
+	tmp := ast.find_names_in_local_scope(rul, location)
+}
 
 # METADATA
 # description: |

--- a/bundle/regal/lsp/completion/location/location_test.rego
+++ b/bundle/regal/lsp/completion/location/location_test.rego
@@ -6,8 +6,9 @@ import data.regal.ast
 
 import data.regal.lsp.completion.location
 
+# regal ignore:rule-length
 test_find_rule_from_location if {
-	module := regal.parse_module("p.rego", `package p
+	policy := `package p
 
 import rego.v1
 
@@ -22,21 +23,27 @@ rule2 if {
 rule3 if {
 	z := 3
 }
-`)
-	not location.find_rule(module.rules, {"row": 2, "col": 6})
+`
+	lines := split(policy, "\n")
 
-	r1 := location.find_rule(module.rules, {"row": 5, "col": 6})
+	module := regal.parse_module("p.rego", policy)
+
+	not location.find_rule(module.rules, {"row": 2, "col": 6}) with input.regal.file.lines as lines
+
+	r1 := location.find_rule(module.rules, {"row": 5, "col": 6}) with input.regal.file.lines as lines
+
 	ast.ref_to_string(r1.head.ref) == "rule1"
 
-	r2 := location.find_rule(module.rules, {"row": 9, "col": 11})
+	r2 := location.find_rule(module.rules, {"row": 9, "col": 11}) with input.regal.file.lines as lines
 	ast.ref_to_string(r2.head.ref) == "rule2"
 
-	r3 := location.find_rule(module.rules, {"row": 15, "col": 0})
+	r3 := location.find_rule(module.rules, {"row": 15, "col": 0}) with input.regal.file.lines as lines
 	ast.ref_to_string(r3.head.ref) == "rule3"
 }
 
+# regal ignore:rule-length
 test_find_locals_at_location if {
-	module := regal.parse_module("p.rego", `package p
+	policy := `package p
 
 import rego.v1
 
@@ -52,12 +59,31 @@ another if {
 	some x, y in collection
 	z := x + y
 }
-`)
+`
+	module := regal.parse_module("p.rego", policy)
+	lines := split(policy, "\n")
 
-	location.find_locals(module.rules, {"row": 6, "col": 1}) with input as module == set()
-	location.find_locals(module.rules, {"row": 6, "col": 10}) with input as module == {"x"}
-	location.find_locals(module.rules, {"row": 10, "col": 1}) with input as module == {"a", "b"}
-	location.find_locals(module.rules, {"row": 10, "col": 6}) with input as module == {"a", "b", "c"}
-	location.find_locals(module.rules, {"row": 15, "col": 1}) with input as module == {"x", "y"}
-	location.find_locals(module.rules, {"row": 16, "col": 1}) with input as module == {"x", "y", "z"}
+	r1 := location.find_locals(module.rules, {"row": 6, "col": 1}) with input as module
+		with input.regal.file.lines as lines
+	r1 == set()
+
+	r2 := location.find_locals(module.rules, {"row": 6, "col": 10}) with input as module
+		with input.regal.file.lines as lines
+	r2 == {"x"}
+
+	r3 := location.find_locals(module.rules, {"row": 10, "col": 1}) with input as module
+		with input.regal.file.lines as lines
+	r3 == {"a", "b"}
+
+	r4 := location.find_locals(module.rules, {"row": 10, "col": 6}) with input as module
+		with input.regal.file.lines as lines
+	r4 == {"a", "b", "c"}
+
+	r5 := location.find_locals(module.rules, {"row": 15, "col": 1}) with input as module
+		with input.regal.file.lines as lines
+	r5 == {"x", "y"}
+
+	r6 := location.find_locals(module.rules, {"row": 16, "col": 1}) with input as module
+		with input.regal.file.lines as lines
+	r6 == {"x", "y", "z"}
 }

--- a/bundle/regal/lsp/util/location/location.rego
+++ b/bundle/regal/lsp/util/location/location.rego
@@ -5,7 +5,7 @@ package regal.lsp.util.location
 import rego.v1
 
 # METADATA
-# description: turns an AST location _with end attribute_ into an LSP range
+# description: turns an AST location (with `end`` attribute) into an LSP range
 to_range(location) := {
 	"start": {
 		"line": location.row - 1,

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -247,45 +247,14 @@ test_camelcase if {
 
 # regal ignore:rule-length
 test_main_lint if {
-	ast := {
-		"package": {
-			"location": "1:1:cGFja2FnZQ==",
-			"path": [
-				{"location": "1:9:cA==", "type": "var", "value": "data"},
-				{"location": "1:9:cA==", "type": "string", "value": "p"},
-			],
-		},
-		"rules": [{
-			"location": "3:1:eCA9IDE=",
-			"head": {
-				"name": "x",
-				"ref": [{"location": "3:1:eA==", "type": "var", "value": "x"}],
-				"value": {
-					"value": 1,
-					"location": "3:5:MQ==",
-					"type": "number",
-				},
-				"location": "3:1:eCA9IDE=",
-			},
-		}],
-		"regal": {
-			"file": {
-				"name": "p.rego",
-				"lines": [
-					"package p",
-					"",
-					"x = 1",
-					"",
-				],
-				"abs": "/regal/p.rego",
-			},
-			"environment": {"path_separator": "/"},
-		},
-	}
+	policy := `package p
+	x = 1`
+
+	module := regal.parse_module("p.rego", policy)
 
 	cfg := {"rules": {"style": {"use-assignment-operator": {"level": "error"}}}}
 
-	result := main.lint with input as ast with config.merged_config as cfg
+	result := main.lint with input as module with config.merged_config as cfg
 
 	result == {
 		"aggregates": {},
@@ -296,10 +265,14 @@ test_main_lint if {
 			"description": "Prefer := over = for assignment",
 			"level": "error",
 			"location": {
-				"col": 3,
+				"col": 4,
 				"file": "p.rego",
-				"row": 3,
-				"text": "x = 1",
+				"row": 2,
+				"end": {
+					"col": 5,
+					"row": 2,
+				},
+				"text": "\tx = 1",
 			},
 			"related_resources": [{
 				"description": "documentation",

--- a/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata_test.rego
+++ b/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata_test.rego
@@ -12,13 +12,22 @@ test_fail_annotation_without_metadata if {
 # title: allow
 allow := false
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "bugs",
 		"description": "Annotation without metadata",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 6, "text": "# title: allow"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 15,
+				"row": 6,
+			},
+			"text": "# title: allow",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/annotation-without-metadata", "bugs"),
@@ -33,8 +42,8 @@ test_success_annotation_with_metadata if {
 # title: allow
 allow := false
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -42,8 +51,8 @@ test_success_annotation_but_no_metadata_location if {
 	module := ast.with_rego_v1(`
 allow := false # title: allow
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -54,7 +63,7 @@ test_success_annotation_without_metadata_but_comment_preceding if {
 # title: allow
 allow := false
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
@@ -22,7 +22,7 @@ report contains violation if {
 
 	not _function_name_excepted(config.for_rule("bugs", "argument-always-wildcard"), name)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(fn.head.args[pos]))
+	violation := result.fail(rego.metadata.chain(), result.location(fn.head.args[pos]))
 }
 
 _function_groups[name] contains fn if {

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
@@ -30,7 +30,7 @@ report contains violation if {
 	# however meaningless it may be. Maybe consider for another rule?
 	expr.terms.type in ast.scalar_types
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr.terms))
+	violation := result.fail(rego.metadata.chain(), result.location(expr.terms))
 }
 
 # METADATA
@@ -45,5 +45,5 @@ report contains violation if {
 	expr.terms[1].type in ast.scalar_types
 	expr.terms[2].type in ast.scalar_types
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr))
+	violation := result.fail(rego.metadata.chain(), result.location(expr))
 }

--- a/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
+++ b/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
@@ -23,5 +23,5 @@ report contains violation if {
 
 	ast.ref_to_string(call.value) in deprecated_builtins
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(call))
+	violation := result.fail(rego.metadata.chain(), result.location(call))
 }

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule.rego
@@ -18,7 +18,7 @@ report contains violation if {
 	]
 
 	violation := result.fail(rego.metadata.chain(), object.union(
-		result.ranged_location_from_text(input.rules[first]),
+		result.location(input.rules[first]),
 		{"description": _message(dup_locations)},
 	))
 }
@@ -35,7 +35,7 @@ _message(locations) := sprintf(
 	count(locations) > 1
 }
 
-_rules_as_text := [base64.decode(util.to_location_object(rule.location).text) | some rule in input.rules]
+_rules_as_text := [util.to_location_object(rule.location).text | some rule in input.rules]
 
 _duplicates contains indices if {
 	# Remove whitespace from textual representation of rule and create a hash from the result.

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
@@ -17,13 +17,19 @@ test_fail_simple_duplicate_rule if {
 		input.foo
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "bugs",
 		"description": "Duplicate rule found at line 10",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 6, "text": "\tallow if {", "end": {"col": 4, "row": 8}},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 6,
+			"text": "\tallow if {",
+			"end": {"col": 3, "row": 8},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/duplicate-rule", "bugs"),
@@ -38,11 +44,12 @@ test_success_similar_but_not_duplicate_rule if {
 
 	allow if input.foo == "bar "
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
+# regal ignore:rule-length
 test_fail_multiple_duplicate_rules if {
 	module := ast.with_rego_v1(`
 
@@ -61,13 +68,22 @@ test_fail_multiple_duplicate_rules if {
 		  input.foo
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "bugs",
 		"description": "Duplicate rules found at lines 14, 18",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 10, "text": "\tallow if {", "end": {"col": 4, "row": 12}},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 10,
+			"text": "\tallow if {",
+			"end": {
+				"col": 3,
+				"row": 12,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/duplicate-rule", "bugs"),

--- a/bundle/regal/rules/bugs/if-empty-object/if_empty_object_test.rego
+++ b/bundle/regal/rules/bugs/if-empty-object/if_empty_object_test.rego
@@ -10,11 +10,21 @@ import data.regal.rules.bugs["if-empty-object"] as rule
 test_fail_if_empty_object if {
 	module := ast.with_rego_v1("rule if {}")
 	r := rule.report with input as module
+
 	r == {{
 		"category": "bugs",
 		"description": "Empty object following `if`",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": "rule if {}"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 5,
+			"text": "rule if {}",
+			"end": {
+				"col": 11,
+				"row": 5,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/if-empty-object", "bugs"),

--- a/bundle/regal/rules/bugs/if-object-literal/if_object_literal.rego
+++ b/bundle/regal/rules/bugs/if-object-literal/if_object_literal.rego
@@ -19,5 +19,5 @@ report contains violation if {
 	count(rule.body) == 1
 	rule.body[0].terms.type == "object"
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(rule.body[0].terms))
+	violation := result.fail(rego.metadata.chain(), result.location(rule.body[0].terms))
 }

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
@@ -46,8 +46,10 @@ _negated_refs contains negated_ref if {
 		some var in ast.find_vars_in_local_scope(rule, util.to_location_object(value.location))
 	}
 
+	term1 := object.union(ref[0], {"location": util.to_location_object(ref[0].location)})
+
 	negated_ref := {
-		"ref": ref,
+		"ref": array.concat([term1], util.rest(ref)),
 		"resolved_path": _resolve(ref, _package_path, ast.resolved_imports),
 	}
 }

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
@@ -22,9 +22,18 @@ test_fail_multivalue_not_reference_same_package if {
 		not partial
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
-	r == expected_with_location({"col": 7, "file": "p2.rego", "row": 6, "text": "not partial"})
+
+	r == expected_with_location({
+		"col": 7,
+		"file": "p2.rego",
+		"row": 6,
+		"end": {
+			"col": 14,
+			"row": 6,
+		},
+		"text": "not partial",
+	})
 }
 
 test_fail_multivalue_not_reference_different_package_using_direct_reference if {
@@ -43,11 +52,21 @@ test_fail_multivalue_not_reference_different_package_using_direct_reference if {
 		not data.foo.partial
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
-	r == expected_with_location({"col": 7, "file": "p2.rego", "row": 6, "text": "not data.foo.partial"})
+
+	r == expected_with_location({
+		"col": 7,
+		"file": "p2.rego",
+		"row": 6,
+		"end": {
+			"col": 11,
+			"row": 6,
+		},
+		"text": "not data.foo.partial",
+	})
 }
 
+# regal ignore:rule-length
 test_fail_multivalue_not_reference_different_package_using_import if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 
@@ -68,9 +87,18 @@ test_fail_multivalue_not_reference_different_package_using_import if {
 		not foo.partial
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
-	r == expected_with_location({"col": 7, "file": "p2.rego", "row": 8, "text": "not foo.partial"})
+
+	r == expected_with_location({
+		"col": 7,
+		"file": "p2.rego",
+		"row": 8,
+		"end": {
+			"col": 10,
+			"row": 8,
+		},
+		"text": "not foo.partial",
+	})
 }
 
 test_success_multivalue_not_reference_invalidated_by_local_var if {
@@ -92,8 +120,8 @@ test_success_multivalue_not_reference_invalidated_by_local_var if {
 		not foo.partial
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -115,8 +143,8 @@ test_success_multivalue_not_reference_invalidated_by_function_argument if {
 		not foo.partial
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -131,8 +159,8 @@ test_success_multivalue_not_reference_in_same_file_not_reported_in_aggregate_rep
 		not partial
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": agg1}
+
 	r == set()
 }
 
@@ -147,9 +175,17 @@ test_fail_multivalue_not_reference_in_same_file_reported_in_normal_report if {
 		not partial
 	}
 	`)
-
 	r := rule.report with input as module
-	r == expected_with_location({"col": 7, "file": "p1.rego", "row": 8, "text": "not partial"})
+
+	r == expected_with_location({
+		"col": 7,
+		"file": "p1.rego",
+		"end": {
+			"col": 14,
+			"row": 8,
+		},
+		"row": 8, "text": "not partial",
+	})
 }
 
 test_success_multivalue_ref_head_rule_not_accounted_for if {
@@ -165,8 +201,8 @@ test_success_multivalue_ref_head_rule_not_accounted_for if {
 		not partial
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": agg1}
+
 	r == set()
 }
 

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
@@ -15,12 +15,15 @@ test_fail_inconsistent_args if {
 	bar(b, a) if b > a
 	`)
 	r := rule.report with input as module
+
 	r == expected_with_location({
-		"col": 6,
-		"file": "policy.rego",
 		"row": 7,
+		"col": 6,
+		"end": {
+			"row": 7,
+			"col": 10,
+		},
 		"text": "\tfoo(b, a) if b > a",
-		"end": {"col": 10, "row": 7},
 	})
 }
 
@@ -32,10 +35,12 @@ test_fail_nested_inconsistent_args if {
 	r := rule.report with input as module
 	r == expected_with_location({
 		"col": 10,
-		"file": "policy.rego",
 		"row": 7,
 		"text": "\ta.b.foo(b, a) if b > a",
-		"end": {"col": 14, "row": 7},
+		"end": {
+			"col": 14,
+			"row": 7,
+		},
 	})
 }
 
@@ -50,6 +55,7 @@ test_success_not_inconsistent_args if {
 	qux(c, a) if c == a
 	`)
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -61,6 +67,7 @@ test_success_using_wildcard if {
 	qux(c, a) if c == a
 	`)
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -72,6 +79,7 @@ test_success_using_pattern_matching if {
 	qux(c, a) if c == a
 	`)
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -84,6 +92,7 @@ expected := {
 		"ref": config.docs.resolve_url("$baseUrl/$category/inconsistent-args", "bugs"),
 	}],
 	"title": "inconsistent-args",
+	"location": {"file": "policy.rego"},
 }
 
 # regal ignore:external-reference

--- a/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint.rego
+++ b/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint.rego
@@ -17,7 +17,7 @@ report contains violation if {
 
 	_any_internal(i, part)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(part))
+	violation := result.fail(rego.metadata.chain(), result.location(part))
 }
 
 _any_internal(0, part) if startswith(part.value, "_")

--- a/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute_test.rego
+++ b/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute_test.rego
@@ -13,11 +13,21 @@ test_fail_invalid_attribute if {
 # is_true: yes
 allow := true
 `)
+
 	r == {{
 		"category": "bugs",
 		"description": "Invalid attribute in metadata annotation",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 6, "text": "# is_true: yes"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 15,
+				"row": 6,
+			},
+			"text": "# is_true: yes",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/invalid-metadata-attribute", "bugs"),
@@ -33,5 +43,6 @@ test_success_valid_metadata if {
 # description: also valid
 allow := true
 `)
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
@@ -12,7 +12,7 @@ report contains violation if {
 
 	contains(ast.ref_to_string(ref.value), "._")
 
-	violation := result.fail(rego.metadata.chain(), result.location(ref))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(ref.value))
 }
 
 report contains violation if {
@@ -20,5 +20,5 @@ report contains violation if {
 
 	contains(ast.ref_to_string(imported.path.value), "._")
 
-	violation := result.fail(rego.metadata.chain(), result.location(imported.path.value))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(imported.path.value))
 }

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
@@ -9,29 +9,61 @@ import data.regal.rules.bugs["leaked-internal-reference"] as rule
 
 test_fail_leaked_internal_reference_in_import if {
 	r := rule.report with input as ast.with_rego_v1(`import data.foo._bar`)
-	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 5, "text": "import data.foo._bar"})
+
+	r == expected_with_location({
+		"col": 8,
+		"row": 5,
+		"end": {
+			"col": 21,
+			"row": 5,
+		},
+		"text": "import data.foo._bar",
+	})
 }
 
 test_fail_leaked_internal_reference_in_rule_head if {
 	r := rule.report with input as ast.with_rego_v1(`var := data.foo._bar`)
-	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 5, "text": "var := data.foo._bar"})
+
+	r == expected_with_location({
+		"col": 8,
+		"file": "policy.rego",
+		"row": 5,
+		"end": {
+			"col": 21,
+			"row": 5,
+		},
+		"text": "var := data.foo._bar",
+	})
 }
 
 test_fail_leaked_internal_reference_in_rule_body if {
 	r := rule.report with input as ast.with_rego_v1(`rule if {
 		x := data.foo._bar
 	}`)
-	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 6, "text": "\t\tx := data.foo._bar"})
+
+	r == expected_with_location({
+		"col": 8,
+		"row": 6,
+		"end": {
+			"col": 21,
+			"row": 6,
+		},
+		"text": "\t\tx := data.foo._bar",
+	})
 }
 
 test_fail_leaked_internal_reference_in_nested_comprehension if {
 	r := rule.report with input as ast.with_rego_v1(`rule if {
 		comp := [x | x := data.foo._bar]
 	}`)
+
 	r == expected_with_location({
 		"col": 21,
-		"file": "policy.rego",
 		"row": 6,
+		"end": {
+			"col": 34,
+			"row": 6,
+		},
 		"text": "\t\tcomp := [x | x := data.foo._bar]",
 	})
 }
@@ -45,6 +77,7 @@ expected := {
 		"ref": config.docs.resolve_url("$baseUrl/$category/leaked-internal-reference", "bugs"),
 	}],
 	"title": "leaked-internal-reference",
+	"location": {"file": "policy.rego"},
 }
 
 # regal ignore:external-reference

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
@@ -6,17 +6,28 @@ import data.regal.ast
 import data.regal.config
 import data.regal.rules.bugs["not-equals-in-loop"] as rule
 
+# regal ignore:rule-length
 test_fail_neq_in_loop if {
 	r := rule.report with input as ast.policy(`deny {
 		"admin" != input.user.groups[_]
 		input.user.groups[_] != "admin"
 	}`)
+
 	r == {
 		{
 			"category": "bugs",
 			"description": "Use of != in loop",
 			"level": "error",
-			"location": {"col": 11, "file": "policy.rego", "row": 4, "text": "\t\t\"admin\" != input.user.groups[_]"},
+			"location": {
+				"col": 11,
+				"file": "policy.rego",
+				"row": 4,
+				"end": {
+					"col": 13,
+					"row": 4,
+				},
+				"text": "\t\t\"admin\" != input.user.groups[_]",
+			},
 			"related_resources": [{
 				"description": "documentation",
 				"ref": config.docs.resolve_url("$baseUrl/$category/not-equals-in-loop", "bugs"),
@@ -27,7 +38,16 @@ test_fail_neq_in_loop if {
 			"category": "bugs",
 			"description": "Use of != in loop",
 			"level": "error",
-			"location": {"col": 24, "file": "policy.rego", "row": 5, "text": "\t\tinput.user.groups[_] != \"admin\""},
+			"location": {
+				"col": 24,
+				"file": "policy.rego",
+				"row": 5,
+				"end": {
+					"col": 26,
+					"row": 5,
+				},
+				"text": "\t\tinput.user.groups[_] != \"admin\"",
+			},
 			"related_resources": [{
 				"description": "documentation",
 				"ref": config.docs.resolve_url("$baseUrl/$category/not-equals-in-loop", "bugs"),
@@ -39,11 +59,21 @@ test_fail_neq_in_loop if {
 
 test_fail_neq_in_loop_one_liner if {
 	r := rule.report with input as ast.with_rego_v1(`deny if "admin" != input.user.groups[_]`)
+
 	r == {{
 		"category": "bugs",
 		"description": "Use of != in loop",
 		"level": "error",
-		"location": {"col": 17, "file": "policy.rego", "row": 5, "text": "deny if \"admin\" != input.user.groups[_]"},
+		"location": {
+			"col": 17,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 19,
+				"row": 5,
+			},
+			"text": "deny if \"admin\" != input.user.groups[_]",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/not-equals-in-loop", "bugs"),

--- a/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
+++ b/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
@@ -26,7 +26,7 @@ report contains violation if {
 
 	ast.ref_to_string(term.value) == ref_str
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(expr.terms.value))
 }
 
 # METADATA
@@ -43,5 +43,5 @@ report contains violation if {
 	expr.terms.type == "ref"
 	ast.ref_to_string(expr.terms.value) == ref_str
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr.terms))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(expr.terms.value))
 }

--- a/bundle/regal/rules/bugs/rule-named-if/rule_named_if_test.rego
+++ b/bundle/regal/rules/bugs/rule-named-if/rule_named_if_test.rego
@@ -11,11 +11,21 @@ test_fail_rule_named_if if {
 	allow := true if {
         input.foo
     }`)
+
 	r == {{
 		"category": "bugs",
 		"description": "Rule named \"if\"",
 		"level": "error",
-		"location": {"col": 16, "file": "policy.rego", "row": 4, "text": "\tallow := true if {"},
+		"location": {
+			"col": 16,
+			"file": "policy.rego",
+			"row": 4,
+			"end": {
+				"col": 18,
+				"row": 4,
+			},
+			"text": "\tallow := true if {",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/rule-named-if", "bugs"),

--- a/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
@@ -9,6 +9,7 @@ import data.regal.rules.bugs["rule-shadows-builtin"] as rule
 test_fail_rule_name_shadows_builtin if {
 	cfg := {"capabilities": {"builtins": {"or": {}}}}
 	r := rule.report with input as ast.policy(`or := 1`) with data.internal.combined_config as cfg
+
 	r == {{
 		"category": "bugs",
 		"description": "Rule name shadows built-in",
@@ -17,7 +18,16 @@ test_fail_rule_name_shadows_builtin if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/rule-shadows-builtin", "bugs"),
 		}],
 		"title": "rule-shadows-builtin",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "or := 1"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 8,
+				"row": 3,
+			},
+			"text": "or := 1",
+		},
 		"level": "error",
 	}}
 }
@@ -25,6 +35,7 @@ test_fail_rule_name_shadows_builtin if {
 test_fail_rule_name_shadows_builtin_namespace if {
 	cfg := {"capabilities": {"builtins": {"http.send": {}}}}
 	r := rule.report with input as ast.policy(`http := "yes"`) with data.internal.combined_config as cfg
+
 	r == {{
 		"category": "bugs",
 		"description": "Rule name shadows built-in",
@@ -33,12 +44,22 @@ test_fail_rule_name_shadows_builtin_namespace if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/rule-shadows-builtin", "bugs"),
 		}],
 		"title": "rule-shadows-builtin",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "http := \"yes\""},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 14,
+				"row": 3,
+			},
+			"text": "http := \"yes\"",
+		},
 		"level": "error",
 	}}
 }
 
 test_success_rule_name_does_not_shadows_builtin if {
 	r := rule.report with input as ast.policy(`foo := 1`)
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration_test.rego
+++ b/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration_test.rego
@@ -9,10 +9,20 @@ import data.regal.rules.bugs["top-level-iteration"] as rule
 
 test_fail_top_level_iteration_wildcard if {
 	r := rule.report with input as ast.with_rego_v1(`x := input.foo.bar[_]`)
+
 	r == {{
 		"category": "bugs",
 		"description": "Iteration in top-level assignment",
-		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": "x := input.foo.bar[_]"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 22,
+				"row": 5,
+			},
+			"text": "x := input.foo.bar[_]",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/top-level-iteration", "bugs"),
@@ -24,10 +34,20 @@ test_fail_top_level_iteration_wildcard if {
 
 test_fail_top_level_iteration_named_var if {
 	r := rule.report with input as ast.with_rego_v1(`x := input.foo.bar[i]`)
+
 	r == {{
 		"category": "bugs",
 		"description": "Iteration in top-level assignment",
-		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": "x := input.foo.bar[i]"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 22,
+				"row": 5,
+			},
+			"text": "x := input.foo.bar[i]",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/top-level-iteration", "bugs"),
@@ -41,33 +61,39 @@ test_success_top_level_known_var_ref if {
 	r := rule.report with input as ast.with_rego_v1(`
 	i := "foo"
 	x := input.foo.bar[i]`)
+
 	r == set()
 }
 
 # https://github.com/StyraInc/regal/issues/852
 test_success_top_level_ref_head_vars_assignment if {
 	r := rule.report with input as ast.with_rego_v1(`foo[x] := input[x] if some x in [1, 2, 3]`)
+
 	r == set()
 }
 
 # https://github.com/StyraInc/regal/issues/401
 test_success_top_level_input_assignment if {
 	r := rule.report with input as ast.with_rego_v1(`x := input`)
+
 	r == set()
 }
 
 test_success_top_level_input_ref if {
 	r := rule.report with input as ast.with_rego_v1(`x := input.foo.bar[input.y]`)
+
 	r == set()
 }
 
 test_success_top_level_const if {
 	r := rule.report with input as ast.with_rego_v1(`x := input.foo.bar[4]`)
+
 	r == set()
 }
 
 test_success_top_level_param if {
 	r := rule.report with input as ast.with_rego_v1(`x(y) := input.foo.bar[y]`)
+
 	r == set()
 }
 
@@ -76,5 +102,6 @@ test_success_top_level_import if {
 	import data.x
 
 	y := input[x]`)
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
@@ -12,11 +12,21 @@ test_fail_unused_return_value if {
 		indexof("s", "s")
 	}`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "bugs",
 		"description": "Non-boolean return value unassigned",
 		"level": "error",
-		"location": {"col": 3, "file": "policy.rego", "row": 6, "text": "\t\tindexof(\"s\", \"s\")"},
+		"location": {
+			"col": 3,
+			"row": 6,
+			"end": {
+				"col": 10,
+				"row": 6,
+			},
+			"file": "policy.rego",
+			"text": "\t\tindexof(\"s\", \"s\")",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/unassigned-return-value", "bugs"),

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
@@ -37,7 +37,7 @@ report contains violation if {
 	# so when all other conditions apply
 	ast.is_output_var(input.rules[to_number(rule_index)], var)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(var))
+	violation := result.fail(rego.metadata.chain(), result.location(var))
 }
 
 _ref_vars[rule_index][var.value] contains var if {

--- a/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
@@ -10,13 +10,22 @@ import data.regal.rules.bugs["var-shadows-builtin"] as rule
 
 test_fail_var_shadows_builtin if {
 	module := ast.with_rego_v1(`allow if http := "yes"`)
-
 	r := rule.report with input as module with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "bugs",
 		"description": "Variable name shadows built-in",
 		"level": "error",
-		"location": {"col": 10, "file": "policy.rego", "row": 5, "text": "allow if http := \"yes\""},
+		"location": {
+			"col": 10,
+			"row": 5,
+			"end": {
+				"col": 14,
+				"row": 5,
+			},
+			"file": "policy.rego",
+			"text": "allow if http := \"yes\"",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/var-shadows-builtin", "bugs"),

--- a/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function.rego
+++ b/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function.rego
@@ -11,11 +11,11 @@ import data.regal.util
 report contains violation if {
 	# notably, not ast.functions, as zero-arity functions are treated
 	# as regular rules (i.e. they have no `args` key in the head)
-	some rule in ast.rules
+	head := ast.rules[_].head
 
-	text := base64.decode(util.to_location_object(rule.location).text)
+	text := util.to_location_object(head.location).text
 
 	regex.match(`^[a-zA-z1-9_\.\[\]"]+\(\)`, text)
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(head.ref))
 }

--- a/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function_test.rego
+++ b/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function_test.rego
@@ -8,14 +8,22 @@ import data.regal.config
 import data.regal.rules.bugs["zero-arity-function"] as rule
 
 test_fail_zero_arity_function if {
-	module := ast.policy("f() := true")
+	r := rule.report with input as ast.policy("f() := true")
 
-	r := rule.report with input as module
 	r == {{
 		"category": "bugs",
 		"description": "Avoid functions without args",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "f() := true"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 2,
+				"row": 3,
+			},
+			"text": "f() := true",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/zero-arity-function", "bugs"),
@@ -25,14 +33,22 @@ test_fail_zero_arity_function if {
 }
 
 test_fail_zero_arity_nested_function if {
-	module := ast.policy("a.b.c() := true")
+	r := rule.report with input as ast.policy("a.b.c() := true")
 
-	r := rule.report with input as module
 	r == {{
 		"category": "bugs",
 		"description": "Avoid functions without args",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "a.b.c() := true"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 6,
+				"row": 3,
+			},
+			"text": "a.b.c() := true",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/zero-arity-function", "bugs"),

--- a/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call_test.rego
+++ b/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call_test.rego
@@ -24,6 +24,10 @@ test_fail_forbidden_function if {
 			"col": 8,
 			"file": "policy.rego",
 			"row": 3,
+			"end": {
+				"col": 17,
+				"row": 3,
+			},
 			"text": `foo := http.send({"method": "GET", "url": "https://example.com"})`,
 		},
 		"related_resources": [{

--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
@@ -23,12 +23,28 @@ none := false
 	aggregated == {{
 		"aggregate_data": {
 			"package_annotated": true,
-			"package_location": "3:1:cGFja2FnZQ==",
+			"package_location": {
+				"col": 1,
+				"row": 3,
+				"end": {
+					"col": 8,
+					"row": 3,
+				},
+				"text": "package",
+			},
 			"rule_annotations": {
 				"foo.bar.none": {false},
 				"foo.bar.rule": {true},
 			},
-			"rule_locations": {"foo.bar.none": "9:1:bm9uZSA6PSBmYWxzZQ=="},
+			"rule_locations": {"foo.bar.none": {
+				"col": 1,
+				"row": 9,
+				"end": {
+					"col": 14,
+					"row": 9,
+				},
+				"text": "none := false",
+			}},
 		},
 		"aggregate_source": {
 			"file": "p.rego",
@@ -57,6 +73,7 @@ test_fail_missing_package_metadata_report if {
 	module := regal.parse_module("p.rego", "package foo.bar")
 	aggregated := rule.aggregate with input as module
 	r := rule.aggregate_report with input.aggregate as aggregated
+
 	r == {{
 		"category": "custom",
 		"description": "Package or rule missing metadata",
@@ -64,6 +81,10 @@ test_fail_missing_package_metadata_report if {
 		"location": {
 			"col": 1,
 			"row": 1,
+			"end": {
+				"col": 8,
+				"row": 1,
+			},
 			"text": "package",
 			"file": "p.rego",
 		},
@@ -75,7 +96,6 @@ test_fail_missing_package_metadata_report if {
 	}}
 }
 
-# regal ignore:rule-length
 test_success_one_missing_one_found_package_metadata_report if {
 	module1 := regal.parse_module("p.rego", "package foo.bar")
 	module2 := regal.parse_module("p.rego", `# METADATA
@@ -113,7 +133,6 @@ package foo.bar
 
 baz := true
 `)
-
 	a := rule.aggregate with input as module
 	r := rule.aggregate_report with input.aggregate as a with config.for_rule as {"level": "error"}
 
@@ -125,6 +144,10 @@ baz := true
 			"col": 1,
 			"file": "p.rego",
 			"row": 5,
+			"end": {
+				"col": 12,
+				"row": 5,
+			},
 			"text": "baz := true",
 		},
 		"related_resources": [{

--- a/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
@@ -12,9 +12,19 @@ test_fail_package_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["package"], "pattern": `^foo\.bar\..+$`}],
 	}
 	r := rule.report with input as regal.parse_module("policy.rego", "package foo.bar") with config.for_rule as cfg
+
 	r == {expected(
 		`Naming convention violation: package name "foo.bar" does not match pattern '^foo\.bar\..+$'`,
-		{"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
+		{
+			"col": 1,
+			"file": "policy.rego",
+			"row": 1,
+			"end": {
+				"col": 8,
+				"row": 1,
+			},
+			"text": "package foo.bar",
+		},
 	)}
 }
 
@@ -24,6 +34,7 @@ test_success_package_name_matches_pattern if {
 		"conventions": [{"targets": ["package"], "pattern": `^foo\.bar$`}],
 	}
 	r := rule.report with input as regal.parse_module("policy.rego", "package foo.bar") with config.for_rule as cfg
+
 	r == set()
 }
 
@@ -33,9 +44,19 @@ test_fail_rule_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["rule"], "pattern": "^[a-z]+$"}],
 	}
 	r := rule.report with input as ast.policy(`FOO := true`) with config.for_rule as cfg
+
 	r == {expected(
 		`Naming convention violation: rule name "FOO" does not match pattern '^[a-z]+$'`,
-		{"col": 1, "file": "policy.rego", "row": 3, "text": "FOO := true"},
+		{
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 12,
+				"row": 3,
+			},
+			"text": "FOO := true",
+		},
 	)}
 }
 
@@ -45,6 +66,7 @@ test_success_rule_name_matches_pattern if {
 		"conventions": [{"targets": ["rule"], "pattern": "^[a-z]+$"}],
 	}
 	r := rule.report with input as ast.policy(`foo := true`) with config.for_rule as cfg
+
 	r == set()
 }
 
@@ -54,9 +76,19 @@ test_fail_function_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["function"], "pattern": "^[a-z]+$"}],
 	}
 	r := rule.report with input as ast.policy(`fooBar(_) := true`) with config.for_rule as cfg
+
 	r == {expected(
 		`Naming convention violation: function name "fooBar" does not match pattern '^[a-z]+$'`,
-		{"col": 1, "file": "policy.rego", "row": 3, "text": "fooBar(_) := true"},
+		{
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 18,
+				"row": 3,
+			},
+			"text": "fooBar(_) := true",
+		},
 	)}
 }
 
@@ -66,6 +98,7 @@ test_success_function_name_matches_pattern if {
 		"conventions": [{"targets": ["function"], "pattern": "^[a-z_]+$"}],
 	}
 	r := rule.report with input as ast.policy(`foo_bar(_) := true`) with config.for_rule as cfg
+
 	r == set()
 }
 
@@ -81,9 +114,19 @@ test_fail_var_name_does_not_match_pattern if {
 		"conventions": [{"targets": ["variable"], "pattern": "^[a-z_]+$"}],
 	}
 	r := rule.report with input as policy with config.for_rule as cfg
+
 	r == {expected(
 		`Naming convention violation: variable name "fooBar" does not match pattern '^[a-z_]+$'`,
-		{"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tfooBar := true"},
+		{
+			"col": 3,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 9,
+				"row": 5,
+			},
+			"text": "\t\tfooBar := true",
+		},
 	)}
 }
 
@@ -100,9 +143,11 @@ test_success_var_name_matches_pattern if {
 		"conventions": [{"targets": ["variable"], "pattern": "^[a-z_]+$"}],
 	}
 	r := rule.report with input as policy with config.for_rule as cfg
+
 	r == set()
 }
 
+# regal ignore:rule-length
 test_fail_multiple_conventions if {
 	policy := regal.parse_module("policy.rego", `package foo.bar
 
@@ -118,18 +163,46 @@ test_fail_multiple_conventions if {
 		{"targets": ["rule", "variable"], "pattern": "^bar$|^foo_bar$"},
 	]}
 	r := rule.report with input as policy with config.for_rule as cfg
+
 	r == {
 		expected(
 			`Naming convention violation: package name "foo.bar" does not match pattern '^acmecorp\.[a-z_\.]+$'`,
-			{"col": 1, "file": "policy.rego", "row": 1, "text": "package foo.bar"},
+			{
+				"col": 1,
+				"file": "policy.rego",
+				"row": 1,
+				"end": {
+					"col": 8,
+					"row": 1,
+				},
+				"text": "package foo.bar",
+			},
 		),
 		expected(
 			`Naming convention violation: rule name "foo" does not match pattern '^bar$|^foo_bar$'`,
-			{"col": 2, "file": "policy.rego", "row": 3, "text": "\tfoo := true"},
+			{
+				"col": 2,
+				"file": "policy.rego",
+				"row": 3,
+				"end": {
+					"col": 13,
+					"row": 3,
+				},
+				"text": "\tfoo := true",
+			},
 		),
 		expected(
 			`Naming convention violation: variable name "fooBar" does not match pattern '^bar$|^foo_bar$'`,
-			{"col": 3, "file": "policy.rego", "row": 6, "text": "\t\tfooBar := true"},
+			{
+				"col": 3,
+				"file": "policy.rego",
+				"row": 6,
+				"end": {
+					"col": 9,
+					"row": 6,
+				},
+				"text": "\t\tfooBar := true",
+			},
 		),
 	}
 }

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
@@ -34,7 +34,7 @@ report contains violation if {
 
 	# Note that this will give us the text representation of the whole rule,
 	# which we'll need as the "if" is only visible here ¯\_(ツ)_/¯
-	text := base64.decode(util.to_location_object(rule.location).text)
+	text := util.to_location_object(rule.location).text
 	lines := [line |
 		some s in split(text, "\n")
 		line := trim_space(s)

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
@@ -16,9 +16,17 @@ test_fail_could_be_one_liner if {
 		input.yes
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 7, "text": "\tallow if {"})
+
+	r == expected_with_location({
+		"col": 2,
+		"row": 7,
+		"end": {
+			"col": 7,
+			"row": 7,
+		},
+		"text": "\tallow if {",
+	})
 }
 
 test_fail_could_be_one_liner_all_keywords if {
@@ -30,9 +38,18 @@ test_fail_could_be_one_liner_all_keywords if {
 		input.yes
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 7, "text": "\tallow if {"})
+
+	r == expected_with_location({
+		"col": 2,
+		"file": "policy.rego",
+		"row": 7,
+		"end": {
+			"col": 7,
+			"row": 7,
+		},
+		"text": "\tallow if {",
+	})
 }
 
 test_fail_could_be_one_liner_allman_style if {
@@ -47,7 +64,15 @@ test_fail_could_be_one_liner_allman_style if {
 	`)
 
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 7, "text": "\tallow if"})
+	r == expected_with_location({
+		"col": 2,
+		"row": 7,
+		"end": {
+			"col": 7,
+			"row": 7,
+		},
+		"text": "\tallow if",
+	})
 }
 
 test_success_if_not_imported if {
@@ -56,8 +81,8 @@ test_success_if_not_imported if {
 		1 == 1
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
+
 	r == set()
 }
 
@@ -78,8 +103,8 @@ test_success_too_long_for_a_one_liner_configured_line_length if {
 		some_really_long_rule_name_in_fact_53_characters_long
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error", "max-line-length": 50}
+
 	r == set()
 }
 
@@ -101,8 +126,8 @@ test_success_no_one_liner_comment_in_rule_body_same_line if {
 		1 == 1 # Surely one equals one
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
+
 	r == set()
 }
 
@@ -113,8 +138,8 @@ test_success_no_one_liner_comment_in_rule_body_line_below if {
 		# Surely one equals one
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
+
 	r == set()
 }
 
@@ -126,20 +151,20 @@ test_success_does_not_use_if if {
 		1 == 1
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
+
 	r == set()
 }
 
 test_success_already_a_one_liner if {
-	module := ast.with_rego_v1(`allow if 1 == 1`)
+	r := rule.report with input as ast.with_rego_v1(`allow if 1 == 1`) with config.for_rule as {"level": "error"}
 
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 	r == set()
 }
 
 test_has_notice_if_unmet_capability if {
 	r := rule.notices with config.capabilities as {}
+
 	r == {{
 		"category": "custom",
 		"description": "Missing capability for keyword `if`",
@@ -158,6 +183,7 @@ expected := {
 		"ref": config.docs.resolve_url("$baseUrl/$category/one-liner-rule", "custom"),
 	}],
 	"title": "one-liner-rule",
+	"location": {"file": "policy.rego"},
 }
 
 # regal ignore:external-reference

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
@@ -23,7 +23,7 @@ report contains violation if {
 
 	not _scalar_fail(cfg, last.terms[2], ast.scalar_types)
 
-	violation := result.fail(rego.metadata.chain(), result.location(last))
+	violation := result.fail(rego.metadata.chain(), result.location(last.terms[2]))
 }
 
 _var_in_head(rule) := rule.head.value.value if rule.head.value.type == "var"

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
@@ -12,9 +12,17 @@ test_fail_value_could_be_in_head_assign if {
 		input.x
 		x := 10
 	}`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := 10"})
+
+	r == expected_with_location({
+		"col": 8,
+		"row": 5,
+		"end": {
+			"col": 10,
+			"row": 5,
+		},
+		"text": "\t\tx := 10",
+	})
 }
 
 test_fail_value_could_be_in_head_assign_composite if {
@@ -22,15 +30,22 @@ test_fail_value_could_be_in_head_assign_composite if {
 		input.x
 		x := {"foo": 10}
 	}`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := {\"foo\": 10}"})
+
+	r == expected_with_location({
+		"col": 8,
+		"row": 5,
+		"end": {
+			"col": 19,
+			"row": 5,
+		},
+		"text": "\t\tx := {\"foo\": 10}",
+	})
 }
 
 test_fail_value_is_in_head_assign if {
-	module := ast.policy(`value := 10 { input.x }`)
+	r := rule.report with input as ast.policy(`value := 10 { input.x }`) with config.for_rule as {"level": "error"}
 
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 	r == set()
 }
 
@@ -39,15 +54,23 @@ test_fail_value_could_be_in_head_eq if {
 		input.x
 		x = 10
 	}`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx = 10"})
+
+	r == expected_with_location({
+		"col": 7,
+		"file": "policy.rego",
+		"row": 5,
+		"end": {
+			"col": 9,
+			"row": 5,
+		},
+		"text": "\t\tx = 10",
+	})
 }
 
 test_success_value_is_in_head_eq if {
-	module := ast.policy(`value = x { input.x }`)
+	r := rule.report with input as ast.policy(`value = x { input.x }`) with config.for_rule as {"level": "error"}
 
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 	r == set()
 }
 
@@ -56,8 +79,8 @@ test_fail_value_could_be_in_head_but_not_a_scalar if {
 		input.x
 		x := [i | i := input[_]]
 	}`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
+
 	r == set()
 }
 
@@ -66,9 +89,17 @@ test_fail_value_could_be_in_head_and_is_a_scalar if {
 		input.x
 		x := 5
 	}`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := 5"})
+
+	r == expected_with_location({
+		"col": 8,
+		"row": 5,
+		"end": {
+			"col": 9,
+			"row": 5,
+		},
+		"text": "\t\tx := 5",
+	})
 }
 
 test_fail_value_could_be_in_head_multivalue_rule if {
@@ -76,9 +107,17 @@ test_fail_value_could_be_in_head_multivalue_rule if {
 		input.bad
 		violation := "not good!"
 	}`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tviolation := \"not good!\""})
+
+	r == expected_with_location({
+		"col": 16,
+		"row": 7,
+		"end": {
+			"col": 27,
+			"row": 7,
+		},
+		"text": "\t\tviolation := \"not good!\"",
+	})
 }
 
 test_fail_value_could_be_in_head_object_rule if {
@@ -86,9 +125,17 @@ test_fail_value_could_be_in_head_object_rule if {
 		input.foo
 		x := "bar"
 	}`)
-
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 5, "text": "\t\tx := \"bar\""})
+
+	r == expected_with_location({
+		"col": 8,
+		"row": 5,
+		"end": {
+			"col": 13,
+			"row": 5,
+		},
+		"text": "\t\tx := \"bar\"",
+	})
 }
 
 expected := {
@@ -100,6 +147,7 @@ expected := {
 		"ref": config.docs.resolve_url("$baseUrl/$category/prefer-value-in-head", "custom"),
 	}],
 	"title": "prefer-value-in-head",
+	"location": {"file": "policy.rego"},
 }
 
 # regal ignore:external-reference

--- a/bundle/regal/rules/idiomatic/ambiguous-scope/ambiguous_scope_test.rego
+++ b/bundle/regal/rules/idiomatic/ambiguous-scope/ambiguous_scope_test.rego
@@ -15,13 +15,22 @@ allow if input.x
 
 allow if input.y
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Ambiguous metadata scope",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 6, "text": "# METADATA"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 15,
+				"row": 7,
+			},
+			"text": "# METADATA",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/ambiguous-scope", "idiomatic"),
@@ -38,13 +47,22 @@ func(x) if x < 10
 
 func(x) if x < "10"
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Ambiguous metadata scope",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 6, "text": "# METADATA"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 6,
+			"text": "# METADATA",
+			"end": {
+				"col": 14,
+				"row": 7,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/ambiguous-scope", "idiomatic"),
@@ -63,8 +81,8 @@ allow if input.x
 # description: input has y
 allow if input.y
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -77,8 +95,8 @@ allow if input.x
 
 allow if input.y
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -90,8 +108,8 @@ allow if input.x
 
 allow if input.y
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -107,8 +125,8 @@ allow if input.x
 
 allow if input.y
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -121,7 +139,7 @@ allow if input.x
 
 allow if input.y
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment.rego
+++ b/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment.rego
@@ -20,5 +20,5 @@ report contains violation if {
 
 	config.capabilities.builtins[ref_name].decl.result == "boolean"
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule))
+	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment_test.rego
+++ b/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment_test.rego
@@ -9,15 +9,23 @@ import data.regal.config
 import data.regal.rules.idiomatic["boolean-assignment"] as rule
 
 test_boolean_assignment_in_rule_head if {
-	module := ast.policy("more_than_one := input.count > 1")
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy("more_than_one := input.count > 1")
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Prefer `if` over boolean assignment",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "more_than_one := input.count > 1"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 33,
+				"row": 3,
+			},
+			"text": "more_than_one := input.count > 1",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/boolean-assignment", "idiomatic"),
@@ -27,17 +35,15 @@ test_boolean_assignment_in_rule_head if {
 }
 
 test_success_uses_if_instead_of_boolean_assignment_in_rule_head if {
-	module := ast.with_rego_v1("more_than_one if input.count > 1")
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.with_rego_v1("more_than_one if input.count > 1")
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
 test_success_non_boolean_assignment_in_rule_head if {
-	module := ast.with_rego_v1(`foo := lower("FOO")`)
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.with_rego_v1(`foo := lower("FOO")`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/custom-has-key-construct/custom_has_key_construct_test.rego
+++ b/bundle/regal/rules/idiomatic/custom-has-key-construct/custom_has_key_construct_test.rego
@@ -10,11 +10,21 @@ test_fail_custom_has_key if {
 	r := rule.report with input as ast.policy(`has_key(name, coll) {
 		_ = coll[name]
 	}`)
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Custom function may be replaced by `in` and `object.keys`",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "has_key(name, coll) {"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 20,
+				"row": 3,
+			},
+			"text": "has_key(name, coll) {",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/custom-has-key-construct", "idiomatic"),
@@ -27,11 +37,21 @@ test_fail_custom_has_key_reversed if {
 	r := rule.report with input as ast.policy(`has_key(name, coll) {
 		coll[name] = _
 	}`)
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Custom function may be replaced by `in` and `object.keys`",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "has_key(name, coll) {"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 20,
+				"row": 3,
+			},
+			"text": "has_key(name, coll) {",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/custom-has-key-construct", "idiomatic"),
@@ -49,11 +69,21 @@ test_fail_custom_has_key_multiple_wildcards if {
 	has_key(name, coll) {
 		coll[name] = _
 	}`)
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Custom function may be replaced by `in` and `object.keys`",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 8, "text": "\thas_key(name, coll) {"},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 8,
+			"end": {
+				"col": 21,
+				"row": 8,
+			},
+			"text": "\thas_key(name, coll) {",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/custom-has-key-construct", "idiomatic"),

--- a/bundle/regal/rules/idiomatic/custom-in-construct/custom_in_construct_test.rego
+++ b/bundle/regal/rules/idiomatic/custom-in-construct/custom_in_construct_test.rego
@@ -11,11 +11,21 @@ test_fail_custom_in if {
 	r := rule.report with input as ast.policy(`has(item, coll) {
     		item == coll[_]
     }`)
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Custom function may be replaced by `in` keyword",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "has(item, coll) {"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 16,
+				"row": 3,
+			},
+			"text": "has(item, coll) {",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/custom-in-construct", "idiomatic"),
@@ -26,11 +36,21 @@ test_fail_custom_in if {
 
 test_fail_custom_in_reversed if {
 	r := rule.report with input as ast.policy(`has(item, coll) { coll[_] == item }`)
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Custom function may be replaced by `in` keyword",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "has(item, coll) { coll[_] == item }"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 16,
+				"row": 3,
+			},
+			"text": "has(item, coll) { coll[_] == item }",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/custom-in-construct", "idiomatic"),

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
@@ -7,6 +7,7 @@ import rego.v1
 import data.regal.ast
 import data.regal.config
 import data.regal.result
+import data.regal.util
 
 # METADATA
 # description: disabled when filename is unknown
@@ -24,7 +25,11 @@ report contains violation if {
 
 	file_path_length_matched != _pkg_path_values
 
-	violation := result.fail(rego.metadata.chain(), result.location(input["package"].path))
+	violation := result.fail(
+		rego.metadata.chain(),
+		# skip the "data" part of the path, as it has no location
+		result.ranged_from_ref(util.rest(input["package"].path)),
+	)
 }
 
 _pkg_path_values := ast.package_path if {

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
@@ -17,7 +17,16 @@ test_fail_directory_structure_package_path_mismatch if {
 	module := regal.parse_module("foo/bar/baz/p.rego", "package foo.baz.bar")
 	r := rule.report with input as module with config.for_rule as _default_config
 
-	r == with_location({"col": 9, "file": "foo/bar/baz/p.rego", "row": 1, "text": "package foo.baz.bar"})
+	r == with_location({
+		"col": 9,
+		"file": "foo/bar/baz/p.rego",
+		"row": 1,
+		"end": {
+			"col": 20,
+			"row": 1,
+		},
+		"text": "package foo.baz.bar",
+	})
 }
 
 test_success_directory_structure_package_path_match_longer_directory_path if {

--- a/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
+++ b/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
@@ -8,55 +8,97 @@ import data.regal.config
 import data.regal.rules.idiomatic["equals-pattern-matching"] as rule
 
 test_fail_simple_head_comparison_could_be_matched_in_arg if {
-	module := ast.policy("f(x) := x == 1")
+	r := rule.report with input as ast.policy("f(x) := x == 1")
 
-	r := rule.report with input as module
-	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := x == 1"})
+	r == expected_with_location({
+		"col": 1,
+		"row": 3,
+		"end": {
+			"col": 15,
+			"row": 3,
+		},
+		"text": "f(x) := x == 1",
+	})
 }
 
 test_fail_simple_head_comparison_could_be_matched_in_arg_eq_order if {
-	module := ast.policy("f(x) := 1 == x")
+	r := rule.report with input as ast.policy("f(x) := 1 == x")
 
-	r := rule.report with input as module
-	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := 1 == x"})
+	r == expected_with_location({
+		"col": 1,
+		"row": 3,
+		"end": {
+			"col": 15,
+			"row": 3,
+		},
+		"text": "f(x) := 1 == x",
+	})
 }
 
 test_fail_simple_head_comparison_could_be_matched_in_arg_multiple_args if {
-	module := ast.policy("f(_, x, _) := x == 1")
+	r := rule.report with input as ast.policy("f(_, x, _) := x == 1")
 
-	r := rule.report with input as module
-	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(_, x, _) := x == 1"})
+	r == expected_with_location({
+		"col": 1,
+		"row": 3,
+		"end": {
+			"col": 21,
+			"row": 3,
+		},
+		"text": "f(_, x, _) := x == 1",
+	})
 }
 
 test_fail_simple_body_comparison_could_be_matched_in_arg if {
-	module := ast.policy(`f(x) := "one" {
+	r := rule.report with input as ast.policy(`f(x) := "one" {
 		x == 1
 	}`)
 
-	r := rule.report with input as module
-	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := \"one\" {"})
+	r == expected_with_location({
+		"col": 1,
+		"row": 3,
+		"end": {
+			"col": 3,
+			"row": 5,
+		},
+		"text": "f(x) := \"one\" {",
+	})
 }
 
 test_fail_simple_body_comparison_could_be_matched_in_arg_eq_order if {
-	module := ast.policy(`f(x) := "one" {
+	r := rule.report with input as ast.policy(`f(x) := "one" {
 		1 == x
 	}`)
 
-	r := rule.report with input as module
-	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 3, "text": "f(x) := \"one\" {"})
+	r == expected_with_location({
+		"col": 1,
+		"row": 3,
+		"end": {
+			"col": 3,
+			"row": 5,
+		},
+		"text": "f(x) := \"one\" {",
+	})
 }
 
 test_fail_simple_body_comparison_could_be_matched_using_if if {
-	module := ast.with_rego_v1(`f(x) := x if x == 1`)
+	r := rule.report with input as ast.with_rego_v1(`f(x) := x if x == 1`)
 
-	r := rule.report with input as module
-	r == expected_with_location({"col": 1, "file": "policy.rego", "row": 5, "text": "f(x) := x if x == 1"})
+	r == expected_with_location({
+		"col": 1,
+		"row": 5,
+		"end": {
+			"col": 20,
+			"row": 5,
+		},
+		"text": "f(x) := x if x == 1",
+	})
 }
 
 test_success_actually_pattern_matching if {
 	module := ast.policy("f(1)")
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -64,8 +106,8 @@ test_success_skipped_on_else if {
 	module := ast.policy(`f(x) {
 		x == 1
 	} else := false`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -78,6 +120,7 @@ expected := {
 		"ref": config.docs.resolve_url("$baseUrl/$category/equals-pattern-matching", "idiomatic"),
 	}],
 	"title": "equals-pattern-matching",
+	"location": {"file": "policy.rego"},
 }
 
 # regal ignore:external-reference

--- a/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint_test.rego
+++ b/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint_test.rego
@@ -6,6 +6,7 @@ import data.regal.config
 
 import data.regal.rules.idiomatic["no-defined-entrypoint"] as rule
 
+# regal ignore:rule-length
 test_aggregate_entrypoints if {
 	module := regal.parse_module("policy.rego", `
 # METADATA
@@ -19,12 +20,28 @@ allow := false`)
 	aggregate := rule.aggregate with input as module
 	aggregate == {
 		{
-			"aggregate_data": {"entrypoint": {"col": 1, "row": 2, "text": "IyBNRVRBREFUQQojIGVudHJ5cG9pbnQ6IHRydWU="}},
+			"aggregate_data": {"entrypoint": {
+				"col": 1,
+				"row": 2,
+				"end": {
+					"col": 19,
+					"row": 3,
+				},
+				"text": "# METADATA\n# entrypoint: true",
+			}},
 			"aggregate_source": {"file": "policy.rego", "package_path": ["p"]},
 			"rule": {"category": "idiomatic", "title": "no-defined-entrypoint"},
 		},
 		{
-			"aggregate_data": {"entrypoint": {"col": 1, "row": 6, "text": "IyBNRVRBREFUQQojIGVudHJ5cG9pbnQ6IHRydWU="}},
+			"aggregate_data": {"entrypoint": {
+				"col": 1,
+				"row": 6,
+				"end": {
+					"col": 19,
+					"row": 7,
+				},
+				"text": "# METADATA\n# entrypoint: true",
+			}},
 			"aggregate_source": {"file": "policy.rego", "package_path": ["p"]},
 			"rule": {"category": "idiomatic", "title": "no-defined-entrypoint"},
 		},

--- a/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
+++ b/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego
@@ -30,7 +30,7 @@ report contains violation if {
 
 	chr == `"`
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(value[pos]))
+	violation := result.fail(rego.metadata.chain(), result.location(value[pos]))
 }
 
 # Mapping of regex.* functions and the position(s)

--- a/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule_test.rego
+++ b/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule_test.rego
@@ -12,13 +12,22 @@ test_fail_set_comprehension_could_be_rule if {
 		some s in input
 		s > 10
 	}`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Prefer set or object rule over comprehension",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": "my_set := {s |"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 3,
+				"row": 8,
+			},
+			"text": "my_set := {s |",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-set-or-object-rule", "idiomatic"),
@@ -32,13 +41,22 @@ test_fail_object_comprehension_could_be_rule if {
 		some k, v in input
 		v == "foo"
 	}`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Prefer set or object rule over comprehension",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 5, "text": "my_obj := {k: v |"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 3,
+				"row": 8,
+			},
+			"text": "my_obj := {k: v |",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-set-or-object-rule", "idiomatic"),
@@ -48,36 +66,31 @@ test_fail_object_comprehension_could_be_rule if {
 }
 
 test_success_set_comprehension_array_to_set_conversion_ref_iteration if {
-	module := ast.with_rego_v1(`my_set := {s | s := arr[_]}`)
+	r := rule.report with input as ast.with_rego_v1(`my_set := {s | s := arr[_]}`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_set_comprehension_array_to_set_conversion_ref_nested_iteration if {
-	module := ast.with_rego_v1(`my_set := {s | s := a.b.c[_]}`)
+	r := rule.report with input as ast.with_rego_v1(`my_set := {s | s := a.b.c[_]}`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_set_comprehension_array_to_set_conversion_ref_nested_iteration_sub_attribute if {
-	module := ast.with_rego_v1(`my_set := {s | s := a.b.c[_].d}`)
+	r := rule.report with input as ast.with_rego_v1(`my_set := {s | s := a.b.c[_].d}`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_set_comprehension_array_to_set_conversion_some_in if {
-	module := ast.with_rego_v1(`my_set := {s | some s in arr}`)
+	r := rule.report with input as ast.with_rego_v1(`my_set := {s | some s in arr}`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_set_comprehension_but_rule_body if {
-	module := ast.with_rego_v1(`my_set := {s | some s in arr; s == ""} if { some_condition }`)
+	r := rule.report with input as ast.with_rego_v1(`my_set := {s | some s in arr; s == ""} if { some_condition }`)
 
-	r := rule.report with input as module
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/use-contains/use_contains.rego
+++ b/bundle/regal/rules/idiomatic/use-contains/use_contains.rego
@@ -24,9 +24,9 @@ report contains violation if {
 	rule.head.key
 	not rule.head.value
 
-	text := base64.decode(util.to_location_object(rule.head.location).text)
+	text := split(util.to_location_object(rule.location).text, "\n")[0]
 
 	not contains(text, " contains ")
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule))
+	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }

--- a/bundle/regal/rules/idiomatic/use-contains/use_contains_test.rego
+++ b/bundle/regal/rules/idiomatic/use-contains/use_contains_test.rego
@@ -14,13 +14,22 @@ test_fail_should_use_contains if {
 	rule[item] {
 		some item in input.items
 	}`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Use the `contains` keyword",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 6, "text": "\trule[item] {"},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"row": 6,
+				"col": 12,
+			},
+			"text": "\trule[item] {",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-contains", "idiomatic"),
@@ -33,8 +42,8 @@ test_success_uses_contains if {
 	module := ast.with_rego_v1(`rule contains item if {
 		some item in input.items
 	}`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -43,7 +52,7 @@ test_success_object_rule if {
 		foo := "bar"
 		bar := "baz"
 	}`)
-
 	r := rule.report with input as module
+
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/use-if/use_if.rego
+++ b/bundle/regal/rules/idiomatic/use-if/use_if.rego
@@ -22,8 +22,8 @@ report contains violation if {
 	some rule in input.rules
 	rule.body
 
-	head_len := count(base64.decode(util.to_location_object(rule.head.location).text))
-	text := trim_space(substring(base64.decode(util.to_location_object(rule.location).text), head_len, -1))
+	head_len := count(util.to_location_object(rule.head.location).text)
+	text := trim_space(substring(util.to_location_object(rule.location).text, head_len, -1))
 
 	not startswith(text, "if")
 

--- a/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
+++ b/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
@@ -13,13 +13,22 @@ test_fail_should_use_if if {
 	] {
 		input.attribute
 	}`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "idiomatic",
 		"description": "Use the `if` keyword",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "rule := [true |"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 3,
+				"row": 7,
+			},
+			"text": "rule := [true |",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-if", "idiomatic"),
@@ -34,14 +43,13 @@ test_success_uses_if if {
 	] if {
 		input.attribute
 	}`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_no_body_no_if if {
-	module := ast.with_rego_v1(`rule := "without body"`)
+	r := rule.report with input as ast.with_rego_v1(`rule := "without body"`)
 
-	r := rule.report with input as module
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
+++ b/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
@@ -10,10 +10,14 @@ test_fail_use_in_operator_string_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	"admin" == input.user.roles[_]
 	}`)
+
 	r == expected_with_location({
 		"col": 13,
-		"file": "policy.rego",
 		"row": 4,
+		"end": {
+			"col": 32,
+			"row": 4,
+		},
 		"text": "\t\"admin\" == input.user.roles[_]",
 	})
 }
@@ -22,31 +26,62 @@ test_fail_use_in_operator_number_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	1 == input.lucky_numbers[_]
 	}`)
-	r == expected_with_location({"col": 7, "file": "policy.rego", "row": 4, "text": "\t1 == input.lucky_numbers[_]"})
+
+	r == expected_with_location({
+		"col": 7,
+		"row": 4,
+		"end": {
+			"col": 29,
+			"row": 4,
+		},
+		"text": "\t1 == input.lucky_numbers[_]",
+	})
 }
 
 test_fail_use_in_operator_array_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	[1] == input.arrays[_]
 	}`)
-	r == expected_with_location({"col": 9, "file": "policy.rego", "row": 4, "text": "\t[1] == input.arrays[_]"})
+
+	r == expected_with_location({
+		"col": 9,
+		"row": 4,
+		"end": {
+			"col": 24,
+			"row": 4,
+		},
+		"text": "\t[1] == input.arrays[_]",
+	})
 }
 
 test_fail_use_in_operator_boolean_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	true == input.booleans[_]
 	}`)
-	r == expected_with_location({"col": 10, "file": "policy.rego", "row": 4, "text": "\ttrue == input.booleans[_]"})
+
+	r == expected_with_location({
+		"col": 10,
+		"row": 4,
+		"end": {
+			"col": 27,
+			"row": 4,
+		},
+		"text": "\ttrue == input.booleans[_]",
+	})
 }
 
 test_fail_use_in_operator_object_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	{"x": "y"} == input.objects[_]
 	}`)
+
 	r == expected_with_location({
 		"col": 16,
-		"file": "policy.rego",
 		"row": 4,
+		"end": {
+			"col": 32,
+			"row": 4,
+		},
 		"text": "\t{\"x\": \"y\"} == input.objects[_]",
 	})
 }
@@ -55,31 +90,61 @@ test_fail_use_in_operator_null_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	null == input.objects[_]
 	}`)
-	r == expected_with_location({"col": 10, "file": "policy.rego", "row": 4, "text": "\tnull == input.objects[_]"})
+
+	r == expected_with_location({
+		"col": 10,
+		"row": 4,
+		"text": "\tnull == input.objects[_]",
+		"end": {
+			"col": 26,
+			"row": 4,
+		},
+	})
 }
 
 test_fail_use_in_operator_set_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	{"foo"} == input.objects[_]
 	}`)
-	r == expected_with_location({"col": 13, "file": "policy.rego", "row": 4, "text": "\t{\"foo\"} == input.objects[_]"})
+
+	r == expected_with_location({
+		"col": 13,
+		"row": 4,
+		"end": {
+			"col": 29,
+			"row": 4,
+		},
+		"text": "\t{\"foo\"} == input.objects[_]",
+	})
 }
 
 test_fail_use_in_operator_var_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 	admin == input.user.roles[_]
 	}`)
-	r == expected_with_location({"col": 11, "file": "policy.rego", "row": 4, "text": "\tadmin == input.user.roles[_]"})
+	r == expected_with_location({
+		"col": 11,
+		"row": 4,
+		"end": {
+			"col": 30,
+			"row": 4,
+		},
+		"text": "\tadmin == input.user.roles[_]",
+	})
 }
 
 test_fail_use_in_operator_string_rhs if {
 	r := rule.report with input as ast.policy(`allow {
 	input.user.roles[_] == "admin"
 	}`)
+
 	r == expected_with_location({
 		"col": 2,
-		"file": "policy.rego",
 		"row": 4,
+		"end": {
+			"col": 21,
+			"row": 4,
+		},
 		"text": "\tinput.user.roles[_] == \"admin\"",
 	})
 }
@@ -88,17 +153,30 @@ test_fail_use_in_operator_var_rhs if {
 	r := rule.report with input as ast.policy(`allow {
 		input.user.roles[_] == admin
 	}`)
-	r == expected_with_location({"col": 3, "file": "policy.rego", "row": 4, "text": "\t\tinput.user.roles[_] == admin"})
+
+	r == expected_with_location({
+		"col": 3,
+		"row": 4,
+		"end": {
+			"col": 22,
+			"row": 4,
+		},
+		"text": "\t\tinput.user.roles[_] == admin",
+	})
 }
 
 test_fail_use_in_operator_ref_lhs if {
 	r := rule.report with input as ast.policy(`allow {
 		data.roles.admin == input.user.roles[_]
 	}`)
+
 	r == expected_with_location({
 		"col": 23,
-		"file": "policy.rego",
 		"row": 4,
+		"end": {
+			"col": 42,
+			"row": 4,
+		},
 		"text": "\t\tdata.roles.admin == input.user.roles[_]",
 	})
 }
@@ -107,10 +185,14 @@ test_fail_use_in_operator_ref_rhs if {
 	r := rule.report with input as ast.policy(`allow {
 		input.user.roles[_] == data.roles.admin
 	}`)
+
 	r == expected_with_location({
 		"col": 3,
-		"file": "policy.rego",
 		"row": 4,
+		"end": {
+			"col": 22,
+			"row": 4,
+		},
 		"text": "\t\tinput.user.roles[_] == data.roles.admin",
 	})
 }
@@ -119,10 +201,14 @@ test_fail_use_in_operator_scalar_eq_operator if {
 	r := rule.report with input as ast.policy(`allow {
 		input.user.roles[_] == data.roles.admin
 	}`)
+
 	r == expected_with_location({
 		"col": 3,
-		"file": "policy.rego",
 		"row": 4,
+		"end": {
+			"col": 22,
+			"row": 4,
+		},
 		"text": "\t\tinput.user.roles[_] == data.roles.admin",
 	})
 }
@@ -131,21 +217,27 @@ test_fail_use_in_operator_ref_eq_operator if {
 	r := rule.report with input as ast.policy(`allow {
 		input.user.roles[_] = "foo"
 	}`)
+
 	r == expected_with_location({
 		"col": 3,
-		"file": "policy.rego",
 		"row": 4,
+		"end": {
+			"col": 22,
+			"row": 4,
+		},
 		"text": "\t\tinput.user.roles[_] = \"foo\"",
 	})
 }
 
 test_success_loop_refs_both_sides if {
 	r := rule.report with input as ast.policy(`allow { required_roles[_] == input.user.roles[_] }`)
+
 	r == set()
 }
 
 test_success_uses_in_operator if {
 	r := rule.report with input as ast.with_rego_v1(`allow if { "admin" in input.user.roles }`)
+
 	r == set()
 }
 
@@ -158,6 +250,7 @@ expected := {
 		"ref": config.docs.resolve_url("$baseUrl/$category/use-in-operator", "idiomatic"),
 	}],
 	"title": "use-in-operator",
+	"location": {"file": "policy.rego"},
 }
 
 # regal ignore:external-reference

--- a/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego
+++ b/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego
@@ -25,7 +25,7 @@ report contains violation if {
 
 	not _var_in_comprehension_body(elem, rule, path)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(elem))
+	violation := result.fail(rego.metadata.chain(), result.location(elem))
 }
 
 _location_path(rule, location) := path if walk(rule, [path, location])

--- a/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
+++ b/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
@@ -29,7 +29,7 @@ report contains violation if {
 	ref[1].value[0].value[0].value == "indexof_n"
 
 	loc1 := result.location(ref[0])
-	loc2 := result.ranged_location_from_text(ref[1])
+	loc2 := result.location(ref[1])
 
-	violation := result.fail(rego.metadata.chain(), object.union(loc1, {"location": {"end": loc2.location.end}}))
+	violation := result.fail(rego.metadata.chain(), result.ranged_location_between(loc1, loc2))
 }

--- a/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input_test.rego
+++ b/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input_test.rego
@@ -8,6 +8,7 @@ import data.regal.rules.imports["avoid-importing-input"] as rule
 
 test_fail_import_input if {
 	r := rule.report with input as ast.policy(`import input.foo`)
+
 	r == {{
 		"category": "imports",
 		"description": "Avoid importing input",
@@ -16,18 +17,29 @@ test_fail_import_input if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-importing-input", "imports"),
 		}],
 		"title": "avoid-importing-input",
-		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": `import input.foo`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 13,
+				"row": 3,
+			},
+			"text": `import input.foo`,
+		},
 		"level": "error",
 	}}
 }
 
 test_sucess_import_aliased_input if {
 	r := rule.report with input as ast.policy(`import input as tfplan`)
+
 	r == set()
 }
 
 test_fail_import_input_aliased_attribute if {
 	r := rule.report with input as ast.policy(`import input.foo.bar as barbar`)
+
 	r == {{
 		"category": "imports",
 		"description": "Avoid importing input",
@@ -36,7 +48,16 @@ test_fail_import_input_aliased_attribute if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-importing-input", "imports"),
 		}],
 		"title": "avoid-importing-input",
-		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": `import input.foo.bar as barbar`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 13,
+				"row": 3,
+			},
+			"text": `import input.foo.bar as barbar`,
+		},
 		"level": "error",
 	}}
 }

--- a/bundle/regal/rules/imports/circular-import/circular_import_test.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import_test.rego
@@ -36,16 +36,26 @@ test_aggregate_rule_contains_single_self_ref if {
 
     import data.example
     `)
-
 	aggregate := rule.aggregate with input as module
 
 	aggregate == {{
-		"aggregate_data": {"refs": {{"location": {"col": 12, "row": 4}, "package_path": "data.example"}}},
+		"aggregate_data": {"refs": {{
+			"location": {
+				"col": 12,
+				"row": 4,
+				"end": {
+					"col": 24,
+					"row": 4,
+				},
+			},
+			"package_path": "data.example",
+		}}},
 		"aggregate_source": {"file": "example.rego", "package_path": ["example"]},
 		"rule": {"category": "imports", "title": "circular-import"},
 	}}
 }
 
+# regal ignore:rule-length
 test_aggregate_rule_surfaces_refs if {
 	module := regal.parse_module("example.rego", `
     package policy.foo
@@ -66,9 +76,18 @@ test_aggregate_rule_surfaces_refs if {
 
 	aggregate == {{
 		"aggregate_data": {"refs": {
-			{"location": {"col": 7, "row": 11}, "package_path": "data.config.deny.enabled"},
-			{"location": {"col": 12, "row": 6}, "package_path": "data.foo.bar"},
-			{"location": {"col": 14, "row": 8}, "package_path": "data.baz.qux"},
+			{
+				"location": {"col": 7, "end": {"col": 31, "row": 11}, "row": 11},
+				"package_path": "data.config.deny.enabled",
+			},
+			{
+				"location": {"col": 12, "end": {"col": 24, "row": 6}, "row": 6},
+				"package_path": "data.foo.bar",
+			},
+			{
+				"location": {"col": 14, "end": {"col": 26, "row": 8}, "row": 8},
+				"package_path": "data.baz.qux",
+			},
 		}},
 		"aggregate_source": {
 			"file": "example.rego",

--- a/bundle/regal/rules/imports/ignored-import/ignored_import_test.rego
+++ b/bundle/regal/rules/imports/ignored-import/ignored_import_test.rego
@@ -13,13 +13,22 @@ test_fail_ignored_import if {
 
 	bar := data.foo
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "imports",
 		"description": "Reference ignores import of data.foo",
 		"level": "error",
-		"location": {"col": 9, "file": "policy.rego", "row": 6, "text": "\tbar := data.foo"},
+		"location": {
+			"col": 9,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 17,
+				"row": 6,
+			},
+			"text": "\tbar := data.foo",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/ignored-import", "imports"),
@@ -35,13 +44,22 @@ test_fail_ignored_most_specific_import if {
 
 	bar := data.foo.bar
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "imports",
 		"description": "Reference ignores import of data.foo.bar",
 		"level": "error",
-		"location": {"col": 9, "file": "policy.rego", "row": 7, "text": "\tbar := data.foo.bar"},
+		"location": {
+			"col": 9,
+			"file": "policy.rego",
+			"row": 7,
+			"end": {
+				"col": 21,
+				"row": 7,
+			},
+			"text": "\tbar := data.foo.bar",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/ignored-import", "imports"),

--- a/bundle/regal/rules/imports/implicit-future-keywords/implicit_future_keywords_test.rego
+++ b/bundle/regal/rules/imports/implicit-future-keywords/implicit_future_keywords_test.rego
@@ -8,6 +8,7 @@ import data.regal.rules.imports["implicit-future-keywords"] as rule
 
 test_fail_future_keywords_import_wildcard if {
 	r := rule.report with input as ast.policy(`import future.keywords`)
+
 	r == {{
 		"category": "imports",
 		"description": "Use explicit future keyword imports",
@@ -16,13 +17,23 @@ test_fail_future_keywords_import_wildcard if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/implicit-future-keywords", "imports"),
 		}],
 		"title": "implicit-future-keywords",
-		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": `import future.keywords`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 14,
+				"row": 3,
+			},
+			"text": `import future.keywords`,
+		},
 		"level": "error",
 	}}
 }
 
 test_success_future_keywords_import_specific if {
 	r := rule.report with input as ast.policy(`import future.keywords.contains`)
+
 	r == set()
 }
 
@@ -32,6 +43,7 @@ test_success_future_keywords_import_specific_many if {
     import future.keywords.if
     import future.keywords.in
     `)
+
 	r == set()
 }
 

--- a/bundle/regal/rules/imports/import-after-rule/import_after_rule_test.rego
+++ b/bundle/regal/rules/imports/import-after-rule/import_after_rule_test.rego
@@ -13,13 +13,22 @@ test_fail_import_after_rule if {
 
 	import data.foo
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "imports",
 		"description": "Import declared after rule",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 6, "text": "\timport data.foo"},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 8,
+				"row": 6,
+			},
+			"text": "\timport data.foo",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/import-after-rule", "imports"),
@@ -34,7 +43,7 @@ test_success_import_before_rule if {
 
 	rule := true
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }

--- a/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin_test.rego
+++ b/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin_test.rego
@@ -9,15 +9,23 @@ import data.regal.config
 import data.regal.rules.imports["import-shadows-builtin"] as rule
 
 test_fail_import_shadows_builtin_name if {
-	module := ast.policy(`import data.print`)
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`import data.print`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "imports",
 		"description": "Import shadows built-in namespace",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import data.print"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 7,
+				"row": 3,
+			},
+			"text": "import data.print",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-builtin", "imports"),
@@ -27,15 +35,23 @@ test_fail_import_shadows_builtin_name if {
 }
 
 test_fail_import_shadows_builtin_namespace if {
-	module := ast.policy(`import input.foo.http`)
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`import input.foo.http`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "imports",
 		"description": "Import shadows built-in namespace",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import input.foo.http"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 7,
+				"row": 3,
+			},
+			"text": "import input.foo.http",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-builtin", "imports"),
@@ -45,17 +61,15 @@ test_fail_import_shadows_builtin_namespace if {
 }
 
 test_success_import_does_not_shadows_builtin_name if {
-	module := ast.policy(`import data.users`)
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`import data.users`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
 test_success_import_shadows_but_alias_does_not if {
-	module := ast.policy(`import data.http as http_attributes`)
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`import data.http as http_attributes`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }

--- a/bundle/regal/rules/imports/import-shadows-import/import_shadows_import.rego
+++ b/bundle/regal/rules/imports/import-shadows-import/import_shadows_import.rego
@@ -19,5 +19,5 @@ report contains violation if {
 
 	identifier in array.slice(_identifiers, 0, i)
 
-	violation := result.fail(rego.metadata.chain(), result.location(input.imports[i].path.value[0]))
+	violation := result.fail(rego.metadata.chain(), result.location(input.imports[i].path))
 }

--- a/bundle/regal/rules/imports/import-shadows-import/import_shadows_import_test.rego
+++ b/bundle/regal/rules/imports/import-shadows-import/import_shadows_import_test.rego
@@ -11,6 +11,7 @@ test_fail_duplicate_import if {
 import data.foo
 import data.foo
 	`)
+
 	r == {{
 		"category": "imports",
 		"description": "Import shadows another import",
@@ -19,7 +20,16 @@ import data.foo
 			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-import", "imports"),
 		}],
 		"title": "import-shadows-import",
-		"location": {"col": 8, "file": "policy.rego", "row": 5, "text": `import data.foo`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 16,
+				"row": 5,
+			},
+			"text": `import data.foo`,
+		},
 		"level": "error",
 	}}
 }
@@ -29,6 +39,7 @@ test_fail_duplicate_import_alias if {
 import data.foo
 import data.bar as foo
 	`)
+
 	r == {{
 		"category": "imports",
 		"description": "Import shadows another import",
@@ -37,7 +48,16 @@ import data.bar as foo
 			"ref": config.docs.resolve_url("$baseUrl/$category/import-shadows-import", "imports"),
 		}],
 		"title": "import-shadows-import",
-		"location": {"col": 8, "file": "policy.rego", "row": 5, "text": `import data.bar as foo`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 5,
+			"end": {
+				"col": 16,
+				"row": 5,
+			},
+			"text": `import data.bar as foo`,
+		},
 		"level": "error",
 	}}
 }

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
@@ -6,6 +6,7 @@ import data.regal.config
 
 import data.regal.rules.imports["prefer-package-imports"] as rule
 
+# regal ignore:rule-length
 test_aggregate_collects_imports_with_location if {
 	r := rule.aggregate with input as regal.parse_module("p.rego", `
 	package a
@@ -17,8 +18,32 @@ test_aggregate_collects_imports_with_location if {
 	r == {{
 		"aggregate_data": {
 			"imports": [
-				{"location": {"col": 2, "file": "p.rego", "row": 4, "text": "\timport data.b"}, "path": ["b"]},
-				{"location": {"col": 2, "file": "p.rego", "row": 5, "text": "\timport data.c.d"}, "path": ["c", "d"]},
+				{
+					"location": {
+						"col": 2,
+						"file": "p.rego",
+						"row": 4,
+						"end": {
+							"col": 8,
+							"row": 4,
+						},
+						"text": "\timport data.b",
+					},
+					"path": ["b"],
+				},
+				{
+					"location": {
+						"col": 2,
+						"file": "p.rego",
+						"row": 5,
+						"end": {
+							"col": 8,
+							"row": 5,
+						},
+						"text": "\timport data.c.d",
+					},
+					"path": ["c", "d"],
+				},
 			],
 			"package_path": ["a"],
 		},
@@ -132,7 +157,16 @@ test_aggregate_ignores_imports_of_regal_in_custom_rule if {
 	r == {{
 		"aggregate_data": {
 			"imports": [{
-				"location": {"col": 2, "file": "p.rego", "row": 6, "text": "\timport data.a.b.c"},
+				"location": {
+					"col": 2,
+					"file": "p.rego",
+					"row": 6,
+					"end": {
+						"col": 8,
+						"row": 6,
+					},
+					"text": "\timport data.a.b.c",
+				},
 				"path": ["a", "b", "c"],
 			}],
 			"package_path": ["custom", "regal", "rules", "foo", "bar"],

--- a/bundle/regal/rules/imports/redundant-alias/redundant_alias_test.rego
+++ b/bundle/regal/rules/imports/redundant-alias/redundant_alias_test.rego
@@ -8,6 +8,7 @@ import data.regal.rules.imports["redundant-alias"] as rule
 
 test_fail_redundant_alias if {
 	r := rule.report with input as ast.policy(`import data.foo.bar as bar`)
+
 	r == {{
 		"category": "imports",
 		"description": "Redundant alias",
@@ -16,12 +17,22 @@ test_fail_redundant_alias if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-alias", "imports"),
 		}],
 		"title": "redundant-alias",
-		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": "import data.foo.bar as bar"},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 12,
+				"row": 3,
+			},
+			"text": "import data.foo.bar as bar",
+		},
 		"level": "error",
 	}}
 }
 
 test_success_not_redundant_alias if {
 	r := rule.report with input as ast.policy(`import data.foo.bar as valid`)
+
 	r == set()
 }

--- a/bundle/regal/rules/imports/redundant-data-import/redundant_data_import_test.rego
+++ b/bundle/regal/rules/imports/redundant-data-import/redundant_data_import_test.rego
@@ -8,6 +8,7 @@ import data.regal.rules.imports["redundant-data-import"] as rule
 
 test_fail_import_data if {
 	r := rule.report with input as ast.policy(`import data`)
+
 	r == {{
 		"category": "imports",
 		"description": "Redundant import of data",
@@ -16,13 +17,23 @@ test_fail_import_data if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-data-import", "imports"),
 		}],
 		"title": "redundant-data-import",
-		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": `import data`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 12,
+				"row": 3,
+			},
+			"text": `import data`,
+		},
 		"level": "error",
 	}}
 }
 
 test_fail_import_data_aliased if {
 	r := rule.report with input as ast.policy(`import data as d`)
+
 	r == {{
 		"category": "imports",
 		"description": "Redundant import of data",
@@ -31,12 +42,22 @@ test_fail_import_data_aliased if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/redundant-data-import", "imports"),
 		}],
 		"title": "redundant-data-import",
-		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": `import data as d`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 12,
+				"row": 3,
+			},
+			"text": `import data as d`,
+		},
 		"level": "error",
 	}}
 }
 
 test_success_import_data_path if {
 	r := rule.report with input as ast.policy(`import data.something`)
+
 	r == set()
 }

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -6,6 +6,7 @@ import data.regal.config
 
 import data.regal.rules.imports["unresolved-import"] as rule
 
+# regal ignore:rule-length
 test_fail_identifies_unresolved_imports if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 	import data.bar
@@ -21,11 +22,29 @@ test_fail_identifies_unresolved_imports if {
 
 	x := 1
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == {
-		with_location({"file": "p1.rego", "row": 5, "col": 2, "text": "\timport data.nope"}),
-		with_location({"file": "p1.rego", "row": 4, "col": 2, "text": "\timport data.bar.nope"}),
+		with_location({
+			"file": "p1.rego",
+			"row": 5,
+			"col": 2,
+			"end": {
+				"col": 8,
+				"row": 5,
+			},
+			"text": "\timport data.nope",
+		}),
+		with_location({
+			"file": "p1.rego",
+			"row": 4,
+			"col": 2,
+			"end": {
+				"col": 8,
+				"row": 4,
+			},
+			"text": "\timport data.bar.nope",
+		}),
 	}
 }
 
@@ -40,8 +59,8 @@ test_success_no_unresolved_imports if {
 
 	x := 1
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -56,9 +75,9 @@ test_success_unresolved_imports_are_excepted if {
 
 	x := 1
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
 		with config.for_rule as {"level": "error", "except-imports": ["data.bar.excepted"]}
+
 	r == set()
 }
 
@@ -69,9 +88,9 @@ test_success_unresolved_imports_with_wildcards_are_excepted if {
 
 	x := 1
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": agg1}
 		with config.for_rule as {"level": "error", "except-imports": ["data.bar.*"]}
+
 	r == set()
 }
 
@@ -83,8 +102,8 @@ test_success_resolved_import_in_middle_of_explicit_paths if {
 
 	x.y.z := 1
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -101,8 +120,8 @@ test_success_map_rule_resolves if {
 		z := {"foo": y + 1}
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -119,8 +138,8 @@ test_success_map_rule_may_resolve_so_allow if {
 		z := {"foo": y + 1}
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -137,8 +156,8 @@ test_success_general_ref_head_rule_may_resolve_so_allow if {
 		z := {"foo": y + 1}
 	}
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
+
 	r == set()
 }
 
@@ -148,8 +167,8 @@ test_success_custom_rule_not_flagging_regal_import if {
 
 	x := 1
 	`)
-
 	r := rule.aggregate_report with input as {"aggregate": agg}
+
 	r == set()
 }
 

--- a/bundle/regal/rules/imports/use-rego-v1/use_rego_v1_test.rego
+++ b/bundle/regal/rules/imports/use-rego-v1/use_rego_v1_test.rego
@@ -13,6 +13,7 @@ test_fail_missing_rego_v1_import if {
 	foo if not bar
 	`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "imports",
 		"description": "Use `import rego.v1`",
@@ -21,7 +22,16 @@ test_fail_missing_rego_v1_import if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-rego-v1", "imports"),
 		}],
 		"title": "use-rego-v1",
-		"location": {"col": 1, "file": "policy.rego", "row": 1, "text": "package policy"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 1,
+			"end": {
+				"col": 8,
+				"row": 1,
+			},
+			"text": "package policy",
+		},
 		"level": "error",
 	}}
 }

--- a/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context_test.rego
+++ b/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context_test.rego
@@ -13,13 +13,22 @@ test_fail_with_used_outside_test if {
 		not foo.deny with input as {}
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "performance",
 		"description": "`with` used outside test context",
 		"level": "error",
-		"location": {"col": 16, "file": "policy.rego", "row": 7, "text": "\t\tnot foo.deny with input as {}"},
+		"location": {
+			"col": 16,
+			"file": "policy.rego",
+			"row": 7,
+			"end": {
+				"col": 32,
+				"row": 7,
+			},
+			"text": "\t\tnot foo.deny with input as {}",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/with-outside-test-context", "performance"),
@@ -34,8 +43,8 @@ test_success_with_used_in_test if {
 		not foo.deny with input as {}
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -45,7 +54,7 @@ test_success_with_used_in_todo_test if {
 		not foo.deny with input as {}
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }

--- a/bundle/regal/rules/style/avoid-get-and-list-prefix/avoid_get_and_list_prefix_test.rego
+++ b/bundle/regal/rules/style/avoid-get-and-list-prefix/avoid_get_and_list_prefix_test.rego
@@ -8,21 +8,7 @@ import data.regal.rules.style["avoid-get-and-list-prefix"] as rule
 
 test_fail_rule_name_starts_with_get if {
 	r := rule.report with input as ast.policy(`get_foo := 1`)
-	r == {{
-		"category": "style",
-		"description": "Avoid `get_` and `list_` prefix for rules and functions",
-		"related_resources": [{
-			"description": "documentation",
-			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-get-and-list-prefix", "style"),
-		}],
-		"title": "avoid-get-and-list-prefix",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "get_foo := 1"},
-		"level": "error",
-	}}
-}
 
-test_fail_function_name_starts_with_list if {
-	r := rule.report with input as ast.policy(`list_users(datasource) := ["we", "have", "no", "users"]`)
 	r == {{
 		"category": "style",
 		"description": "Avoid `get_` and `list_` prefix for rules and functions",
@@ -32,7 +18,38 @@ test_fail_function_name_starts_with_list if {
 		}],
 		"title": "avoid-get-and-list-prefix",
 		"location": {
-			"col": 1, "file": "policy.rego", "row": 3,
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 13,
+				"row": 3,
+			},
+			"text": "get_foo := 1",
+		},
+		"level": "error",
+	}}
+}
+
+test_fail_function_name_starts_with_list if {
+	r := rule.report with input as ast.policy(`list_users(datasource) := ["we", "have", "no", "users"]`)
+
+	r == {{
+		"category": "style",
+		"description": "Avoid `get_` and `list_` prefix for rules and functions",
+		"related_resources": [{
+			"description": "documentation",
+			"ref": config.docs.resolve_url("$baseUrl/$category/avoid-get-and-list-prefix", "style"),
+		}],
+		"title": "avoid-get-and-list-prefix",
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 56,
+				"row": 3,
+			},
 			"text": `list_users(datasource) := ["we", "have", "no", "users"]`,
 		},
 		"level": "error",

--- a/bundle/regal/rules/style/chained-rule-body/chained_rule_body_test.rego
+++ b/bundle/regal/rules/style/chained-rule-body/chained_rule_body_test.rego
@@ -13,14 +13,21 @@ test_fail_chained_incremental_definition if {
 	} {
 		input.y
 	}`)
-
 	r := rule.report with input as module
 
 	r == {{
 		"category": "style",
 		"description": "Avoid chaining rule bodies",
 		"level": "error",
-		"location": {"col": 4, "file": "policy.rego", "row": 5, "text": "\t} {"},
+		"location": {
+			"col": 4,
+			"file": "policy.rego",
+			"row": 5, "text": "\t} {",
+			"end": {
+				"col": 3,
+				"row": 7,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/chained-rule-body", "style"),

--- a/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment.rego
+++ b/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment.rego
@@ -42,7 +42,7 @@ report contains violation if {
 	rhs.type in {"var", "ref"}
 	not _dynamic_ref(rhs)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr))
+	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(expr.terms))
 }
 
 # METADATA
@@ -68,7 +68,7 @@ report contains violation if {
 	rhs.type in {"var", "ref"}
 	not _dynamic_ref(rhs)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(expr))
+	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(expr.terms))
 }
 
 _dynamic_ref(value) if {

--- a/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
+++ b/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
@@ -12,13 +12,22 @@ test_fail_comprehension_term_assignment_last_expr if {
 		some y in input
 		x := y
 	]`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "style",
 		"description": "Assignment can be moved to comprehension term",
 		"level": "error",
-		"location": {"col": 3, "end": {"col": 9, "row": 7}, "file": "policy.rego", "row": 7, "text": "\t\tx := y"},
+		"location": {
+			"col": 3,
+			"end": {
+				"col": 9,
+				"row": 7,
+			},
+			"file": "policy.rego",
+			"row": 7,
+			"text": "\t\tx := y",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/comprehension-term-assignment", "style"),

--- a/bundle/regal/rules/style/default-over-else/default_over_else_test.rego
+++ b/bundle/regal/rules/style/default-over-else/default_over_else_test.rego
@@ -15,9 +15,18 @@ test_fail_conditionless_else_simple_rule if {
 		input.y
 	} else := 3
 	`)
-
 	r := rule.report with input as module
-	r == with_location({"col": 4, "file": "policy.rego", "row": 8, "text": "\t} else := 3"})
+
+	r == with_location({
+		"col": 4,
+		"file": "policy.rego",
+		"row": 8,
+		"end": {
+			"col": 13,
+			"row": 8,
+		},
+		"text": "\t} else := 3",
+	})
 }
 
 test_fail_conditionless_else_object_assignment if {
@@ -26,9 +35,18 @@ test_fail_conditionless_else_object_assignment if {
 		input.x
 	} else := {"bar": "foo"}
 	`)
-
 	r := rule.report with input as module
-	r == with_location({"col": 4, "file": "policy.rego", "row": 6, "text": "\t} else := {\"bar\": \"foo\"}"})
+
+	r == with_location({
+		"col": 4,
+		"file": "policy.rego",
+		"row": 6,
+		"end": {
+			"col": 26,
+			"row": 6,
+		},
+		"text": "\t} else := {\"bar\": \"foo\"}",
+	})
 }
 
 test_success_conditionless_else_not_constant if {
@@ -39,8 +57,8 @@ test_success_conditionless_else_not_constant if {
 		input.x
 	} else := {"bar": y}
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -50,8 +68,8 @@ test_success_conditionless_else_input_ref if {
 		input.x
 	} else := input.foo
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -61,8 +79,8 @@ test_success_conditionless_else_custom_function if {
 		input.foo
 	} else := 1
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -72,12 +90,21 @@ test_fail_conditionless_else_custom_function_prefer_default_functions if {
 		input.foo
 	} else := 1
 	`)
-
 	r := rule.report with input as module with config.for_rule as {
 		"level": "error",
 		"prefer-default-functions": true,
 	}
-	r == with_location({"col": 4, "file": "policy.rego", "row": 6, "text": "\t} else := 1"})
+
+	r == with_location({
+		"col": 4,
+		"file": "policy.rego",
+		"row": 6,
+		"end": {
+			"col": 13,
+			"row": 6,
+		},
+		"text": "\t} else := 1",
+	})
 }
 
 test_success_conditionless_else_custom_function_not_constant if {
@@ -86,11 +113,11 @@ test_success_conditionless_else_custom_function_not_constant if {
 		input.foo
 	} else := y
 	`)
-
 	r := rule.report with input as module with config.for_rule as {
 		"level": "error",
 		"prefer-default-functions": true,
 	}
+
 	r == set()
 }
 

--- a/bundle/regal/rules/style/default-over-not/default_over_not_test.rego
+++ b/bundle/regal/rules/style/default-over-not/default_over_not_test.rego
@@ -13,11 +13,21 @@ test_fail_default_over_not if {
 	user := "foo" if not input.user
 	`)
 	r := rule.report with input as module
+
 	r == {{
 		"category": "style",
 		"description": "Prefer default assignment over negated condition",
 		"level": "error",
-		"location": {"col": 19, "file": "policy.rego", "row": 7, "text": "\tuser := \"foo\" if not input.user"},
+		"location": {
+			"col": 19,
+			"file": "policy.rego",
+			"row": 7,
+			"end": {
+				"col": 33,
+				"row": 7,
+			},
+			"text": "\tuser := \"foo\" if not input.user",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/default-over-not", "style"),

--- a/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
+++ b/bundle/regal/rules/style/detached-metadata/detached_metadata_test.rego
@@ -15,11 +15,21 @@ package p
 
 allow := true
 `)
+
 	r == {{
 		"category": "style",
 		"description": "Detached metadata annotation",
 		"level": "error",
-		"location": {"col": 1, "file": "p.rego", "row": 4, "text": "# METADATA"},
+		"location": {
+			"col": 1,
+			"file": "p.rego",
+			"row": 4,
+			"end": {
+				"col": 36,
+				"row": 5,
+			},
+			"text": "# METADATA",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/detached-metadata", "style"),
@@ -43,7 +53,16 @@ allow := true
 		"category": "style",
 		"description": "Detached metadata annotation",
 		"level": "error",
-		"location": {"col": 1, "file": "p.rego", "row": 4, "text": "# METADATA"},
+		"location": {
+			"col": 1,
+			"file": "p.rego",
+			"row": 4,
+			"end": {
+				"col": 36,
+				"row": 5,
+			},
+			"text": "# METADATA",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/detached-metadata", "style"),
@@ -103,7 +122,16 @@ package p
 		"category": "style",
 		"description": "Detached metadata annotation",
 		"level": "error",
-		"location": {"col": 1, "file": "p.rego", "row": 5, "text": "# METADATA"},
+		"location": {
+			"col": 1,
+			"file": "p.rego",
+			"row": 5,
+			"end": {
+				"col": 21,
+				"row": 7,
+			},
+			"text": "# METADATA",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/detached-metadata", "style"),

--- a/bundle/regal/rules/style/double-negative/double_negative_test.rego
+++ b/bundle/regal/rules/style/double-negative/double_negative_test.rego
@@ -15,10 +15,19 @@ test_fail_double_negative if {
 
     fine if not not_fine
     `)
+
 	r == {{
 		"category": "style",
 		"description": "Avoid double negatives",
-		"location": {"col": 13, "file": "policy.rego", "row": 8, "text": "    fine if not not_fine"},
+		"location": {
+			"col": 13,
+			"file": "policy.rego",
+			"row": 8, "text": "    fine if not not_fine",
+			"end": {
+				"col": 25,
+				"row": 8,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/double-negative", "style"),

--- a/bundle/regal/rules/style/external-reference/external_reference_test.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference_test.rego
@@ -10,13 +10,31 @@ import data.regal.rules.style["external-reference"] as rule
 test_fail_function_references_input if {
 	r := rule.report with input as ast.policy(`f(_) { input.foo }`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 3, "text": `f(_) { input.foo }`})
+	r == expected_with_location({
+		"col": 8,
+		"file": "policy.rego",
+		"row": 3,
+		"end": {
+			"col": 13,
+			"row": 3,
+		},
+		"text": `f(_) { input.foo }`,
+	})
 }
 
 test_fail_function_references_data if {
 	r := rule.report with input as ast.policy(`f(_) { data.foo }`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 3, "text": `f(_) { data.foo }`})
+	r == expected_with_location({
+		"col": 8,
+		"file": "policy.rego",
+		"row": 3,
+		"end": {
+			"col": 12,
+			"row": 3,
+		},
+		"text": `f(_) { data.foo }`,
+	})
 }
 
 test_fail_function_references_data_in_expr if {
@@ -24,7 +42,16 @@ test_fail_function_references_data_in_expr if {
 		x == data.foo
 	}`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == expected_with_location({"col": 8, "file": "policy.rego", "row": 4, "text": "\t\tx == data.foo"})
+	r == expected_with_location({
+		"col": 8,
+		"file": "policy.rego",
+		"row": 4,
+		"end": {
+			"col": 12,
+			"row": 4,
+		},
+		"text": "\t\tx == data.foo",
+	})
 }
 
 test_fail_function_references_rule if {
@@ -37,19 +64,46 @@ f(x, y) {
 }
 	`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == expected_with_location({"col": 7, "file": "policy.rego", "row": 8, "text": `	y == foo`})
+	r == expected_with_location({
+		"col": 7,
+		"file": "policy.rego",
+		"row": 8,
+		"end": {
+			"col": 10,
+			"row": 8,
+		},
+		"text": `	y == foo`,
+	})
 }
 
 test_fail_external_reference_in_head_assignment if {
 	r := rule.report with input as ast.policy(`f(_) := r`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == expected_with_location({"col": 9, "file": "policy.rego", "row": 3, "text": "f(_) := r"})
+	r == expected_with_location({
+		"col": 9,
+		"file": "policy.rego",
+		"row": 3,
+		"end": {
+			"col": 10,
+			"row": 3,
+		},
+		"text": "f(_) := r",
+	})
 }
 
 test_fail_external_reference_in_head_terms if {
 	r := rule.report with input as ast.policy(`f(_) := {"r": r}`)
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == expected_with_location({"col": 15, "file": "policy.rego", "row": 3, "text": "f(_) := {\"r\": r}"})
+	r == expected_with_location({
+		"col": 15,
+		"file": "policy.rego",
+		"row": 3,
+		"end": {
+			"col": 16,
+			"row": 3,
+		},
+		"text": "f(_) := {\"r\": r}",
+	})
 }
 
 test_success_function_references_no_input_or_data if {

--- a/bundle/regal/rules/style/file-length/file_length_test.rego
+++ b/bundle/regal/rules/style/file-length/file_length_test.rego
@@ -6,6 +6,7 @@ import data.regal.config
 
 import data.regal.rules.style["file-length"] as rule
 
+# regal ignore:rule-length
 test_fail_configured_file_length_exceeded if {
 	module := regal.parse_module("policy.rego", `package policy
 
@@ -17,11 +18,21 @@ test_fail_configured_file_length_exceeded if {
 		"level": "error",
 		"max-file-length": 2,
 	}
+
 	r == {{
 		"category": "style",
 		"description": "Max file length exceeded",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 1, "text": "package policy"},
+		"location": {
+			"col": 1,
+			"row": 1,
+			"end": {
+				"col": 8,
+				"row": 1,
+			},
+			"file": "policy.rego",
+			"text": "package policy",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/file-length", "style"),

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
@@ -11,11 +11,21 @@ test_fail_function_arg_return_value if {
 	r := rule.report with input as ast.policy(`foo := i { indexof("foo", "o", i) }`)
 		with config.for_rule as {"level": "error"}
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "style",
 		"description": "Function argument used for return value",
 		"level": "error",
-		"location": {"col": 32, "file": "policy.rego", "row": 3, "text": "foo := i { indexof(\"foo\", \"o\", i) }"},
+		"location": {
+			"col": 32,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 33,
+				"row": 3,
+			},
+			"text": "foo := i { indexof(\"foo\", \"o\", i) }",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/function-arg-return", "style"),
@@ -32,7 +42,16 @@ test_fail_function_arg_return_value_multi_part_ref if {
 		"category": "style",
 		"description": "Function argument used for return value",
 		"level": "error",
-		"location": {"col": 38, "file": "policy.rego", "row": 3, "text": `foo := r { regex.match("foo", "foo", r) }`},
+		"location": {
+			"col": 38,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 39,
+				"row": 3,
+			},
+			"text": `foo := r { regex.match("foo", "foo", r) }`,
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/function-arg-return", "style"),

--- a/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
+++ b/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
@@ -15,8 +15,8 @@ test_success_non_messy_definition if {
 
 	bar if false
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -28,9 +28,17 @@ test_fail_messy_definition if {
 
 	foo if 5 == 1
 	`)
-
 	r := rule.report with input as module
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 10, "text": "\tfoo if 5 == 1"})
+
+	r == expected_with_location({
+		"col": 2,
+		"row": 10,
+		"end": {
+			"col": 15,
+			"row": 10,
+		},
+		"text": "\tfoo if 5 == 1",
+	})
 }
 
 test_fail_messy_default_definition if {
@@ -41,9 +49,17 @@ test_fail_messy_default_definition if {
 
 	foo if 5 == 1
 	`)
-
 	r := rule.report with input as module
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 10, "text": "\tfoo if 5 == 1"})
+
+	r == expected_with_location({
+		"col": 2,
+		"row": 10,
+		"end": {
+			"col": 15,
+			"row": 10,
+		},
+		"text": "\tfoo if 5 == 1",
+	})
 }
 
 test_fail_messy_nested_rule_definition if {
@@ -54,9 +70,17 @@ test_fail_messy_nested_rule_definition if {
 
 	base.foo if 5 == 1
 	`)
-
 	r := rule.report with input as module
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 10, "text": "\tbase.foo if 5 == 1"})
+
+	r == expected_with_location({
+		"col": 2,
+		"row": 10,
+		"end": {
+			"col": 20,
+			"row": 10,
+		},
+		"text": "\tbase.foo if 5 == 1",
+	})
 }
 
 test_success_non_incremental_nested_rule_definition if {
@@ -67,8 +91,8 @@ test_success_non_incremental_nested_rule_definition if {
 
 	base.bar if 5 == 1
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -93,9 +117,17 @@ test_fail_messy_incremental_nested_variable_rule_definitiion if {
 
 	base[x].foo := 1 if { x := 1 }
 	`)
-
 	r := rule.report with input as module
-	r == expected_with_location({"col": 2, "file": "policy.rego", "row": 10, "text": "\tbase[x].foo := 1 if { x := 1 }"})
+
+	r == expected_with_location({
+		"col": 2,
+		"row": 10,
+		"end": {
+			"col": 32,
+			"row": 10,
+		},
+		"text": "\tbase[x].foo := 1 if { x := 1 }",
+	})
 }
 
 expected := {
@@ -107,6 +139,7 @@ expected := {
 		"ref": config.docs.resolve_url("$baseUrl/$category/messy-rule", "style"),
 	}],
 	"title": "messy-rule",
+	"location": {"file": "policy.rego"},
 }
 
 # regal ignore:external-reference

--- a/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment_test.rego
+++ b/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment_test.rego
@@ -8,6 +8,7 @@ import data.regal.rules.style["no-whitespace-comment"] as rule
 
 test_fail_no_leading_whitespace if {
 	r := rule.report with input as ast.policy(`#foo`)
+
 	r == {{
 		"category": "style",
 		"description": "Comment should start with whitespace",
@@ -16,13 +17,23 @@ test_fail_no_leading_whitespace if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/no-whitespace-comment", "style"),
 		}],
 		"title": "no-whitespace-comment",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "#foo"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 5,
+				"row": 3,
+			},
+			"text": "#foo",
+		},
 		"level": "error",
 	}}
 }
 
 test_fail_no_leading_whitespace_multiple_hashes if {
 	r := rule.report with input as ast.policy(`##foo`)
+
 	r == {{
 		"category": "style",
 		"description": "Comment should start with whitespace",
@@ -31,28 +42,41 @@ test_fail_no_leading_whitespace_multiple_hashes if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/no-whitespace-comment", "style"),
 		}],
 		"title": "no-whitespace-comment",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "##foo"},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 6,
+				"row": 3,
+			},
+			"text": "##foo",
+		},
 		"level": "error",
 	}}
 }
 
 test_success_excepted_pattern if {
 	r := rule.report with input as ast.policy(`#-- foo`) with config.for_rule as {"except-pattern": "^--"}
+
 	r == set()
 }
 
 test_success_leading_whitespace if {
 	r := rule.report with input as ast.policy(`# foo`)
+
 	r == set()
 }
 
 test_success_leading_whitespace_double_hash if {
 	r := rule.report with input as ast.policy(`## foo`)
+
 	r == set()
 }
 
 test_success_lonely_hash if {
 	r := rule.report with input as ast.policy(`#`)
+
 	r == set()
 }
 
@@ -61,6 +85,7 @@ test_success_comment_with_newline if {
 	# foo
 	#
 	# bar`)
+
 	r == set()
 }
 
@@ -69,5 +94,6 @@ test_success_multiple_hash_comment if {
 	##########
 	# Foobar #
 	##########`)
+
 	r == set()
 }

--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
@@ -28,5 +28,5 @@ report contains violation if {
 
 	ast.assignment_terms(expr)[1].type == "var"
 
-	violation := result.fail(rego.metadata.chain(), result.location(expr.terms))
+	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(expr.terms))
 }

--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
@@ -19,7 +19,16 @@ test_pointless_reassignment_in_rule_head if {
 		"category": "style",
 		"description": "Pointless reassignment of variable",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 8, "text": "\tbar := foo"},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 8,
+			"text": "\tbar := foo",
+			"end": {
+				"col": 12,
+				"row": 8,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-reassignment", "style"),
@@ -42,7 +51,16 @@ test_pointless_reassignment_in_rule_body if {
 		"category": "style",
 		"description": "Pointless reassignment of variable",
 		"level": "error",
-		"location": {"col": 7, "file": "policy.rego", "row": 9, "text": "\t\tbar := foo"},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 9,
+			"end": {
+				"col": 13,
+				"row": 9,
+			},
+			"text": "\t\tbar := foo",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/pointless-reassignment", "style"),

--- a/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
+++ b/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
@@ -13,12 +13,12 @@ report contains violation if {
 	some part in ast.named_refs(rule.head.ref)
 	not util.is_snake_case(part.value)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(part))
+	violation := result.fail(rego.metadata.chain(), result.location(part))
 }
 
 report contains violation if {
 	var := ast.found.vars[_][_][_]
 	not util.is_snake_case(var.value)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(var))
+	violation := result.fail(rego.metadata.chain(), result.location(var))
 }

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration_test.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration_test.rego
@@ -15,7 +15,17 @@ test_fail_simple_iteration if {
 	r := rule.report with config.for_rule as allow_nesting(2)
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == with_location({"col": 10, "file": "policy.rego", "row": 6, "text": "\t\tvar := input.foo[_]"})
+
+	r == with_location({
+		"col": 10,
+		"file": "policy.rego",
+		"row": 6,
+		"end": {
+			"col": 22,
+			"row": 6,
+		},
+		"text": "\t\tvar := input.foo[_]",
+	})
 }
 
 test_fail_simple_iteration_comprehension if {
@@ -25,7 +35,17 @@ test_fail_simple_iteration_comprehension if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == with_location({"col": 8, "file": "policy.rego", "row": 6, "text": "\t\tp := input.foo[_]"})
+
+	r == with_location({
+		"col": 8,
+		"file": "policy.rego",
+		"row": 6,
+		"end": {
+			"col": 20,
+			"row": 6,
+		},
+		"text": "\t\tp := input.foo[_]",
+	})
 }
 
 test_fail_simple_iteration_output_var if {
@@ -35,7 +55,17 @@ test_fail_simple_iteration_output_var if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == with_location({"col": 3, "file": "policy.rego", "row": 6, "text": "\t\tinput.foo[x]"})
+
+	r == with_location({
+		"col": 3,
+		"file": "policy.rego",
+		"row": 6,
+		"end": {
+			"col": 15,
+			"row": 6,
+		},
+		"text": "\t\tinput.foo[x]",
+	})
 }
 
 test_fail_simple_iteration_output_var_some_decl if {
@@ -46,7 +76,17 @@ test_fail_simple_iteration_output_var_some_decl if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == with_location({"col": 3, "file": "policy.rego", "row": 7, "text": "\t\tinput.foo[x]"})
+
+	r == with_location({
+		"col": 3,
+		"file": "policy.rego",
+		"row": 7,
+		"end": {
+			"col": 15,
+			"row": 7,
+		},
+		"text": "\t\tinput.foo[x]",
+	})
 }
 
 test_success_some_in_var_input if {
@@ -57,6 +97,7 @@ test_success_some_in_var_input if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -68,6 +109,7 @@ test_success_allow_nesting_zero if {
 
 	r := rule.report with config.for_rule as allow_nesting(0) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -78,6 +120,7 @@ test_success_allow_nesting_one if {
 
 	r := rule.report with config.for_rule as allow_nesting(1) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -88,6 +131,7 @@ test_success_allow_nesting_two if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -98,7 +142,17 @@ test_fail_allow_nesting_two if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == with_location({"col": 3, "file": "policy.rego", "row": 6, "text": "\t\tinput.foo[_]"})
+
+	r == with_location({
+		"col": 3,
+		"file": "policy.rego",
+		"row": 6,
+		"end": {
+			"col": 15,
+			"row": 6,
+		},
+		"text": "\t\tinput.foo[_]",
+	})
 }
 
 test_success_not_output_vars if {
@@ -112,6 +166,7 @@ test_success_not_output_vars if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -127,10 +182,11 @@ test_success_output_var_to_input_var if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
-test_success_complex_comprehension_term if {
+test_fail_complex_comprehension_term if {
 	policy := ast.with_rego_v1(`
 
 	foo := [{"foo": bar} | input[bar]]
@@ -138,6 +194,7 @@ test_success_complex_comprehension_term if {
 
 	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -154,6 +211,7 @@ test_success_allow_if_subattribute if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -170,7 +228,17 @@ test_fail_ignore_if_subattribute_disabled if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
-	r == with_location({"col": 10, "file": "policy.rego", "row": 6, "text": "\t\tbar := input.foo[_].bar"})
+
+	r == with_location({
+		"col": 10,
+		"file": "policy.rego",
+		"row": 6,
+		"end": {
+			"col": 26,
+			"row": 6,
+		},
+		"text": "\t\tbar := input.foo[_].bar",
+	})
 }
 
 test_success_allow_if_inside_array if {
@@ -185,6 +253,7 @@ test_success_allow_if_inside_array if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -198,6 +267,7 @@ test_success_allow_if_inside_set if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -211,6 +281,7 @@ test_success_allow_if_inside_object if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -224,6 +295,7 @@ test_success_allow_if_inside_rule_head_key if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -238,6 +310,7 @@ test_success_allow_if_contains_check_eq if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -252,6 +325,7 @@ test_success_allow_if_contains_check_equal if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -266,6 +340,7 @@ test_success_iteration_in_args if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -278,6 +353,7 @@ test_success_iteration_in_args_call_in_comprehension_head if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 
@@ -290,6 +366,7 @@ test_success_top_level_iteration if {
 	}
 		with input as policy
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }
 

--- a/bundle/regal/rules/style/rule-length/rule_length.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length.rego
@@ -12,7 +12,8 @@ report contains violation if {
 	cfg := config.for_rule("style", "rule-length")
 
 	some rule in input.rules
-	lines := split(base64.decode(util.to_location_object(rule.location).text), "\n")
+
+	lines := split(util.to_location_object(rule.location).text, "\n")
 
 	_line_count(cfg, rule, lines) > cfg["max-rule-length"]
 

--- a/bundle/regal/rules/style/rule-length/rule_length_test.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length_test.rego
@@ -6,6 +6,8 @@ import data.regal.config
 
 import data.regal.rules.style["rule-length"] as rule
 
+# yes, ironic
+# regal ignore:rule-length
 test_fail_rule_longer_than_configured_max_length if {
 	module := regal.parse_module("policy.rego", `package p
 
@@ -16,17 +18,26 @@ test_fail_rule_longer_than_configured_max_length if {
 		input.x
 	}
 	`)
-
 	r := rule.report with input as module with config.for_rule as {
 		"level": "error",
 		"max-rule-length": 3,
 		"count-comments": true,
 	}
+
 	r == {{
 		"category": "style",
 		"description": "Max rule length exceeded",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 3, "text": "\tmy_long_rule {"},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 14,
+				"row": 3,
+			},
+			"text": "\tmy_long_rule {",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/rule-length", "style"),

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
@@ -16,11 +16,9 @@ import data.regal.util
 report contains violation if {
 	some rule in input.rules
 
-	name := ast.ref_static_to_string(rule.head.ref)
+	strings.any_prefix_match(ast.ref_static_to_string(rule.head.ref), _possible_offending_prefixes)
 
-	strings.any_prefix_match(name, _possible_offending_prefixes)
-
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(rule.head.ref[0]))
+	violation := result.fail(rego.metadata.chain(), result.location(rule.head.ref[0]))
 }
 
 _titleize(str) := upper(str) if count(str) == 1

--- a/bundle/regal/rules/style/todo-comment/todo_comment_test.rego
+++ b/bundle/regal/rules/style/todo-comment/todo_comment_test.rego
@@ -8,6 +8,7 @@ import data.regal.rules.style["todo-comment"] as rule
 
 test_fail_todo_comment if {
 	r := rule.report with input as ast.policy(`# TODO: do something clever`)
+
 	r == {{
 		"category": "style",
 		"description": "Avoid TODO comments",
@@ -16,13 +17,23 @@ test_fail_todo_comment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/todo-comment", "style"),
 		}],
 		"title": "todo-comment",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": `# TODO: do something clever`},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 28,
+				"row": 3,
+			},
+			"text": `# TODO: do something clever`,
+		},
 		"level": "error",
 	}}
 }
 
 test_fail_fixme_comment if {
 	r := rule.report with input as ast.policy(`# fixme: this is broken`)
+
 	r == {{
 		"category": "style",
 		"description": "Avoid TODO comments",
@@ -31,7 +42,16 @@ test_fail_fixme_comment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/todo-comment", "style"),
 		}],
 		"title": "todo-comment",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": `# fixme: this is broken`},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 24,
+				"row": 3,
+			},
+			"text": `# fixme: this is broken`,
+		},
 		"level": "error",
 	}}
 }

--- a/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule_test.rego
+++ b/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule_test.rego
@@ -13,8 +13,8 @@ test_success_default_declared_first if {
 
 	foo if true
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -24,13 +24,22 @@ test_fail_default_declared_after if {
 
 	default foo := true
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "style",
 		"description": "Default rule should be declared first",
 		"level": "error",
-		"location": {"col": 2, "file": "policy.rego", "row": 8, "text": "\tdefault foo := true"},
+		"location": {
+			"col": 2,
+			"file": "policy.rego",
+			"row": 8,
+			"end": {
+				"col": 9,
+				"row": 8,
+			},
+			"text": "\tdefault foo := true",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/trailing-default-rule", "style"),

--- a/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment.rego
+++ b/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment.rego
@@ -36,7 +36,7 @@ report contains violation if {
 	rule.body[0].terms[1].type == "var"
 	rule.body[0].terms[1].value == rule.head.value.value
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule.body[0].terms[1]))
+	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(rule.body[0].terms))
 }
 
 # Multi-value rules
@@ -56,7 +56,7 @@ report contains violation if {
 	rule.body[0].terms[1].type == "var"
 	rule.body[0].terms[1].value == rule.head.key.value
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule.body[0].terms[1]))
+	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(rule.body[0].terms))
 }
 
 # Assignment using either = or :=

--- a/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment_test.rego
+++ b/bundle/regal/rules/style/unconditional-assignment/unconditional_assignment_test.rego
@@ -10,6 +10,7 @@ test_fail_unconditional_assignment_in_body if {
 	r := rule.report with input as ast.policy(`x := y {
 		y := 1
 	}`)
+
 	r == {{
 		"category": "style",
 		"description": "Unconditional assignment in rule body",
@@ -18,7 +19,16 @@ test_fail_unconditional_assignment_in_body if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
 		}],
 		"title": "unconditional-assignment",
-		"location": {"col": 3, "file": "policy.rego", "row": 4, "text": "\t\ty := 1"},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 4,
+			"end": {
+				"col": 9,
+				"row": 4,
+			},
+			"text": "\t\ty := 1",
+		},
 		"level": "error",
 	}}
 }
@@ -27,6 +37,7 @@ test_fail_unconditional_eq_in_body if {
 	r := rule.report with input as ast.policy(`x = y {
 		y = 1
 	}`)
+
 	r == {{
 		"category": "style",
 		"description": "Unconditional assignment in rule body",
@@ -35,18 +46,29 @@ test_fail_unconditional_eq_in_body if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
 		}],
 		"title": "unconditional-assignment",
-		"location": {"col": 3, "file": "policy.rego", "row": 4, "text": "\t\ty = 1"},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 4,
+			"end": {
+				"col": 8,
+				"row": 4,
+			},
+			"text": "\t\ty = 1",
+		},
 		"level": "error",
 	}}
 }
 
 test_success_conditional_assignment_in_body if {
 	r := rule.report with input as ast.policy(`x := y { input.foo == "bar"; y := 1 }`)
+
 	r == set()
 }
 
 test_success_unconditional_assignment_but_with_in_body if {
 	r := rule.report with input as ast.policy(`x := y { y := 5 with input as 1 }`)
+
 	r == set()
 }
 
@@ -54,6 +76,7 @@ test_success_unconditional_assignment_but_else if {
 	r := rule.report with input as ast.policy(`msg := x {
     	x := input.foo
     } else := input.bar`)
+
 	r == set()
 }
 
@@ -61,6 +84,7 @@ test_fail_unconditional_multi_value_assignment if {
 	r := rule.report with input as ast.with_rego_v1(`x contains y if {
 		y := 1
 	}`)
+
 	r == {{
 		"category": "style",
 		"description": "Unconditional assignment in rule body",
@@ -69,7 +93,16 @@ test_fail_unconditional_multi_value_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
 		}],
 		"title": "unconditional-assignment",
-		"location": {"col": 3, "file": "policy.rego", "row": 6, "text": "\t\ty := 1"},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 9,
+				"row": 6,
+			},
+			"text": "\t\ty := 1",
+		},
 		"level": "error",
 	}}
 }
@@ -78,6 +111,7 @@ test_fail_unconditional_map_assignment if {
 	r := rule.report with input as ast.with_rego_v1(`x["y"] := y if {
 		y := 1
 	}`)
+
 	r == {{
 		"category": "style",
 		"description": "Unconditional assignment in rule body",
@@ -86,7 +120,16 @@ test_fail_unconditional_map_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/unconditional-assignment", "style"),
 		}],
 		"title": "unconditional-assignment",
-		"location": {"col": 3, "file": "policy.rego", "row": 6, "text": "\t\ty := 1"},
+		"location": {
+			"col": 3,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 9,
+				"row": 6,
+			},
+			"text": "\t\ty := 1",
+		},
 		"level": "error",
 	}}
 }

--- a/bundle/regal/rules/style/unnecessary-some/unnecessary_some_test.rego
+++ b/bundle/regal/rules/style/unnecessary-some/unnecessary_some_test.rego
@@ -13,13 +13,22 @@ test_fail_some_unnecessary_value if {
 		some "x" in ["x"]
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "style",
 		"description": "Unnecessary use of `some`",
 		"level": "error",
-		"location": {"col": 8, "file": "policy.rego", "row": 7, "text": "\t\tsome \"x\" in [\"x\"]"},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 7,
+			"end": {
+				"col": 20,
+				"row": 7,
+			},
+			"text": "\t\tsome \"x\" in [\"x\"]",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/unnecessary-some", "style"),
@@ -34,13 +43,22 @@ test_fail_some_unnecessary_key_value if {
 		some "x", 1 in {"x": 1}
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "style",
 		"description": "Unnecessary use of `some`",
 		"level": "error",
-		"location": {"col": 8, "file": "policy.rego", "row": 7, "text": "\t\tsome \"x\", 1 in {\"x\": 1}"},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 7,
+			"end": {
+				"col": 26,
+				"row": 7,
+			},
+			"text": "\t\tsome \"x\", 1 in {\"x\": 1}",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/unnecessary-some", "style"),
@@ -55,8 +73,8 @@ test_success_some_value_using_var if {
 		some var in input.vars
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -66,8 +84,8 @@ test_success_some_key_value_using_var_for_value if {
 		some "x", var in {"x": 1}
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
@@ -77,14 +95,13 @@ test_success_some_key_value_using_var_for_key if {
 		some var, 1 in {"x": 1}
 	}
 	`)
-
 	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_just_in_head if {
-	module := ast.with_rego_v1(`rule := [1 in []]`)
+	r := rule.report with input as ast.with_rego_v1(`rule := [1 in []]`)
 
-	r := rule.report with input as module
 	r == set()
 }

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
@@ -19,8 +19,18 @@ report contains violation if {
 	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
 	loc := result.location(rule)
+	eq_col := _eq_col(loc)
 
-	violation := result.fail(rego.metadata.chain(), object.union(loc, {"location": {"col": _eq_col(loc)}}))
+	violation := result.fail(rego.metadata.chain(), object.union(
+		loc,
+		{"location": {
+			"col": eq_col,
+			"end": {
+				"row": loc.location.row,
+				"col": eq_col + 1,
+			},
+		}},
+	))
 }
 
 report contains violation if {
@@ -32,8 +42,18 @@ report contains violation if {
 	not ast.implicit_boolean_assignment(rule)
 
 	loc := result.location(result.location(rule.head.ref[0]))
+	eq_col := _eq_col(loc)
 
-	violation := result.fail(rego.metadata.chain(), object.union(loc, {"location": {"col": _eq_col(loc)}}))
+	violation := result.fail(rego.metadata.chain(), object.union(
+		loc,
+		{"location": {
+			"col": eq_col,
+			"end": {
+				"row": loc.location.row,
+				"col": eq_col + 1,
+			},
+		}},
+	))
 }
 
 report contains violation if {
@@ -54,8 +74,18 @@ report contains violation if {
 	# extract the text from location to see if '=' is used for
 	# assignment
 	regex.match(`else\s*=`, loc.location.text)
+	eq_col := _eq_col(loc)
 
-	violation := result.fail(rego.metadata.chain(), object.union(loc, {"location": {"col": _eq_col(loc)}}))
+	violation := result.fail(rego.metadata.chain(), object.union(
+		loc,
+		{"location": {
+			"col": eq_col,
+			"end": {
+				"row": loc.location.row,
+				"col": eq_col + 1,
+			},
+		}},
+	))
 }
 
 _eq_col(loc) := max([0, indexof(loc.location.text, "=")]) + 1

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
@@ -16,7 +16,16 @@ test_fail_unification_in_regular_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 5, "file": "policy.rego", "row": 3, "text": "foo = false"},
+		"location": {
+			"col": 5,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 6,
+				"row": 3,
+			},
+			"text": "foo = false",
+		},
 		"level": "error",
 	}}
 }
@@ -31,7 +40,16 @@ test_fail_not_implicit_boolean_assignment_with_body if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 7, "file": "policy.rego", "row": 3, "text": "allow = true { true }"},
+		"location": {
+			"col": 7,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 8,
+				"row": 3,
+			},
+			"text": "allow = true { true }",
+		},
 		"level": "error",
 	}}
 }
@@ -46,7 +64,16 @@ test_fail_not_implicit_boolean_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 5, "file": "policy.rego", "row": 3, "text": "foo = true"},
+		"location": {
+			"col": 5,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 6,
+				"row": 3,
+			},
+			"text": "foo = true",
+		},
 		"level": "error",
 	}}
 }
@@ -66,7 +93,16 @@ test_fail_unification_in_default_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 11, "file": "policy.rego", "row": 3, "text": "default x = false"},
+		"location": {
+			"col": 11,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 12,
+				"row": 3,
+			},
+			"text": "default x = false",
+		},
 		"level": "error",
 	}}
 }
@@ -81,7 +117,16 @@ test_fail_unification_in_default_function_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 14, "file": "policy.rego", "row": 3, "text": "default x(_) = false"},
+		"location": {
+			"col": 14,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 15,
+				"row": 3,
+			},
+			"text": "default x(_) = false",
+		},
 		"level": "error",
 	}}
 }
@@ -106,7 +151,16 @@ test_fail_unification_in_object_rule_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 8, "file": "policy.rego", "row": 3, "text": `x["a"] = 1`},
+		"location": {
+			"col": 8,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 9,
+				"row": 3,
+			},
+			"text": `x["a"] = 1`,
+		},
 		"level": "error",
 	}}
 }
@@ -126,7 +180,16 @@ test_fail_unification_in_function_assignment if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 		}],
 		"title": "use-assignment-operator",
-		"location": {"col": 10, "file": "policy.rego", "row": 3, "text": `foo(bar) = "baz"`},
+		"location": {
+			"col": 10,
+			"file": "policy.rego",
+			"row": 3,
+			"end": {
+				"col": 11,
+				"row": 3,
+			},
+			"text": `foo(bar) = "baz"`,
+		},
 		"level": "error",
 	}}
 }
@@ -179,7 +242,10 @@ test_fail_unification_in_else if {
 				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 			}],
 			"title": "use-assignment-operator",
-			"location": {"col": 9, "file": "policy.rego", "row": 8, "text": "\t} else = true if {"},
+			"location": {"col": 9, "file": "policy.rego", "row": 8, "text": "\t} else = true if {", "end": {
+				"col": 10,
+				"row": 8,
+			}},
 			"level": "error",
 		},
 		{
@@ -190,7 +256,10 @@ test_fail_unification_in_else if {
 				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 			}],
 			"title": "use-assignment-operator",
-			"location": {"col": 9, "file": "policy.rego", "row": 10, "text": "\t} else = false"},
+			"location": {"col": 9, "file": "policy.rego", "row": 10, "text": "\t} else = false", "end": {
+				"col": 10,
+				"row": 10,
+			}},
 			"level": "error",
 		},
 	}

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition.rego
@@ -13,10 +13,11 @@ report contains violation if {
 	value[0].value[0].type == "var"
 	value[0].value[0].value in {"equal", "neq"} # perhaps add more operators here?
 	value[1].type in ast.scalar_types
+
 	not value[2].type in ast.scalar_types
 	not _ref_with_vars(value[2].value)
 
-	violation := result.fail(rego.metadata.chain(), result.location(value))
+	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(value))
 }
 
 _ref_with_vars(ref) if {

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
@@ -17,9 +17,10 @@ test_fail_yoda_conditions if {
 		]
 	}`)
 	r := rule.report with input as module
+
 	r == expected_with_location([
-		{"col": 9, "file": "policy.rego", "row": 4, "text": "\t\t\"foo\" == input.bar"},
-		{"col": 10, "file": "policy.rego", "row": 8, "text": "\t\t\t\"foo\" == foo"},
+		{"col": 3, "end": {"row": 4, "col": 21}, "file": "policy.rego", "row": 4, "text": "\t\t\"foo\" == input.bar"},
+		{"col": 4, "end": {"row": 8, "col": 16}, "file": "policy.rego", "row": 8, "text": "\t\t\t\"foo\" == foo"},
 	])
 }
 
@@ -34,8 +35,8 @@ test_fail_yoda_conditions_not_equals if {
 	}`)
 	r := rule.report with input as module
 	r == expected_with_location([
-		{"col": 9, "file": "policy.rego", "row": 4, "text": "\t\t\"foo\" != input.bar"},
-		{"col": 10, "file": "policy.rego", "row": 8, "text": "\t\t\t\"foo\" != foo"},
+		{"col": 3, "end": {"col": 21, "row": 4}, "file": "policy.rego", "row": 4, "text": "\t\t\"foo\" != input.bar"},
+		{"col": 4, "end": {"col": 16, "row": 8}, "file": "policy.rego", "row": 8, "text": "\t\t\t\"foo\" != foo"},
 	])
 }
 

--- a/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf_test.rego
+++ b/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf_test.rego
@@ -20,7 +20,13 @@ test_fail_print_sprintf if {
 		"description": "Dubious use of print and sprintf",
 		"level": "error",
 		"location": {
-			"col": 9, "file": "policy.rego", "row": 4,
+			"col": 9,
+			"file": "policy.rego",
+			"row": 4,
+			"end": {
+				"col": 16,
+				"row": 4,
+			},
 			"text": "\t\tprint(sprintf(\"name is: %s domain is: %s\", [input.name, input.domain]))",
 		},
 		"related_resources": [{
@@ -45,7 +51,16 @@ test_fail_bodies_print_sprintf if {
 		"category": "testing",
 		"description": "Dubious use of print and sprintf",
 		"level": "error",
-		"location": {"col": 10, "file": "policy.rego", "row": 6, "text": "\t\t\tprint(sprintf(\"x is: %s\", [x]))"},
+		"location": {
+			"col": 10,
+			"file": "policy.rego",
+			"row": 6,
+			"end": {
+				"col": 17,
+				"row": 6,
+			},
+			"text": "\t\t\tprint(sprintf(\"x is: %s\", [x]))",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/dubious-print-sprintf", "testing"),

--- a/bundle/regal/rules/testing/identically-named-tests/identically_named_tests.rego
+++ b/bundle/regal/rules/testing/identically-named-tests/identically_named_tests.rego
@@ -14,7 +14,7 @@ report contains violation if {
 
 	name in array.slice(test_names, 0, i)
 
-	violation := result.fail(rego.metadata.chain(), result.location(_rule_by_name(name, ast.tests)))
+	violation := result.fail(rego.metadata.chain(), result.location(_rule_by_name(name, ast.tests).head))
 }
 
 _rule_by_name(name, rules) := regal.last([rule |

--- a/bundle/regal/rules/testing/identically-named-tests/identically_named_tests_test.rego
+++ b/bundle/regal/rules/testing/identically-named-tests/identically_named_tests_test.rego
@@ -13,6 +13,7 @@ test_fail_identically_named_tests if {
 	test_foo { true }
 	`)
 	r := rule.report with input as ast
+
 	r == {{
 		"category": "testing",
 		"description": "Multiple tests with same name",
@@ -21,7 +22,16 @@ test_fail_identically_named_tests if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/identically-named-tests", "testing"),
 		}],
 		"title": "identically-named-tests",
-		"location": {"col": 2, "file": "foo_test.rego", "row": 5, "text": "\ttest_foo { true }"},
+		"location": {
+			"row": 5,
+			"col": 2,
+			"end": {
+				"col": 10,
+				"row": 5,
+			},
+			"file": "foo_test.rego",
+			"text": "\ttest_foo { true }",
+		},
 		"level": "error",
 	}}
 }

--- a/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable.rego
+++ b/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable.rego
@@ -38,7 +38,7 @@ report contains violation if {
 	# }
 	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(part))
+	violation := result.fail(rego.metadata.chain(), result.location(part))
 }
 
 report contains violation if {
@@ -49,5 +49,5 @@ report contains violation if {
 
 	ast.is_output_var(input.rules[to_number(i)], var)
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(var))
+	violation := result.fail(rego.metadata.chain(), result.location(var))
 }

--- a/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
+++ b/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
@@ -16,7 +16,10 @@ test_fail_rule_named_foo if {
 		"file": "policy.rego",
 		"row": 3,
 		"text": "foo := true",
-		"end": {"col": 4, "row": 3},
+		"end": {
+			"col": 4,
+			"row": 3,
+		},
 	})}
 }
 
@@ -33,14 +36,20 @@ test_fail_metasyntactic_vars if {
 			"file": "policy.rego",
 			"row": 4,
 			"text": "\t\tfooBar := true",
-			"end": {"col": 9, "row": 4},
+			"end": {
+				"col": 9,
+				"row": 4,
+			},
 		}),
 		expected_with_location({
 			"col": 9,
 			"file": "policy.rego",
 			"row": 5,
 			"text": "\t\tinput[baz]",
-			"end": {"col": 12, "row": 5},
+			"end": {
+				"col": 12,
+				"row": 5,
+			},
 		}),
 	}
 }

--- a/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call_test.rego
+++ b/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call_test.rego
@@ -18,12 +18,14 @@ test_fail_call_to_print_and_trace if {
 			"col": 3,
 			"file": "policy.rego",
 			"row": 4,
+			"end": {"col": 8, "row": 4},
 			"text": "\t\tprint(\"foo\")",
 		}),
 		expected_with_location({
 			"col": 20,
 			"file": "policy.rego",
 			"row": 6,
+			"end": {"col": 25, "row": 6},
 			"text": "\t\tx := [i | i = 0; trace(\"bar\")]",
 		}),
 	}

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package.rego
@@ -12,7 +12,7 @@ report contains violation if {
 
 	some rule in ast.tests
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_location_from_text(rule.head))
+	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
 }
 
 _is_test_package(package_name) if endswith(package_name, "_test")

--- a/bundle/regal/rules/testing/todo-test/todo_test_test.rego
+++ b/bundle/regal/rules/testing/todo-test/todo_test_test.rego
@@ -14,6 +14,7 @@ test_fail_todo_test if {
 	test_bar { true }
 	`)
 	r := rule.report with input as ast
+
 	r == {{
 		"category": "testing",
 		"description": "TODO test encountered",
@@ -22,7 +23,16 @@ test_fail_todo_test if {
 			"ref": config.docs.resolve_url("$baseUrl/$category/todo-test", "testing"),
 		}],
 		"title": "todo-test",
-		"location": {"col": 2, "file": "foo_test.rego", "row": 4, "text": "\ttodo_test_foo { false }"},
+		"location": {
+			"col": 2,
+			"file": "foo_test.rego",
+			"row": 4,
+			"end": {
+				"col": 15,
+				"row": 4,
+			},
+			"text": "\ttodo_test_foo { false }",
+		},
 		"level": "error",
 	}}
 }

--- a/bundle/regal/util/util_test.rego
+++ b/bundle/regal/util/util_test.rego
@@ -24,3 +24,23 @@ test_rest if {
 	util.rest([1]) == []
 	util.rest([]) == []
 }
+
+test_to_location_object if {
+	loc := util.to_location_object("3:1:5:2") with input.regal.file.lines as [
+		"package p",
+		"",
+		"allow if {",
+		"\ttrue",
+		"}",
+	]
+
+	loc == {
+		"row": 3,
+		"col": 1,
+		"end": {
+			"row": 5,
+			"col": 2,
+		},
+		"text": "allow if {\n\ttrue\n}",
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	dario.cat/mergo v1.0.1
-	github.com/anderseknert/roast v0.3.0
+	github.com/anderseknert/roast v0.4.1
 	github.com/coreos/go-semver v0.3.1
 	github.com/fatih/color v1.17.0
 	github.com/fsnotify/fsnotify v1.7.0
@@ -15,7 +15,7 @@ require (
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/open-policy-agent/opa v0.68.1-0.20240923144505-09c1bdfc7c77
+	github.com/open-policy-agent/opa v0.69.0
 	github.com/owenrumney/go-sarif/v2 v2.3.3
 	github.com/pdevine/go-asciisprite v0.1.6
 	github.com/pkg/profile v1.7.0
@@ -29,7 +29,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
-	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/agnivade/levenshtein v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0kC2U78=
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
-github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
-github.com/anderseknert/roast v0.3.0 h1:LJ9zT0yB9xpS01QzR8g2FkP9x8TBPJVvEY08zTypHRs=
-github.com/anderseknert/roast v0.3.0/go.mod h1:+VbTe/Fj1AUhtafMwz9JBdoPqFCS4rkNwsAhJwMgr1Y=
+github.com/agnivade/levenshtein v1.2.0 h1:U9L4IOT0Y3i0TIlUIDJ7rVUziKi/zPbrJGaFrtYH3SY=
+github.com/agnivade/levenshtein v1.2.0/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
+github.com/anderseknert/roast v0.4.1 h1:OzwwwW2HOQe6/qfsxKyaAXT4hYbULAaqhewhN/Em6JI=
+github.com/anderseknert/roast v0.4.1/go.mod h1:LJIt906EwHkwKAOePJIY5DUuDumHto0xryuLjR4Nq5A=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
@@ -49,8 +49,8 @@ github.com/dgraph-io/badger/v3 v3.2103.5 h1:ylPa6qzbjYRQMU6jokoj4wzcaweHylt//CH0
 github.com/dgraph-io/badger/v3 v3.2103.5/go.mod h1:4MPiseMeDQ3FNCYwRbbcBOGJLf5jsE0PPFzRiKjtcdw=
 github.com/dgraph-io/ristretto v0.1.1 h1:6CWw5tJNgpegArSHpNHJKldNeq03FQCwYvfMVWajOK8=
 github.com/dgraph-io/ristretto v0.1.1/go.mod h1:S1GPSBCYCIhmVNfcth17y2zZtQT6wzkzgwUve0VDWWA=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48 h1:fRzb/w+pyskVMQ+UbP35JkH8yB7MYb4q/qhBarqZE6g=
-github.com/dgryski/trifles v0.0.0-20200323201526-dd97f9abfb48/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
+github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a h1:mATvB/9r/3gvcejNsXKSkQ6lcIaNec2nyfOdlTBR2lU=
@@ -172,8 +172,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
-github.com/open-policy-agent/opa v0.68.1-0.20240923144505-09c1bdfc7c77 h1:KhNvRjtRVpEC/kjiaH9etSmn4w4ulKYM1a/shZBNw/o=
-github.com/open-policy-agent/opa v0.68.1-0.20240923144505-09c1bdfc7c77/go.mod h1:V9vbXtXRhQ8G4/sjL/g6txe8MaLOfkmmklufwZNaVK4=
+github.com/open-policy-agent/opa v0.69.0 h1:s2igLw2Z6IvGWGuXSfugWkVultDMsM9pXiDuMp7ckWw=
+github.com/open-policy-agent/opa v0.69.0/go.mod h1:+qyXJGkpEJ6kpB1kGo8JSwHtVXbTdsGdQYPWWNYNj+4=
 github.com/owenrumney/go-sarif v1.1.1/go.mod h1:dNDiPlF04ESR/6fHlPyq7gHKmrM0sHUvAGjsoh8ZH0U=
 github.com/owenrumney/go-sarif/v2 v2.3.3 h1:ubWDJcF5i3L/EIOER+ZyQ03IfplbSU1BLOE26uKQIIU=
 github.com/owenrumney/go-sarif/v2 v2.3.3/go.mod h1:MSqMMx9WqlBSY7pXoOZWgEsVB4FDNfhcaXDA1j6Sr+w=

--- a/internal/embeds/templates/builtin/builtin_test.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin_test.rego.tpl
@@ -19,7 +19,16 @@ test_rule_named_foo_not_allowed if {
 		"category": "{{.Category}}",
 		"description": "Add description of rule here!",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "foo := true"},
+		"location": {
+			"file": "policy.rego",
+			"row": 1,
+			"col": 1,
+			"end": {
+				"row": 1,
+				"col": 12,
+			},
+			"text": "foo := true"
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/{{.NameOriginal}}", "{{.Category}}"),

--- a/internal/embeds/templates/custom/custom_test.rego.tpl
+++ b/internal/embeds/templates/custom/custom_test.rego.tpl
@@ -19,7 +19,16 @@ test_rule_named_foo_not_allowed if {
 		"category": "{{.Category}}",
 		"description": "Add description of rule here!",
 		"level": "error",
-		"location": {"col": 2, "file": "example.rego", "row": 4, "text": "\tfoo := true"},
+		"location": {
+			"file": "example.rego",
+			"row": 4,
+			"col": 2,
+			"end": {
+				"row": 4,
+				"col": 13,
+			},
+			"text": "\tfoo := true"
+		},
 		"title": "{{.NameOriginal}}",
 	}}
 }

--- a/internal/lsp/store_test.go
+++ b/internal/lsp/store_test.go
@@ -38,15 +38,14 @@ func TestPutFileModStoresRoastRepresentation(t *testing.T) {
 	// down elsewhere.
 	expect := `{
   "package": {
-    "location": "1:1:cGFja2FnZQ==",
+    "location": "1:1:1:8",
     "path": [
       {
-        "location": "1:9:ZXhhbXBsZQ==",
         "type": "var",
         "value": "data"
       },
       {
-        "location": "1:9:ZXhhbXBsZQ==",
+        "location": "1:9:1:16",
         "type": "string",
         "value": "example"
       }
@@ -56,22 +55,21 @@ func TestPutFileModStoresRoastRepresentation(t *testing.T) {
     {
       "head": {
         "assign": true,
-        "location": "3:1:cnVsZSA6PSB0cnVl",
-        "name": "rule",
+        "location": "3:1:3:13",
         "ref": [
           {
-            "location": "3:1:cnVsZQ==",
+            "location": "3:1:3:5",
             "type": "var",
             "value": "rule"
           }
         ],
         "value": {
-          "location": "3:9:dHJ1ZQ==",
+          "location": "3:9:3:13",
           "type": "boolean",
           "value": true
         }
       },
-      "location": "3:1:cnVsZSA6PSB0cnVl"
+      "location": "3:1:3:13"
     }
   ]
 }`


### PR DESCRIPTION
Wow, this took quite some time to finish! But looking at the end result, I'd say it was worth it. Having Roast represent locations as `row:col:end_row:end_col` means quite a reduction in AST size, and Regal's own JSON AST goes from 12 Mb to 10 Mb (in OPA AST that is 24 Mb for comparison).

Running `regal lint bundle` is also ~100 ms faster, and improvement of about 5%. Nice!

But this wasn't only about performance. Having end locations available for any node means we can now easily show e.g. violations with a precise location in LSP editors, and won't have to default to end-of-line, as we previously did for most rules. This also meant that we were able to remove all code in Regal that tried to calculate end position based on the text attribute. Nice!

NOTE: this should be merged after https://github.com/anderseknert/roast/pull/11 so that we can depend on a tagged roast version.