### PR TITLE
Lsp logging

### DIFF
--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/styrainc/regal/internal/lsp"
+	"github.com/styrainc/regal/internal/lsp/log"
 )
 
 func init() {
@@ -25,7 +26,8 @@ func init() {
 			defer cancel()
 
 			opts := &lsp.LanguageServerOptions{
-				ErrorLog: os.Stderr,
+				LogWriter: os.Stderr,
+				LogLevel:  log.LevelMessage,
 			}
 
 			ls := lsp.NewLanguageServer(ctx, opts)

--- a/internal/lsp/config/watcher_test.go
+++ b/internal/lsp/config/watcher_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/styrainc/regal/internal/lsp/log"
 )
 
 func TestWatcher(t *testing.T) {
@@ -22,7 +24,9 @@ foo: bar
 		t.Fatal(err)
 	}
 
-	watcher := NewWatcher(&WatcherOpts{ErrorWriter: os.Stderr})
+	watcher := NewWatcher(&WatcherOpts{LogFunc: func(l log.Level, s string, a ...any) {
+		t.Logf(l.String()+": "+s, a...)
+	}})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-policy-agent/opa/topdown/print"
 
 	rbundle "github.com/styrainc/regal/bundle"
+	"github.com/styrainc/regal/internal/lsp/log"
 	"github.com/styrainc/regal/internal/lsp/uri"
 	"github.com/styrainc/regal/pkg/builtins"
 )
