### PR TITLE
Exclude `print` from "function return value in args" check

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -298,6 +298,9 @@ function_ret_args(fn_name, terms) := array.slice(terms, count(all_functions[fn_n
 # METADATA
 # description: true if last argument of function is a return assignment
 function_ret_in_args(fn_name, terms) if {
+	# special case: print does not have a last argument as it's variadic
+	fn_name != "print"
+
 	rest := array.slice(terms, 1, count(terms))
 
 	# for now, bail out of nested calls

--- a/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
@@ -40,3 +40,11 @@ test_success_var_does_not_shadow_builtin if {
 	r := rule.report with input as module with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
+
+# https://github.com/StyraInc/regal/issues/1163
+test_success_print_excluded if {
+	module := ast.with_rego_v1(`x if print([y - 1])`)
+
+	r := rule.report with input as module with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r == set()
+}


### PR DESCRIPTION
Fixes #1163

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->