### PR TITLE
lint/rpt: Handle no-color ttys

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -238,6 +238,13 @@ func buildPrettyViolationsTable(violations []report.Violation) string {
 		}
 
 		table.Append([]string{yellow("Rule:"), violation.Title})
+
+		// if there is no support for color, then we show the level in addition
+		// so that the level of the violation is still clear
+		if color.NoColor {
+			table.Append([]string{"Level:", violation.Level})
+		}
+
 		table.Append([]string{yellow("Description:"), description})
 		table.Append([]string{yellow("Category:"), violation.Category})
 		// End location ignored here as it's not too interesting in this format and line:column

--- a/pkg/reporter/testdata/pretty/reporter-long-text.txt
+++ b/pkg/reporter/testdata/pretty/reporter-long-text.txt
@@ -1,4 +1,5 @@
 Rule:         	long-violation                                                                                                          	
+Level:        	warning                                                                                                                 	
 Description:  	violation with a long description                                                                                       	
 Category:     	long                                                                                                                    	
 Location:     	b.rego:22:18                                                                                                            	

--- a/pkg/reporter/testdata/pretty/reporter.txt
+++ b/pkg/reporter/testdata/pretty/reporter.txt
@@ -1,4 +1,5 @@
 Rule:         	breaking-the-law                	
+Level:        	error                           	
 Description:  	Rego must not break the law!    	
 Category:     	legal                           	
 Location:     	a.rego:1:1                      	
@@ -6,6 +7,7 @@ Text:         	package illegal
 Documentation:	https://example.com/illegal     	
               	
 Rule:         	questionable-decision           	
+Level:        	warning                         	
 Description:  	Questionable decision found     	
 Category:     	really?                         	
 Location:     	b.rego:22:18                    	


### PR DESCRIPTION
This fixes https://github.com/StyraInc/regal/issues/1211 by supporting the NO_COLOR environment variable and checking if the output is a tty before using color.

The color.NoColor global is used as described here: https://github.com/fatih/color?tab=readme-ov-file#disableenable-color

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->