### PR TITLE
linter: use a buffered error channel

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -826,7 +826,10 @@ func (l Linter) lintWithRegoRules(ctx context.Context, input rules.Input) (repor
 
 	var mu sync.Mutex
 
-	errCh := make(chan error)
+	// the error channel is buffered to prevent blocking
+	// caused by the context cancellation happening before
+	// errors are sent and the per-file goroutines can exit.
+	errCh := make(chan error, len(input.FileNames))
 	doneCh := make(chan bool)
 
 	for _, name := range input.FileNames {


### PR DESCRIPTION
This allows the linter to more gracefully exit from context cancellation.

As seen in
https://github.com/StyraInc/regal/actions/runs/11233013451/job/31225814604, this can cause test cases to timeout after there are errors.

My understanding the error being attempted to be sent to the channel is a context cancellation error.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->