### PR TITLE
lsp: Fix inconsistent processing of ignores

### DIFF
--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -9,11 +9,11 @@ package regal.config
 import rego.v1
 
 # METADATA
-# description: the rootDir value set on the current linter instance
+# description: the path prefix value set on the current linter instance
 # scope: document
-default root_dir := ""
+default path_prefix := ""
 
-root_dir := data.internal.root_dir
+path_prefix := data.internal.path_prefix
 
 # METADATA
 # description: the base URL for documentation of linter rules

--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -9,6 +9,13 @@ package regal.config
 import rego.v1
 
 # METADATA
+# description: the rootDir value set on the current linter instance
+# scope: document
+default root_dir := ""
+
+root_dir := data.internal.root_dir
+
+# METADATA
 # description: the base URL for documentation of linter rules
 docs["base_url"] := "https://docs.styra.com/regal/rules"
 

--- a/bundle/regal/config/exclusion_test.rego
+++ b/bundle/regal/config/exclusion_test.rego
@@ -91,21 +91,6 @@ test_excluded_file_cli_overrides_config if {
 		with data.eval.params as object.union(params, {"ignore_files": [""]})
 }
 
-test_excluded_file_using_uri if {
-	conf := {"rules": {"test": {"rule": {
-		"level": "error",
-		"ignore": {"files": ["foo/**/p.rego"]},
-	}}}}
-
-	config.excluded_file("test", "rule", "file:///workspace/folder/foo/bar/p.rego") with config.merged_config as conf
-}
-
-test_not_excluded_file_using_uri if {
-	conf := {"rules": {"test": {"rule": {"level": "error"}}}}
-
-	not config.excluded_file("test", "rule", "file:///workspace/folder/foo/bar/p.rego") with config.merged_config as conf
-}
-
 test_trailing_slash if {
 	config._trailing_slash("foo/**/bar") == {"foo/**/bar", "foo/**/bar/**"} # regal ignore:leaked-internal-reference
 	config._trailing_slash("foo") == {"foo", "foo/**"} # regal ignore:leaked-internal-reference

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -40,7 +40,7 @@ _rules_to_run[category] contains title if {
 
 	config.for_rule(category, title).level != "ignore"
 
-	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.root_dir, "/"]))
+	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
 
 	not config.excluded_file(
 		category,
@@ -103,7 +103,7 @@ report contains violation if {
 
 	config.for_rule(category, title).level != "ignore"
 
-	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.root_dir, "/"]))
+	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
 
 	not config.excluded_file(
 		category,

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -39,7 +39,14 @@ _rules_to_run[category] contains title if {
 	config.merged_config.rules[category][title]
 
 	config.for_rule(category, title).level != "ignore"
-	not config.excluded_file(category, title, input.regal.file.name)
+
+	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.root_dir, "/"]))
+
+	not config.excluded_file(
+		category,
+		title,
+		file_name_relative_to_root,
+	)
 }
 
 _notices contains _grouped_notices[_][_][_]
