### PR TITLE
lsp/hover: Use link overrides if set

### DIFF
--- a/internal/lsp/hover/hover.go
+++ b/internal/lsp/hover/hover.go
@@ -60,12 +60,23 @@ func CreateHoverContent(builtin *ast.Builtin) string {
 	}
 	builtinCacheLock.Unlock()
 
-	title := fmt.Sprintf(
-		"[%s](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-%s-%s)",
-		builtin.Name,
+	link := fmt.Sprintf(
+		"https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-%s-%s",
 		rego.BuiltinCategory(builtin),
 		strings.ReplaceAll(builtin.Name, ".", ""),
 	)
+
+	// Enterprise OPA supports custom links via categories from 1.29.1
+	// https://github.com/StyraInc/enterprise-opa/blob/v1.29.1/capabilities/v1.29.1.json#L5110
+	for _, category := range builtin.Categories {
+		if strings.HasPrefix(category, "url=") {
+			link = category[4:]
+
+			break
+		}
+	}
+
+	title := fmt.Sprintf("[%s](%s)", builtin.Name, link)
 
 	sb := &strings.Builder{}
 

--- a/internal/lsp/hover/hover_test.go
+++ b/internal/lsp/hover/hover_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/types"
 )
 
 func TestCreateHoverContent(t *testing.T) {
@@ -25,6 +26,21 @@ func TestCreateHoverContent(t *testing.T) {
 		{
 			ast.JSONFilter,
 			"testdata/hover/jsonfilter.md",
+		},
+		{
+			&ast.Builtin{
+				Name:        "foo.bar",
+				Description: "Description for Foo Bar",
+				Decl: types.NewFunction(
+					types.Args(
+						types.Named("arg1", types.S).Description("arg1 for foobar"),
+						types.Named("arg2", types.S).Description("arg2 for foobar"),
+					),
+					types.Named("output", types.N).Description("the output for foobar"),
+				),
+				Categories: []string{"foo", "url=https://example.com"},
+			},
+			"testdata/hover/foobar.md",
 		},
 	}
 

--- a/internal/lsp/hover/testdata/hover/foobar.md
+++ b/internal/lsp/hover/testdata/hover/foobar.md
@@ -1,0 +1,16 @@
+### [foo.bar](https://example.com)
+
+```rego
+output := foo.bar(arg1, arg2)
+```
+
+Description for Foo Bar
+
+
+#### Arguments
+
+- `arg1` string — arg1 for foobar
+- `arg2` string — arg2 for foobar
+
+
+Returns `output` of type `number`: the output for foobar


### PR DESCRIPTION
Other engines may expose custom builtins with does not on openpolicyagent.org, [see here](https://github.com/StyraInc/enterprise-opa/blob/v1.29.1/capabilities/v1.29.1.json#L5110).


This PR supports loading them from the Categories for a builtin.

Thanks @srenatus for the help on this one!

<img width="941" alt="Screenshot 2024-11-06 at 14 36 14" src="https://github.com/user-attachments/assets/d6aa285d-df36-4eb0-b1f8-2852171b2dc3">
