### PR TITLE
ci: Allow race detector to fail

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,10 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test -race ./...
+        id: race
+        continue-on-error: true
+      - run: echo "race detector failed but job is optional"
+        if: job.steps.race.status == failure()
 
   code_coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This step is unreliable and needs more investigation. It is currently running in optional mode.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->