### PR TITLE
io: Address path input.json separator issue

### DIFF
--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -6,7 +6,6 @@ import (
 	files "io/fs"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -99,10 +98,10 @@ func ExcludeTestFilter() filter.LoaderFilter {
 // both the location and the reader.
 func FindInput(file string, workspacePath string) (string, io.Reader) {
 	relative := strings.TrimPrefix(file, workspacePath)
-	components := strings.Split(path.Dir(relative), string(filepath.Separator))
+	components := strings.Split(filepath.Dir(relative), string(filepath.Separator))
 
 	for i := range len(components) {
-		inputPath := path.Join(workspacePath, path.Join(components[:len(components)-i]...), "input.json")
+		inputPath := filepath.Join(workspacePath, filepath.Join(components[:len(components)-i]...), "input.json")
 
 		f, err := os.Open(inputPath)
 		if err == nil {


### PR DESCRIPTION
When searching for an input.json file to use, the existing code will use the path library, rather than filepath which is separator aware.

This causes issues on Windows where the path separator is \ and not /.
