### PR TITLE
Add UNIwise company to adopters.md

### DIFF
--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -60,6 +60,7 @@ Companies and organizations using Regal (not counting organizations behind the o
 - [Miro](https://miro.com)
 - [Stacklok](https://stacklok.com)
 - [Styra](https://www.styra.com)
+- [UNIwise](https://uniwise.eu/)
 <!-- cspell:enable-->
 
 ## Community


### PR DESCRIPTION
I work for [UNIwise](https://uniwise.eu/) and we use Regal for all our OPA policies, and would like to show our support for it here.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->