### PR TITLE
internal/lsp/*_test.go: replace for+success pattern

### DIFF
--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -57,8 +57,7 @@ import rego.v1
 	defer timeout.Stop()
 
 	// no unresolved-imports at this stage
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case violations := <-messages["foo.rego"]:
 			if slices.Contains(violations, "unresolved-import") {
@@ -70,10 +69,6 @@ import rego.v1
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for expected foo.rego diagnostics")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -99,8 +94,7 @@ import rego.v1
 	// unresolved-imports is now expected
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case violations := <-messages["foo.rego"]:
 			if !slices.Contains(violations, "unresolved-import") {
@@ -112,10 +106,6 @@ import rego.v1
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for expected foo.rego diagnostics")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -144,8 +134,7 @@ import data.qux # new name for bar.rego package
 	// unresolved-imports is again not expected
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case violations := <-messages["foo.rego"]:
 			if slices.Contains(violations, "unresolved-import") {
@@ -157,10 +146,6 @@ import data.qux # new name for bar.rego package
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for expected foo.rego diagnostics")
-		}
-
-		if success {
-			break
 		}
 	}
 }
@@ -206,9 +191,7 @@ import data.quz
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
-	for {
-		success := false
-
+	for success := false; !success; {
 		select {
 		case <-ticker.C:
 			aggs := ls.cache.GetFileAggregates()
@@ -221,10 +204,6 @@ import data.quz
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file aggregates to be set")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -292,9 +271,7 @@ import data.wow # new
 
 	timeout.Reset(determineTimeout())
 
-	for {
-		success := false
-
+	for success := false; !success; {
 		select {
 		case <-ticker.C:
 			imports = determineImports(ls.cache.GetFileAggregates())
@@ -308,10 +285,6 @@ import data.wow # new
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file aggregates to be set")
-		}
-
-		if success {
-			break
 		}
 	}
 }
@@ -358,8 +331,7 @@ import rego.v1
 	timeout := time.NewTimer(determineTimeout())
 	defer timeout.Stop()
 
-	for {
-		var success bool
+	for success := true; !success; {
 		select {
 		case violations := <-messages["foo.rego"]:
 			if !slices.Contains(violations, "unresolved-import") {
@@ -377,10 +349,6 @@ import rego.v1
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for foo.rego diagnostics")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -407,8 +375,7 @@ import rego.v1
 	// wait for foo.rego to have the correct violations
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case violations := <-messages["foo.rego"]:
 			if slices.Contains(violations, "unresolved-import") {
@@ -426,10 +393,6 @@ import rego.v1
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for foo.rego diagnostics")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -454,8 +417,7 @@ import rego.v1
 	// check the violation is back
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case violations := <-messages["foo.rego"]:
 			if !slices.Contains(violations, "unresolved-import") {
@@ -473,10 +435,6 @@ import rego.v1
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for foo.rego diagnostics")
-		}
-
-		if success {
-			break
 		}
 	}
 }

--- a/internal/lsp/server_config_test.go
+++ b/internal/lsp/server_config_test.go
@@ -87,17 +87,12 @@ allow := true
 	timeout := time.NewTimer(determineTimeout())
 	defer timeout.Stop()
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case requestData := <-receivedMessages:
 			success = testRequestDataCodes(t, requestData, mainRegoFileURI, []string{"opa-fmt"})
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -120,17 +115,12 @@ allow := true
 	// validate that the client received a new, empty diagnostics notification for the file
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case requestData := <-receivedMessages:
 			success = testRequestDataCodes(t, requestData, mainRegoFileURI, []string{})
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
 		}
 	}
 }
@@ -164,8 +154,7 @@ func TestLanguageServerCachesEnabledRulesAndUsesDefaultConfig(t *testing.T) {
 	timeout := time.NewTimer(3 * time.Second)
 	ticker := time.NewTicker(500 * time.Millisecond)
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case <-ticker.C:
 			enabledRules := ls.getEnabledNonAggregateRules()
@@ -180,10 +169,6 @@ func TestLanguageServerCachesEnabledRulesAndUsesDefaultConfig(t *testing.T) {
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for enabled rules to be correct")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -221,8 +206,7 @@ rules:
 
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case <-ticker.C:
 			enabledRules := ls.getEnabledNonAggregateRules()
@@ -243,10 +227,6 @@ rules:
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for enabled rules to be correct")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -270,8 +250,7 @@ rules:
 
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case <-ticker.C:
 			enabledRules := ls.getEnabledNonAggregateRules()
@@ -298,10 +277,6 @@ rules:
 			success = true
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for enabled rules to be correct")
-		}
-
-		if success {
-			break
 		}
 	}
 }

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -84,17 +84,12 @@ rules:
 	timeout := time.NewTimer(determineTimeout())
 	defer timeout.Stop()
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case requestData := <-receivedMessages:
 			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{"opa-fmt", "use-assignment-operator"})
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -119,17 +114,12 @@ allow := true
 	// validate that the client received a new diagnostics notification for the file
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case requestData := <-receivedMessages:
 			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{"opa-fmt"})
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file diagnostics to be sent")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -151,8 +141,7 @@ rules:
 	// validate that the client received a new, empty diagnostics notification for the file
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case requestData := <-receivedMessages:
 			if requestData.URI != mainRegoURI {
@@ -175,10 +164,6 @@ rules:
 			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for main.rego diagnostics to be sent")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -204,8 +189,7 @@ capabilities:
 	// validate that the client received a new, empty diagnostics notification for the file
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case requestData := <-receivedMessages:
 			if requestData.URI != mainRegoURI {
@@ -228,10 +212,6 @@ capabilities:
 			success = testRequestDataCodes(t, requestData, mainRegoURI, []string{})
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for main.rego diagnostics to be sent")
-		}
-
-		if success {
-			break
 		}
 	}
 
@@ -262,8 +242,7 @@ allow := neo4j.q
 	// validate that the client received a new diagnostics notification for the file
 	timeout.Reset(determineTimeout())
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case requestData := <-receivedMessages:
 			if requestData.URI != mainRegoURI {
@@ -287,10 +266,6 @@ allow := neo4j.q
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file diagnostics to be sent")
 		}
-
-		if success {
-			break
-		}
 	}
 
 	// 7. With our new config applied, and the file updated, we can ask the
@@ -302,9 +277,7 @@ allow := neo4j.q
 	ticker := time.NewTicker(500 * time.Millisecond)
 	defer ticker.Stop()
 
-	for {
-		foundNeo4j := false
-
+	for success := false; !success; {
 		select {
 		case <-ticker.C:
 			// Create a new context with timeout for each request, this is
@@ -346,7 +319,7 @@ allow := neo4j.q
 				}
 
 				if label == "neo4j.query" {
-					foundNeo4j = true
+					success = true
 
 					break
 				}
@@ -355,10 +328,6 @@ allow := neo4j.q
 			t.Logf("waiting for neo4j.query in completion results for neo4j.q, got %v", itemsList)
 		case <-timeout.C:
 			t.Fatalf("timed out waiting for file completion to correct")
-		}
-
-		if foundNeo4j {
-			break
 		}
 	}
 }

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -319,8 +319,7 @@ func TestNewFileTemplating(t *testing.T) {
   "label": "Template new Rego file"
 }`, newFileURI, expectedNewFileURI, tempDir)
 
-	for {
-		var success bool
+	for success := false; !success; {
 		select {
 		case msg := <-receivedMessages:
 			t.Log("received message:", string(msg))
@@ -344,17 +343,11 @@ func TestNewFileTemplating(t *testing.T) {
 				}
 			}
 
-			if allLinesMatch {
-				success = true
-			}
+			success = allLinesMatch
 		case <-timeout.C:
 			t.Log("never received expected message", expectedMessage)
 
 			t.Fatalf("timed out waiting for expected message to be sent")
-		}
-
-		if success {
-			break
 		}
 	}
 }


### PR DESCRIPTION
It's no functional change, just makes the code a little more concise.

Hope you don't mind me messing with your test code like this. Originally, I had attempted to use labels, like

```go
outer:
    for {
      select {
        case ... :
          // stuff
        break outer
    }
```
but labels need to be unique within a file, and having to go with `outer1`, `outer2`, ... etc would have been awkward.