### PR TITLE
Handle `file://` URLs in exclusion policy

### DIFF
--- a/bundle/regal/config/exclusion_test.rego
+++ b/bundle/regal/config/exclusion_test.rego
@@ -64,36 +64,46 @@ rules_config_ignore_delta := {"rules": {"test": {"test-case": {"ignore": {"files
 config_ignore := {"ignore": {"files": ["p.rego"]}}
 
 test_excluded_file_default if {
-	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
+	not config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
 		with config.merged_config as rules_config_error
-
-	e == false
 }
 
 test_excluded_file_with_ignore if {
 	c := object.union(rules_config_error, rules_config_ignore_delta)
-	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
+
+	config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params
 		with config.merged_config as c
-	e == true
 }
 
 test_excluded_file_config if {
-	e := config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
-	e == true
+	config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
 }
 
 test_excluded_file_cli_flag if {
-	e := config.excluded_file("test", "test-case", "p.rego") with data.eval.params as object.union(
+	config.excluded_file("test", "test-case", "p.rego") with data.eval.params as object.union(
 		params,
 		{"ignore_files": ["p.rego"]},
 	)
-	e == true
 }
 
 test_excluded_file_cli_overrides_config if {
-	e := config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
+	not config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
 		with data.eval.params as object.union(params, {"ignore_files": [""]})
-	e == false
+}
+
+test_excluded_file_using_uri if {
+	conf := {"rules": {"test": {"rule": {
+		"level": "error",
+		"ignore": {"files": ["foo/**/p.rego"]},
+	}}}}
+
+	config.excluded_file("test", "rule", "file:///workspace/folder/foo/bar/p.rego") with config.merged_config as conf
+}
+
+test_not_excluded_file_using_uri if {
+	conf := {"rules": {"test": {"rule": {"level": "error"}}}}
+
+	not config.excluded_file("test", "rule", "file:///workspace/folder/foo/bar/p.rego") with config.merged_config as conf
 }
 
 test_trailing_slash if {

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -1,10 +1,14 @@
 package lsp
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
+	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/parse"
+	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/report"
 )
 
@@ -63,5 +67,79 @@ func TestConvertReportToDiagnostics(t *testing.T) {
 
 	if !reflect.DeepEqual(fileDiags, expectedFileDiags) {
 		t.Errorf("Expected file diagnostics: %v, got: %v", expectedFileDiags, fileDiags)
+	}
+}
+
+func TestLintWithConfigIgnoreWildcards(t *testing.T) {
+	t.Parallel()
+
+	conf := &config.Config{
+		Rules: map[string]config.Category{
+			"idiomatic": {
+				"directory-package-mismatch": config.Rule{
+					Level: "ignore",
+				},
+			},
+		},
+	}
+
+	contents := "package p\n\nimport rego.v1\n\ncamelCase := 1\n"
+	module := parse.MustParseModule(contents)
+	workspacePath := "/workspace"
+	fileURI := "file:///workspace/ignore/p.rego"
+	state := cache.NewCache()
+
+	state.SetFileContents(fileURI, contents)
+	state.SetModule(fileURI, module)
+	state.SetFileDiagnostics(fileURI, []types.Diagnostic{})
+
+	if err := updateFileDiagnostics(
+		context.Background(),
+		state,
+		conf,
+		fileURI,
+		workspacePath,
+		[]string{"prefer-snake-case"},
+	); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	diagnostics, _ := state.GetFileDiagnostics(fileURI)
+	if len(diagnostics) != 1 {
+		t.Fatalf("Expected one diagnostic item, got %v", diagnostics)
+	}
+
+	if diagnostics[0].Code != "prefer-snake-case" {
+		t.Errorf("Expected diagnostic code to be prefer-snake-case, got %v", diagnostics[0].Code)
+	}
+
+	// Clear the diagnostic and update the config with a wildcard ignore
+	// for any file in the ignore directory.
+
+	state.SetFileDiagnostics(fileURI, []types.Diagnostic{})
+
+	conf.Rules["style"] = config.Category{
+		"prefer-snake-case": config.Rule{
+			Level: "error",
+			Ignore: &config.Ignore{
+				Files: []string{"ignore/**"},
+			},
+		},
+	}
+
+	if err := updateFileDiagnostics(
+		context.Background(),
+		state,
+		conf,
+		fileURI,
+		workspacePath,
+		[]string{"prefer-snake-case"},
+	); err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	diagnostics, _ = state.GetFileDiagnostics(fileURI)
+	if len(diagnostics) != 0 {
+		t.Fatalf("Expected no diagnostics, got %v", diagnostics)
 	}
 }


### PR DESCRIPTION
This is not an ideal solution, as we should not be sending URLs to the linter in the first place. But as fixing that is a much broader issue, we'll have to settle for a hack in the meantime.

Fixes #1204

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->