### PR TITLE
Use test logger for client handler

### DIFF
--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -39,14 +39,16 @@ import rego.v1
 
 	messages := createMessageChannels(files)
 
-	clientHandler := createClientHandler(t, messages)
+	logger := newTestLogger(t)
+
+	clientHandler := createClientHandler(t, logger, messages)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	tempDir := t.TempDir()
 
-	_, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	_, connClient, err := createAndInitServer(ctx, logger, tempDir, files, clientHandler)
 	if err != nil {
 		t.Fatalf("failed to create and init language server: %s", err)
 	}
@@ -339,13 +341,15 @@ import rego.v1
 
 	messages := createMessageChannels(files)
 
-	clientHandler := createClientHandler(t, messages)
+	logger := newTestLogger(t)
+
+	clientHandler := createClientHandler(t, logger, messages)
 
 	// set up the server and client connections
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	_, connClient, err := createAndInitServer(ctx, logger, tempDir, files, clientHandler)
 	if err != nil {
 		t.Fatalf("failed to create and init language server: %s", err)
 	}

--- a/internal/lsp/server_multi_file_test.go
+++ b/internal/lsp/server_multi_file_test.go
@@ -54,15 +54,17 @@ ignore:
 `,
 	}
 
+	logger := newTestLogger(t)
+
 	messages := createMessageChannels(files)
 
-	clientHandler := createClientHandler(t, messages)
+	clientHandler := createClientHandler(t, logger, messages)
 
 	// set up the server and client connections
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, files, clientHandler)
+	_, connClient, err := createAndInitServer(ctx, logger, tempDir, files, clientHandler)
 	if err != nil {
 		t.Fatalf("failed to create and init language server: %s", err)
 	}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -174,13 +174,14 @@ func createAndInitServer(
 
 func createClientHandler(
 	t *testing.T,
+	logger io.Writer,
 	messages map[string]chan []string,
 ) func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 	t.Helper()
 
 	return func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 		if req.Method != "textDocument/publishDiagnostics" {
-			t.Log("unexpected request method:", req.Method)
+			fmt.Fprintln(logger, "unexpected request method:", req.Method)
 
 			return struct{}{}, nil
 		}
@@ -200,7 +201,7 @@ func createClientHandler(
 		slices.Sort(violations)
 
 		fileBase := filepath.Base(requestData.URI)
-		t.Log("queue", fileBase, len(messages[fileBase]))
+		fmt.Fprintln(logger, "queue", fileBase, len(messages[fileBase]))
 
 		select {
 		case messages[fileBase] <- violations:


### PR DESCRIPTION
This protects against logging in tests after they finish which I have seen crop up 2x this week.
