### PR TITLE
workflows/build: 'npm install' from subdir

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,8 @@ jobs:
         with:
           version: ${{ steps.opa.outputs.version }}
           static: ${{ matrix.os.static }}
-      - run: npm install --prefix build
+      - run: npm install
+        working-directory: build
       - name: Restore rq cache
         id: cache-rq
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2


### PR DESCRIPTION
Should be exactly like before, but without the security scanner complaining.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->