@@ -95,7 +102,15 @@ report contains violation if {
 	violation := data.custom.regal.rules[category][title].report[_]
 
 	config.for_rule(category, title).level != "ignore"
-	not config.excluded_file(category, title, input.regal.file.name)
+
+	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.root_dir, "/"]))
+
+	not config.excluded_file(
+		category,
+		title,
+		file_name_relative_to_root,
+	)
+
 	not _ignored(violation, ast.ignore_directives)
 }
 

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -194,7 +194,6 @@ test_exclude_files_rule_config if {
 test_exclude_files_rule_config_with_path_prefix_relative_name if {
 	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
 
-	# regal ignore:leaked-internal-reference
 	rules_to_run := main._rules_to_run with config.merged_config as cfg
 		with config.for_rule as {"level": "error", "ignore": {"files": ["bar/*"]}}
 		with input.regal.file.name as "bar/p.rego"
@@ -206,7 +205,6 @@ test_exclude_files_rule_config_with_path_prefix_relative_name if {
 test_not_exclude_files_rule_config_with_path_prefix_relative_name if {
 	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
 
-	# regal ignore:leaked-internal-reference
 	rules_to_run := main._rules_to_run with config.merged_config as cfg
 		with config.for_rule as {"level": "error", "ignore": {"files": ["notmatching/*"]}}
 		with input.regal.file.name as "bar/p.rego"
@@ -218,7 +216,6 @@ test_not_exclude_files_rule_config_with_path_prefix_relative_name if {
 test_exclude_files_rule_config_with_path_prefix if {
 	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
 
-	# regal ignore:leaked-internal-reference
 	rules_to_run := main._rules_to_run with config.merged_config as cfg
 		with config.for_rule as {"level": "error", "ignore": {"files": ["bar/*"]}}
 		with input.regal.file.name as "/foo/bar/p.rego"
@@ -230,7 +227,6 @@ test_exclude_files_rule_config_with_path_prefix if {
 test_not_exclude_files_rule_config_with_path_prefix if {
 	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
 
-	# regal ignore:leaked-internal-reference
 	rules_to_run := main._rules_to_run with config.merged_config as cfg
 		with config.for_rule as {"level": "error", "ignore": {"files": ["notmatching/*"]}}
 		with input.regal.file.name as "/foo/bar/p.rego"
@@ -242,7 +238,6 @@ test_not_exclude_files_rule_config_with_path_prefix if {
 test_exclude_files_rule_config_with_uri_and_path_prefix if {
 	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
 
-	# regal ignore:leaked-internal-reference
 	rules_to_run := main._rules_to_run with config.merged_config as cfg
 		with config.for_rule as {"level": "error", "ignore": {"files": ["bar/*"]}}
 		with input.regal.file.name as "file:///foo/bar/p.rego"
@@ -254,7 +249,6 @@ test_exclude_files_rule_config_with_uri_and_path_prefix if {
 test_not_exclude_files_rule_config_with_uri_and_path_prefix if {
 	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
 
-	# regal ignore:leaked-internal-reference
 	rules_to_run := main._rules_to_run with config.merged_config as cfg
 		with config.for_rule as {"level": "error", "ignore": {"files": ["notmatching/*"]}}
 		with input.regal.file.name as "file:///foo/bar/p.rego"

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -191,6 +191,78 @@ test_exclude_files_rule_config if {
 	count(report) == 0
 }
 
+test_exclude_files_rule_config_with_path_prefix_relative_name if {
+	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
+
+	# regal ignore:leaked-internal-reference
+	rules_to_run := main._rules_to_run with config.merged_config as cfg
+		with config.for_rule as {"level": "error", "ignore": {"files": ["bar/*"]}}
+		with input.regal.file.name as "bar/p.rego"
+		with config.path_prefix as "/foo" # ignored as not prefix of input file
+
+	rules_to_run == {}
+}
+
+test_not_exclude_files_rule_config_with_path_prefix_relative_name if {
+	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
+
+	# regal ignore:leaked-internal-reference
+	rules_to_run := main._rules_to_run with config.merged_config as cfg
+		with config.for_rule as {"level": "error", "ignore": {"files": ["notmatching/*"]}}
+		with input.regal.file.name as "bar/p.rego"
+		with config.path_prefix as "/foo" # ignored as not prefix of input file
+
+	rules_to_run == {"testing": {"test"}}
+}
+
+test_exclude_files_rule_config_with_path_prefix if {
+	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
+
+	# regal ignore:leaked-internal-reference
+	rules_to_run := main._rules_to_run with config.merged_config as cfg
+		with config.for_rule as {"level": "error", "ignore": {"files": ["bar/*"]}}
+		with input.regal.file.name as "/foo/bar/p.rego"
+		with config.path_prefix as "/foo"
+
+	rules_to_run == {}
+}
+
+test_not_exclude_files_rule_config_with_path_prefix if {
+	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
+
+	# regal ignore:leaked-internal-reference
+	rules_to_run := main._rules_to_run with config.merged_config as cfg
+		with config.for_rule as {"level": "error", "ignore": {"files": ["notmatching/*"]}}
+		with input.regal.file.name as "/foo/bar/p.rego"
+		with config.path_prefix as "/foo"
+
+	rules_to_run == {"testing": {"test"}}
+}
+
+test_exclude_files_rule_config_with_uri_and_path_prefix if {
+	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
+
+	# regal ignore:leaked-internal-reference
+	rules_to_run := main._rules_to_run with config.merged_config as cfg
+		with config.for_rule as {"level": "error", "ignore": {"files": ["bar/*"]}}
+		with input.regal.file.name as "file:///foo/bar/p.rego"
+		with config.path_prefix as "file:///foo"
+
+	rules_to_run == {}
+}
+
+test_not_exclude_files_rule_config_with_uri_and_path_prefix if {
+	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
+
+	# regal ignore:leaked-internal-reference
+	rules_to_run := main._rules_to_run with config.merged_config as cfg
+		with config.for_rule as {"level": "error", "ignore": {"files": ["notmatching/*"]}}
+		with input.regal.file.name as "file:///foo/bar/p.rego"
+		with config.path_prefix as "file:///foo"
+
+	rules_to_run == {"testing": {"test"}}
+}
+
 test_force_exclude_file_eval_param if {
 	policy := `package p
 

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -149,7 +149,7 @@ func updateFileDiagnostics(
 	cache *cache.Cache,
 	regalConfig *config.Config,
 	fileURI string,
-	workspaceRootDir string,
+	workspaceRootURI string,
 	updateDiagnosticsForRules []string,
 ) error {
 	module, ok := cache.GetModule(fileURI)
@@ -171,7 +171,7 @@ func updateFileDiagnostics(
 		// needed to get the aggregateData out so we can update the cache
 		WithExportAggregates(true).
 		WithInputModules(&input).
-		WithRootDir(workspaceRootDir)
+		WithRootDir(workspaceRootURI)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)
@@ -182,7 +182,7 @@ func updateFileDiagnostics(
 		return fmt.Errorf("failed to lint: %w", err)
 	}
 
-	fileDiags := convertReportToDiagnostics(&rpt, workspaceRootDir)
+	fileDiags := convertReportToDiagnostics(&rpt, workspaceRootURI)
 
 	files := cache.GetAllFiles()
 
@@ -213,7 +213,7 @@ func updateAllDiagnostics(
 	ctx context.Context,
 	cache *cache.Cache,
 	regalConfig *config.Config,
-	workspaceRootDir string,
+	workspaceRootURI string,
 	overwriteAggregates bool,
 	aggregatesReportOnly bool,
 	updateDiagnosticsForRules []string,
@@ -224,9 +224,10 @@ func updateAllDiagnostics(
 	files := cache.GetAllFiles()
 
 	regalInstance := linter.NewLinter().
-		WithRootDir(workspaceRootDir).
+		WithRootDir(workspaceRootURI).
 		// aggregates need only be exported if they're to be used to overwrite.
-		WithExportAggregates(overwriteAggregates)
+		WithExportAggregates(overwriteAggregates).
+		WithRootDir(workspaceRootURI)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)
@@ -245,7 +246,7 @@ func updateAllDiagnostics(
 		return fmt.Errorf("failed to lint: %w", err)
 	}
 
-	fileDiags := convertReportToDiagnostics(&rpt, workspaceRootDir)
+	fileDiags := convertReportToDiagnostics(&rpt, workspaceRootURI)
 
 	for uri := range files {
 		parseErrs, ok := cache.GetParseErrors(uri)

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -171,7 +171,7 @@ func updateFileDiagnostics(
 		// needed to get the aggregateData out so we can update the cache
 		WithExportAggregates(true).
 		WithInputModules(&input).
-		WithRootDir(workspaceRootURI)
+		WithPathPrefix(workspaceRootURI)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)
@@ -224,10 +224,9 @@ func updateAllDiagnostics(
 	files := cache.GetAllFiles()
 
 	regalInstance := linter.NewLinter().
-		WithRootDir(workspaceRootURI).
+		WithPathPrefix(workspaceRootURI).
 		// aggregates need only be exported if they're to be used to overwrite.
-		WithExportAggregates(overwriteAggregates).
-		WithRootDir(workspaceRootURI)
+		WithExportAggregates(overwriteAggregates)
 
 	if regalConfig != nil {
 		regalInstance = regalInstance.WithUserConfig(*regalConfig)

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -85,7 +85,7 @@ func TestLintWithConfigIgnoreWildcards(t *testing.T) {
 
 	contents := "package p\n\nimport rego.v1\n\ncamelCase := 1\n"
 	module := parse.MustParseModule(contents)
-	workspacePath := "/workspace"
+	workspaceRootURI := "file:///workspace"
 	fileURI := "file:///workspace/ignore/p.rego"
 	state := cache.NewCache()
 
@@ -98,7 +98,7 @@ func TestLintWithConfigIgnoreWildcards(t *testing.T) {
 		state,
 		conf,
 		fileURI,
-		workspacePath,
+		workspaceRootURI,
 		[]string{"prefer-snake-case"},
 	); err != nil {
 		t.Fatalf("Expected no error, got %v", err)
@@ -132,7 +132,7 @@ func TestLintWithConfigIgnoreWildcards(t *testing.T) {
 		state,
 		conf,
 		fileURI,
-		workspacePath,
+		workspaceRootURI,
 		[]string{"prefer-snake-case"},
 	); err != nil {
 		t.Fatalf("Expected no error, got %v", err)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -389,7 +389,7 @@ func (l *LanguageServer) StartDiagnosticsWorker(ctx context.Context) {
 					ctx,
 					l.cache,
 					l.getLoadedConfig(),
-					l.workspacePath(),
+					l.workspaceRootURI,
 					// this is intended to only be set to true once at start up,
 					// on following runs, cached aggregate data is used.
 					job.OverwriteAggregates,

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -209,7 +209,7 @@ func (l Linter) WithProfiling(enabled bool) Linter {
 }
 
 // WithRootDir sets the root directory for the linter.
-// A door directory or prefix can be used to resolve relative paths
+// A root directory or prefix can be used to resolve relative paths
 // referenced in the linter configuration with absolute file paths or URIs.
 func (l Linter) WithRootDir(rootDir string) Linter {
 	l.rootDir = rootDir
@@ -267,6 +267,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 			"internal": map[string]any{
 				"combined_config": config.ToMap(*conf),
 				"capabilities":    rio.ToMap(config.CapabilitiesForThisVersion()),
+				"root_dir":        l.rootDir,
 			},
 		},
 	}

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -43,7 +43,7 @@ type Linter struct {
 	userConfig           *config.Config
 	combinedCfg          *config.Config
 	dataBundle           *bundle.Bundle
-	rootDir              string
+	pathPrefix           string
 	customRuleFSRootPath string
 	inputPaths           []string
 	ruleBundles          []*bundle.Bundle
@@ -208,11 +208,11 @@ func (l Linter) WithProfiling(enabled bool) Linter {
 	return l
 }
 
-// WithRootDir sets the root directory for the linter.
-// A root directory or prefix can be used to resolve relative paths
+// WithPathPrefix sets the root path prefix for the linter.
+// A root directory prefix can be used to resolve relative paths
 // referenced in the linter configuration with absolute file paths or URIs.
-func (l Linter) WithRootDir(rootDir string) Linter {
-	l.rootDir = rootDir
+func (l Linter) WithPathPrefix(pathPrefix string) Linter {
+	l.pathPrefix = pathPrefix
 
 	return l
 }
@@ -267,7 +267,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 			"internal": map[string]any{
 				"combined_config": config.ToMap(*conf),
 				"capabilities":    rio.ToMap(config.CapabilitiesForThisVersion()),
-				"root_dir":        l.rootDir,
+				"path_prefix":     l.pathPrefix,
 			},
 		},
 	}
@@ -280,7 +280,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 
 	l.startTimer(regalmetrics.RegalFilterIgnoredFiles)
 
-	filtered, err := config.FilterIgnoredPaths(l.inputPaths, ignore, true, l.rootDir)
+	filtered, err := config.FilterIgnoredPaths(l.inputPaths, ignore, true, l.pathPrefix)
 	if err != nil {
 		return report.Report{}, fmt.Errorf("errors encountered when reading files to lint: %w", err)
 	}
@@ -304,7 +304,7 @@ func (l Linter) Lint(ctx context.Context) (report.Report, error) {
 			l.inputModules.FileNames,
 			ignore,
 			false,
-			l.rootDir,
+			l.pathPrefix,
 		)
 		if err != nil {
 			return report.Report{}, fmt.Errorf("failed to filter paths: %w", err)

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -272,7 +272,7 @@ or := 1
 
 			linter := NewLinter()
 
-			linter = linter.WithRootDir(tc.rootDir)
+			linter = linter.WithPathPrefix(tc.rootDir)
 
 			if tc.userConfig != nil {
 				linter = linter.WithUserConfig(*tc.userConfig)


### PR DESCRIPTION
In the LS linting, pattern/* would not work when it would in the CLI. This was related to how abs paths were resolved and is fundamentally caused by and issue with URIs being used as file names in the linter.

Now, all files from the LS lint are ignored based on their path with the workspace root URI trimmed.


https://github.com/user-attachments/assets/30118754-61d5-4265-b68b-9fac99c204d9



