### PR TITLE
feat: enable `regal/startDebugging` LSP method in Neovim

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -711,8 +711,8 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { // nolint:mai
 				// handle this ourselves as it's a rename and not a content edit
 				fixed = false
 			case "regal.debug":
-				if l.clientIdentifier != clients.IdentifierVSCode {
-					l.logError(errors.New("regal.debug command is only supported in VSCode"))
+				if l.clientIdentifier != clients.IdentifierVSCode && l.clientIdentifier != clients.IdentifierNeovim {
+					l.logError(errors.New("regal.debug command is only supported in VSCode and Neovim"))
 
 					break
 				}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->

Refs: neovim/nvim-lspconfig#3354

I created a pull request to nvim-lspconfig, it adds an LSP handler for `regal/startDebugging` method to regal default config.
Then, in this pull request, I'd like to enable `regal/startDebugging` method in Neovim to use `Debug` codelens feature.

Demo:
![nvim-debug-codelens](https://github.com/user-attachments/assets/0547ebd9-94c6-4a59-89f5-f77b431f2aed)


I'm also planning to write an Neovim handler for `regal/showEvalResult`. I'll send a PR about it later.

---

Update:

I closed neovim/nvim-lspconfig#3354 because the handler depends on nvim-dap plugin.

Then, I updated nvim-dap-rego to bundle this handler into it.
https://github.com/rinx/nvim-dap-rego/commit/7316f3fa47266dbb28a82f77a0e1e9adc83ab4a3