### PR TITLE
Fix false positive given arity mismatch in `inconsistent-args`

### DIFF
--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
@@ -24,6 +24,9 @@ report contains violation if {
 
 	some name, args_list in function_args_by_name
 
+	# leave that to the compiler
+	not _arity_mismatch(args_list)
+
 	# "Partition" the args by their position
 	by_position := [s |
 		some i, _ in args_list[0]
@@ -37,6 +40,12 @@ report contains violation if {
 	args := _find_function_by_name(name).head.args
 
 	violation := result.fail(rego.metadata.chain(), result.ranged_location_between(args[0], regal.last(args)))
+}
+
+_arity_mismatch(args_list) if {
+	len := count(args_list[0])
+	some arr in args_list
+	count(arr) != len
 }
 
 _inconsistent_args(position) if {

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
@@ -83,6 +83,19 @@ test_success_using_pattern_matching if {
 	r == set()
 }
 
+# this is a compiler error, so let's not flag it here
+# see https://github.com/StyraInc/regal/issues/1250
+test_success_incorrect_arity if {
+	module := ast.with_rego_v1(`
+	foo(a, b) if a == b
+	foo(a, b, c) if a > b > c
+	foo(b, a) if a == b
+	`)
+	r := rule.report with input as module
+
+	r == set()
+}
+
 expected := {
 	"category": "bugs",
 	"description": "Inconsistently named function arguments",


### PR DESCRIPTION
While a mismatched arg is technically still a violation, the arity mismatch should probably be dealt with first, so let's have the compiler handle that.

Fixes #1250

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->