### PR TITLE
Fetch .regal.json capabilites files for Enterprise OPA

### DIFF
--- a/build/do.rq
+++ b/build/do.rq
@@ -287,7 +287,7 @@ fetch_eopa_caps if {
 		not eopa_caps_tree[p]
 
 		# construct the URL to fetch the content from
-		r := rq.template("https://raw.githubusercontent.com/StyraInc/enterprise-opa/main/capabilities/{{.tag}}.json", {"tag": t})
+		r := rq.template("https://raw.githubusercontent.com/StyraInc/enterprise-opa/main/capabilities/{{.tag}}.regal.json", {"tag": t})
 	}
 
 	print(sprintf("fetching %d capabilities files missing locally", [count(missing_locally)]))


### PR DESCRIPTION
Soon, as part of the Enterprise OPA release process, complete built-ins data will be pushed to the public repo. This will allow Regal to generate rich hover messages and show the correct links to documentation of additional built-ins.