@@ -47,7 +48,7 @@ func (l *LanguageServer) Eval(
 
 	for k, v := range dataBundles {
 		if v.Manifest.Roots == nil {
-			l.logError(fmt.Errorf("bundle %s has no roots and will be skipped", k))
+			l.logf(log.LevelMessage, "bundle %s has no roots and will be skipped", k)
 
 			continue
 		}

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -8,13 +8,19 @@ import (
 	"testing"
 
 	rio "github.com/styrainc/regal/internal/io"
+	"github.com/styrainc/regal/internal/lsp/log"
 	"github.com/styrainc/regal/internal/parse"
 )
 
 func TestEvalWorkspacePath(t *testing.T) {
 	t.Parallel()
 
-	ls := NewLanguageServer(context.Background(), &LanguageServerOptions{ErrorLog: os.Stderr})
+	logger := newTestLogger(t)
+
+	ls := NewLanguageServer(
+		context.Background(),
+		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
+	)
 
 	policy1 := `package policy1
 

--- a/internal/lsp/log/level.go
+++ b/internal/lsp/log/level.go
@@ -1,0 +1,33 @@
+package log
+
+// Level controls the level of server logging and corresponds to TraceValue in
+// the LSP spec:
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue.
+type Level int
+
+const (
+	// LevelOff is used to disable logging completely.
+	LevelOff Level = iota
+	// LogLevelMessage are intended to contain errors and other messages that
+	// should be shown in normal operation.
+	LevelMessage
+	// LogLevelDebug is includes LogLevelMessage, but also information that is
+	// not expected to be useful unless debugging the server.
+	LevelDebug
+)
+
+func (l Level) String() string {
+	return [...]string{"Off", "Messages", "Debug"}[l]
+}
+
+func (l Level) ShouldLog(incoming Level) bool {
+	if l == LevelOff {
+		return false
+	}
+
+	if l == LevelDebug {
+		return true
+	}
+
+	return l == LevelMessage && incoming == LevelMessage
+}

--- a/internal/lsp/log/level_test.go
+++ b/internal/lsp/log/level_test.go
@@ -1,0 +1,49 @@
+package log
+
+import "testing"
+
+func TestShouldLog(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		Level                Level
+		IncomingMessageLevel Level
+		ExpectLog            bool
+	}{
+		"Off, no logs": {
+			Level:                LevelOff,
+			IncomingMessageLevel: LevelMessage,
+			ExpectLog:            false,
+		},
+		"Off, no logs from debug": {
+			Level:                LevelOff,
+			IncomingMessageLevel: LevelDebug,
+			ExpectLog:            false,
+		},
+		"Message, no logs from debug": {
+			Level:                LevelMessage,
+			IncomingMessageLevel: LevelDebug,
+			ExpectLog:            false,
+		},
+		"Debug, logs from Message": {
+			Level:                LevelDebug,
+			IncomingMessageLevel: LevelMessage,
+			ExpectLog:            true,
+		},
+		"Debug, all logs": {
+			Level:                LevelDebug,
+			IncomingMessageLevel: LevelDebug,
+			ExpectLog:            true,
+		},
+	}
+
+	for label, tc := range testCases {
+		t.Run(label, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tc.Level.ShouldLog(tc.IncomingMessageLevel); got != tc.ExpectLog {
+				t.Errorf("expected %v, got %v", tc.ExpectLog, got)
+			}
+		})
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -167,6 +167,8 @@ func (l *LanguageServer) Handle(
 	conn *jsonrpc2.Conn,
 	req *jsonrpc2.Request,
 ) (result any, err error) {
+	l.logf(log.LevelDebug, "received request: %s", req.Method)
+
 	// null params are allowed, but only for certain methods
 	if req.Params == nil && req.Method != "shutdown" && req.Method != "exit" {
 		return nil, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
@@ -260,6 +262,7 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case job := <-l.lintFileJobs:
+				l.logf(log.LevelDebug, "linting file %s (%s)", job.URI, job.Reason)
 				bis := l.builtinsForCurrentCapabilities()
 
 				// updateParse will not return an error when the parsing failed,
@@ -302,6 +305,8 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 					// any other rules globally other than aggregate rules.
 					AggregateReportOnly: true,
 				}
+
+				l.logf(log.LevelDebug, "linting file %s done", job.URI)
 			}
 		}
 	}()
@@ -366,6 +371,8 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case job := <-workspaceLintRuns:
+				l.logf(log.LevelDebug, "linting workspace: %#v", job)
+
 				// if there are no parsed modules in the cache, then there is
 				// no need to run the aggregate report. This can happen if the
 				// server is very slow to start up.
@@ -398,6 +405,8 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 						l.logf(log.LevelMessage, "failed to send diagnostic: %s", err)
 					}
 				}
+
+				l.log(log.LevelDebug, "linting workspace done")
 			}
 		}
 	}()

--- a/internal/lsp/server_builtins_test.go
+++ b/internal/lsp/server_builtins_test.go
@@ -3,15 +3,20 @@ package lsp
 import (
 	"context"
 	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/log"
 )
 
 // https://github.com/StyraInc/regal/issues/679
 func TestProcessBuiltinUpdateExitsOnMissingFile(t *testing.T) {
 	t.Parallel()
 
-	ls := NewLanguageServer(context.Background(), &LanguageServerOptions{
-		ErrorLog: newTestLogger(t),
-	})
+	logger := newTestLogger(t)
+
+	ls := NewLanguageServer(
+		context.Background(),
+		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
+	)
 
 	if err := ls.processHoverContentUpdate(context.Background(), "file://missing.rego", "foo"); err != nil {
 		t.Fatal(err)

--- a/internal/lsp/server_rename_test.go
+++ b/internal/lsp/server_rename_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/clients"
+	"github.com/styrainc/regal/internal/lsp/log"
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/fixer/fixes"
 )
@@ -24,7 +25,13 @@ func TestLanguageServerFixRenameParams(t *testing.T) {
 
 	ctx := context.Background()
 
-	l := NewLanguageServer(ctx, &LanguageServerOptions{ErrorLog: newTestLogger(t)})
+	logger := newTestLogger(t)
+
+	ls := NewLanguageServer(
+		ctx,
+		&LanguageServerOptions{LogWriter: logger, LogLevel: log.LevelDebug},
+	)
+
 	c := cache.NewCache()
 	f := &fixes.DirectoryPackageMismatch{}
 
@@ -32,10 +39,10 @@ func TestLanguageServerFixRenameParams(t *testing.T) {
 
 	c.SetFileContents(fileURL, "package authz.main.rules")
 
-	l.clientIdentifier = clients.IdentifierVSCode
-	l.workspaceRootURI = fmt.Sprintf("file://%s/workspace", tmpDir)
-	l.cache = c
-	l.loadedConfig = &config.Config{
+	ls.clientIdentifier = clients.IdentifierVSCode
+	ls.workspaceRootURI = fmt.Sprintf("file://%s/workspace", tmpDir)
+	ls.cache = c
+	ls.loadedConfig = &config.Config{
 		Rules: map[string]config.Category{
 			"idiomatic": {
 				"directory-package-mismatch": config.Rule{
@@ -48,7 +55,7 @@ func TestLanguageServerFixRenameParams(t *testing.T) {
 		},
 	}
 
-	params, err := l.fixRenameParams("fix my file!", f, fileURL)
+	params, err := ls.fixRenameParams("fix my file!", f, fileURL)
 	if err != nil {
 		t.Fatalf("failed to fix rename params: %s", err)
 	}

--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/anderseknert/roast/pkg/encoding"
 	"github.com/sourcegraph/jsonrpc2"
 
+	"github.com/styrainc/regal/internal/lsp/log"
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/util"
 )
@@ -119,7 +120,8 @@ func createAndInitServer(
 
 	// set up the server and client connections
 	ls := NewLanguageServer(ctx, &LanguageServerOptions{
-		ErrorLog:                 logger,
+		LogWriter:                logger,
+		LogLevel:                 log.LevelDebug,
 		WorkspaceDiagnosticsPoll: pollingInterval,
 	})
 
@@ -181,7 +183,7 @@ func createClientHandler(
 
 	return func(_ context.Context, _ *jsonrpc2.Conn, req *jsonrpc2.Request) (result any, err error) {
 		if req.Method != "textDocument/publishDiagnostics" {
-			fmt.Fprintln(logger, "unexpected request method:", req.Method)
+			fmt.Fprintln(logger, "createClientHandler: unexpected request method:", req.Method)
 
 			return struct{}{}, nil
 		}
@@ -201,7 +203,7 @@ func createClientHandler(
 		slices.Sort(violations)
 
 		fileBase := filepath.Base(requestData.URI)
-		fmt.Fprintln(logger, "queue", fileBase, len(messages[fileBase]))
+		fmt.Fprintln(logger, "createClientHandler: queue", fileBase, len(messages[fileBase]))
 
 		select {
 		case messages[fileBase] <- violations:


### PR DESCRIPTION
We have been having a hard time debugging test suite issues like this one: https://github.com/StyraInc/regal/actions/runs/11233013451/job/31225814604 where the order of events doesn't appear to follow the order expected based on the implementation.

This PR makes an improvement to the Language Server to support logging of messages at different levels.

This retains the old behaviour in a new model, but then also adds a number of debug messages for requests and diagnostics jobs to aid in debugging tests.

In future, we may wish for more log levels, but for now, I have used the three available  in the LSP TraceValues.