### PR TITLE
workflow: use different branch (and also PR) for caps updates

### DIFF
--- a/.github/workflows/update-caps.yml
+++ b/.github/workflows/update-caps.yml
@@ -40,5 +40,6 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           title: "automated: update capabilities"
+          branch: create-pull-request/caps
           add-paths: |
             internal/capabilities/embedded/eopa/*.json


### PR DESCRIPTION
So now updating the example index and updating caps should no longer try to use the same PR.