### PR TITLE
lsp/templating: gracefully handle unknown root

### DIFF
--- a/internal/lsp/server_formatting_test.go
+++ b/internal/lsp/server_formatting_test.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/sourcegraph/jsonrpc2"
@@ -30,7 +31,7 @@ func TestFormatting(t *testing.T) {
 		t.Fatalf("failed to create and init language server: %s", err)
 	}
 
-	mainRegoURI := fileURIScheme + tempDir + mainRegoFileName
+	mainRegoURI := fileURIScheme + filepath.Join(tempDir, "main/main.rego")
 
 	// Simple as possible — opa fmt should just remove a newline
 	content := `package main

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -3,7 +3,6 @@ package lsp
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -145,7 +144,7 @@ func TestTemplateContentsForFileInWorkspaceRoot(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 
-	if !errors.Is(err, &templatingInRootError{}) {
+	if !strings.Contains(err.Error(), "this function does not template files in the workspace root") {
 		t.Fatalf("expected error to be templatingInRootError, got %T", err)
 	}
 }

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -127,7 +127,7 @@ func TestTemplateContentsForFileInWorkspaceRoot(t *testing.T) {
 
 	err = os.WriteFile(filepath.Join(td, ".regal/config.yaml"), []byte{}, 0o600)
 	if err != nil {
-		t.Fatalf("failed to create directory %s: %s", filepath.Join(td, ".regal"), err)
+		t.Fatalf("failed to create file %s: %s", filepath.Join(td, ".regal"), err)
 	}
 
 	ctx := context.Background()
@@ -145,7 +145,7 @@ func TestTemplateContentsForFileInWorkspaceRoot(t *testing.T) {
 	}
 
 	if !strings.Contains(err.Error(), "this function does not template files in the workspace root") {
-		t.Fatalf("expected error to be templatingInRootError, got %T", err)
+		t.Fatalf("expected error about root templating, got %s", err.Error())
 	}
 }
 


### PR DESCRIPTION
This also disables templating for files in the root.

Fixes https://github.com/StyraInc/regal/issues/1164

Related to https://github.com/StyraInc/regal/issues/1141, but this needs more work

Sorry for the low res video... 

https://github.com/user-attachments/assets/18c95fce-4981-4e8b-a1c0-45418aac9573

