### PR TITLE
Add `--instrument` flag to `regal lint`

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -49,6 +49,7 @@ type lintCommandParams struct {
 	enablePrint     bool
 	metrics         bool
 	profile         bool
+	instrument      bool
 	disableAll      bool
 	enableAll       bool
 }
@@ -167,6 +168,8 @@ func init() {
 		"enable metrics reporting (currently supported only for JSON output format)")
 	lintCommand.Flags().BoolVar(&params.profile, "profile", false,
 		"enable profiling metrics to be added to reporting (currently supported only for JSON output format)")
+	lintCommand.Flags().BoolVar(&params.instrument, "instrument", false,
+		"enable instrumentation metrics to be added to reporting (currently supported only for JSON output format)")
 
 	lintCommand.Flags().VarP(&params.disable, "disable", "d",
 		"disable specific rule(s). This flag can be repeated.")
@@ -283,6 +286,10 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 
 	if params.profile {
 		regal = regal.WithProfiling(true)
+	}
+
+	if params.instrument {
+		regal = regal.WithInstrumentation(true)
 	}
 
 	var userConfig config.Config

--- a/cmd/profiling.go
+++ b/cmd/profiling.go
@@ -28,9 +28,9 @@ func wrapProfiling(f func([]string) error) func(*cobra.Command, []string) error 
 		case "clock":
 			opts = append(opts, profile.ClockProfile)
 		case "mem_heap":
-			opts = append(opts, profile.MemProfileHeap)
+			opts = append(opts, profile.MemProfileHeap, profile.MemProfileRate(1024))
 		case "mem_allocs":
-			opts = append(opts, profile.MemProfileAllocs)
+			opts = append(opts, profile.MemProfileAllocs, profile.MemProfileRate(1024))
 		case "trace":
 			opts = append(opts, profile.TraceProfile)
 		case "goroutine":


### PR DESCRIPTION
Same as for `opa eval`

Unrelated change is increasing the granularity of the memory allocation collectors, as I found that helped a lot when tracking down allocations

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->