### PR TITLE
feat(lsp): add initialization options about codelenses

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1649,25 +1649,26 @@ func (l *LanguageServer) handleTextDocumentCodeLens(
 		return nil, nil // return a null response, as per the spec
 	}
 
-	ls, err := rego.CodeLenses(ctx, params.TextDocument.URI, contents, module)
+	lenses, err := rego.CodeLenses(ctx, params.TextDocument.URI, contents, module)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get code lenses: %w", err)
 	}
 
 	if l.clientInitializationOptions.EnableDebugCodelens != nil &&
 		*l.clientInitializationOptions.EnableDebugCodelens {
-		return ls, nil
+		return lenses, nil
 	}
 
 	// filter out `regal.debug` codelens
-	lenses := make([]types.CodeLens, 0, len(ls))
-	for _, lens := range ls {
+	filteredLenses := make([]types.CodeLens, 0, len(lenses))
+
+	for _, lens := range lenses {
 		if lens.Command.Command != "regal.debug" {
 			lenses = append(lenses, lens)
 		}
 	}
 
-	return lenses, nil
+	return filteredLenses, nil
 }
 
 func (l *LanguageServer) handleTextDocumentCompletion(

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -20,7 +20,9 @@ type FileEvent struct {
 }
 
 type InitializationOptions struct {
-	Formatter *string `json:"formatter,omitempty"`
+	Formatter                 *string `json:"formatter,omitempty"`
+	EnableDebugCodelens       *bool   `json:"enableDebugCodelens,omitempty"`
+	EvalCodelensDisplayInline *bool   `json:"evalCodelensDisplayInline,omitempty"`
 }
 
 type InitializeParams struct {

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -20,9 +20,15 @@ type FileEvent struct {
 }
 
 type InitializationOptions struct {
-	Formatter                 *string `json:"formatter,omitempty"`
-	EnableDebugCodelens       *bool   `json:"enableDebugCodelens,omitempty"`
-	EvalCodelensDisplayInline *bool   `json:"evalCodelensDisplayInline,omitempty"`
+	// Formatter specifies the formatter to use. Options: 'opa fmt' (default),
+	// 'opa fmt --rego-v1' or 'regal fix'.
+	Formatter *string `json:"formatter,omitempty"`
+	// EnableDebugCodelens, if set, will enable debug codelens
+	// when clients request code lenses for a file.
+	EnableDebugCodelens *bool `json:"enableDebugCodelens,omitempty"`
+	// EvalCodelensDisplayInline, if set, will show evaluation results natively
+	// in the calling editor, rather than in an output file.
+	EvalCodelensDisplayInline *bool `json:"evalCodelensDisplayInline,omitempty"`
 }
 
 type InitializeParams struct {


### PR DESCRIPTION
Refs: #1175 

This pull request adds two options to LSP's initialization options.

- `enableDebugCodelens`: to enable/disable debug codelens
- `evalCodelensDisplayInline`: to select result output methods of evaluate codelens

In the current implementation, `Debug` codelens feature requires the client is VSCode.
However like I showed in #1175, it is possible to use this feature if the client implements specific handlers for the Regal's `regal/startDebugging` request.
In this pull request, I propose to add the options to control the Regal's behavior about codelenses.

This change will be breaking to vscode-opa, but just adding two parameters to https://github.com/open-policy-agent/vscode-opa/blob/f49ab2ec0e72516749f7416daea4a246ddfe7b6b/src/ls/clients/regal.ts#L203.
I'll send a pull request to handle this issue.

For Neovim users, nvim-dap-rego provides `regal/startDebugging` handler. rinx/nvim-dap-rego@7316f3fa47266dbb28a82f77a0e1e9adc83ab4a3 

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->