### PR TITLE
Use new setting to cache AST conversions from store

### DIFF
--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/topdown"
 
 	rbundle "github.com/styrainc/regal/bundle"
 	rio "github.com/styrainc/regal/internal/io"
@@ -139,13 +138,14 @@ func prepareQuery(ctx context.Context, store storage.Store, query string) (*rego
 
 func prepareRegoArgs(store storage.Store, query ast.Body) []func(*rego.Rego) {
 	return []func(*rego.Rego){
+		rego.StoreReadAST(true),
 		rego.Store(store),
 		rego.ParsedQuery(query),
 		rego.ParsedBundle("regal", &rbundle.LoadedBundle),
 		rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 		rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
-		// TODO: remove later
-		rego.EnablePrintStatements(true),
-		rego.PrintHook(topdown.NewPrintHook(os.Stderr)),
+		// Uncomment for development
+		// rego.EnablePrintStatements(true),
+		// rego.PrintHook(topdown.NewPrintHook(os.Stderr)),
 	}
 }

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -118,6 +118,7 @@ func initialize() {
 			rego.ParsedBundle("regal", &rbundle.LoadedBundle),
 			rego.Function2(builtins.RegalParseModuleMeta, builtins.RegalParseModule),
 			rego.Function1(builtins.RegalLastMeta, builtins.RegalLast),
+			rego.StoreReadAST(true),
 		}, args...)
 	}
 

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -709,6 +709,7 @@ func (l Linter) prepareRegoArgs(query ast.Body) ([]func(*rego.Rego), error) {
 	}
 
 	regoArgs = append(regoArgs,
+		rego.StoreReadAST(true),
 		rego.Metrics(l.metrics),
 		rego.ParsedQuery(query),
 		rego.ParsedBundle("regal_eval_params", &dataBundle),

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -760,3 +760,17 @@ import data.unresolved`,
 		t.Fatalf("unexpected files: %v", got)
 	}
 }
+
+func BenchmarkRegalLintingItself(b *testing.B) {
+	linter := NewLinter().WithInputPaths([]string{"../../bundle"}).WithEnableAll(true)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := linter.Lint(context.Background())
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
This doesn't have a huge impact on `regal lint` (although it does result in less allocations), but could potentially make a real difference for the LSP policies where ASTs from the whole workspace is provided under `data.workspace`.

Also, add the simple benchmark test I've been using for OPA fixes.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->