### PR TITLE
config: Generate C:\-style capabilities paths

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -433,6 +433,12 @@ func (config *Config) UnmarshalYAML(value *yaml.Node) error {
 			)
 		}
 
+		// prepending a / is done here to ensure that windows drive letter paths
+		// are parsed as paths and not host:ports in URLs.
+		if !strings.HasPrefix(absfp, "/") {
+			absfp = "/" + absfp
+		}
+
 		capabilitiesURL = "file://" + absfp
 	}
 


### PR DESCRIPTION
This change ensures that config files with relative capabilities references work correctly.

Fixes https://github.com/StyraInc/regal/issues/1202

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->