### PR TITLE
Make `prefer-snake-case` check package name

### DIFF
--- a/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
+++ b/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case.rego
@@ -9,8 +9,17 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
+	some part in input["package"].path
+
+	not util.is_snake_case(part.value)
+
+	violation := result.fail(rego.metadata.chain(), result.location(part))
+}
+
+report contains violation if {
 	some rule in input.rules
 	some part in ast.named_refs(rule.head.ref)
+
 	not util.is_snake_case(part.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(part))
@@ -18,6 +27,7 @@ report contains violation if {
 
 report contains violation if {
 	var := ast.found.vars[_][_][_]
+
 	not util.is_snake_case(var.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(var))

--- a/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case_test.rego
+++ b/bundle/regal/rules/style/prefer-snake-case/prefer_snake_case_test.rego
@@ -22,6 +22,25 @@ test_success_snake_cased_rule_name if {
 	r == set()
 }
 
+test_fail_camel_cased_package_name if {
+	r := rule.report with input as regal.parse_module("p.rego", `package camelCase`)
+	r == expected_with_locations([{
+		"col": 9,
+		"end": {
+			"col": 18,
+			"row": 1,
+		},
+		"file": "p.rego",
+		"row": 1,
+		"text": "package camelCase",
+	}])
+}
+
+test_success_snake_cased_package_name if {
+	r := rule.report with input as regal.parse_module("p.rego", `package snake_case`)
+	r == set()
+}
+
 test_fail_camel_cased_some_declaration if {
 	r := rule.report with input as ast.policy(`p {some fooBar; input[_]}`)
 	r == expected_with_locations([{

--- a/docs/rules/style/prefer-snake-case.md
+++ b/docs/rules/style/prefer-snake-case.md
@@ -26,8 +26,8 @@ user_is_admin if "admin" in input.user.roles
 
 ## Rationale
 
-The built-in functions use `snake_case` for naming — follow that convention for your own rules, functions, and
-variables, unless you have a really good reason not to.
+The built-in functions use `snake_case` for naming — follow that convention for your own packages, rules, functions,
+and variables, unless you have a really good reason not to.
 
 ## Exceptions
 


### PR DESCRIPTION
Previously, only rules and vars were checked.

Fixes #1205

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->