### PR TITLE
Fix custom rules that report on the absence of aggregates

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -429,6 +429,30 @@ func TestAggregatesAreCollectedAndUsed(t *testing.T) {
 			t.Errorf("expected 1 violation, got %d", rep.Summary.NumViolations)
 		}
 	})
+
+	t.Run("custom policy where nothing aggregate is a violation", func(t *testing.T) {
+		stdout, stderr := bytes.Buffer{}, bytes.Buffer{}
+
+		err := regal(&stdout, &stderr)("lint", "--format", "json", "--rules",
+			basedir+filepath.FromSlash("/custom/regal/rules/testcase/empty_aggregate/"),
+			basedir+filepath.FromSlash("/two_policies"))
+
+		expectExitCode(t, err, 3, &stdout, &stderr)
+
+		if exp, act := "", stderr.String(); exp != act {
+			t.Errorf("expected stderr %q, got %q", exp, act)
+		}
+
+		var rep report.Report
+
+		if err = json.Unmarshal(stdout.Bytes(), &rep); err != nil {
+			t.Fatalf("expected JSON response, got %v", stdout.String())
+		}
+
+		if rep.Summary.NumViolations != 1 {
+			t.Errorf("expected 1 violation, got %d", rep.Summary.NumViolations)
+		}
+	})
 }
 
 func TestLintAggregateIgnoreDirective(t *testing.T) {

--- a/e2e/testdata/aggregates/custom/regal/rules/testcase/empty_aggregate/empty_aggregate.rego
+++ b/e2e/testdata/aggregates/custom/regal/rules/testcase/empty_aggregate/empty_aggregate.rego
@@ -1,0 +1,21 @@
+# METADATA
+# description: |
+#   Test to ensure a custom rule that aggregated no data is still reported
+# related_resources:
+#   - description: issue
+#     ref: https://github.com/StyraInc/regal/issues/1259
+package custom.regal.rules.testcase.empty_aggregates
+
+import rego.v1
+
+import data.regal.result
+
+aggregate contains result.aggregate(rego.metadata.chain(), {}) if {
+	input.nope
+}
+
+aggregate_report contains violation if {
+	count(input.aggregate) == 0
+
+	violation := result.fail(rego.metadata.chain(), {})
+}


### PR DESCRIPTION
While custom aggregate rules would largely work before, those that report on the absence of data (like a rule named "allow") did not work. This as the aggregator sent nothing back in those caes — and contrary to the built-in rules, Regal had then no way of knowing in the next step that the aggregate report rules should be called even with no data.

I'm not super happy about the way we communicate this back to the Go side, but there's a lot I'm not happy about with regards to how aggregate data is shuffled back and forth. Some effort to fix that will however have to wait until later.

Fixes #1259

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->