### PR TITLE
lsp: Use notify for sending messages

### DIFF
--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -74,7 +74,7 @@ import rego.v1
 
 	barURI := fileURIScheme + filepath.Join(tempDir, "bar.rego")
 
-	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	err = connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: barURI,
 		},
@@ -111,7 +111,7 @@ import rego.v1
 
 	fooURI := fileURIScheme + filepath.Join(tempDir, "foo.rego")
 
-	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	err = connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: fooURI,
 		},
@@ -249,7 +249,7 @@ import data.quz
 	}
 
 	// 2. check the aggregates for a file are updated after an update
-	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	err = connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: fileURIScheme + filepath.Join(tempDir, "bar.rego"),
 		},
@@ -355,7 +355,7 @@ import rego.v1
 	// update the contents of the bar.rego file to address the unresolved-import
 	barURI := fileURIScheme + filepath.Join(tempDir, "bar.rego")
 
-	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	err = connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: barURI,
 		},
@@ -397,7 +397,7 @@ import rego.v1
 	}
 
 	// update the contents of the bar.rego to bring back the violation
-	err = connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	err = connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: barURI,
 		},

--- a/internal/lsp/server_config_test.go
+++ b/internal/lsp/server_config_test.go
@@ -193,7 +193,7 @@ rules:
 	}
 
 	// this event is sent to allow the server to detect the new config
-	if err := connClient.Call(ctx, "workspace/didChangeWatchedFiles", types.WorkspaceDidChangeWatchedFilesParams{
+	if err := connClient.Notify(ctx, "workspace/didChangeWatchedFiles", types.WorkspaceDidChangeWatchedFilesParams{
 		Changes: []types.FileEvent{
 			{
 				URI:  fileURIScheme + filepath.Join(tempDir, ".regal/config.yaml"),

--- a/internal/lsp/server_multi_file_test.go
+++ b/internal/lsp/server_multi_file_test.go
@@ -130,7 +130,7 @@ ignore:
 
 	// 3. Client sends textDocument/didChange notification with new contents
 	// for authz.rego no response to the call is expected
-	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	if err := connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: fileURIScheme + filepath.Join(tempDir, "authz.rego"),
 		},

--- a/internal/lsp/server_single_file_test.go
+++ b/internal/lsp/server_single_file_test.go
@@ -95,7 +95,7 @@ rules:
 
 	// Client sends textDocument/didChange notification with new contents for main.rego
 	// no response to the call is expected
-	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	if err := connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: mainRegoURI,
 		},
@@ -220,7 +220,7 @@ capabilities:
 	// the start of an EOPA-specific call, so if the capabilities were
 	// loaded correctly, we should see a completion later after we ask for
 	// it.
-	if err := connClient.Call(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
+	if err := connClient.Notify(ctx, "textDocument/didChange", types.TextDocumentDidChangeParams{
 		TextDocument: types.TextDocumentIdentifier{
 			URI: mainRegoURI,
 		},

--- a/internal/lsp/server_template_test.go
+++ b/internal/lsp/server_template_test.go
@@ -262,7 +262,7 @@ func TestNewFileTemplating(t *testing.T) {
 	}
 
 	// Client sends workspace/didCreateFiles notification
-	if err := connClient.Call(ctx, "workspace/didCreateFiles", types.WorkspaceDidCreateFilesParams{
+	if err := connClient.Notify(ctx, "workspace/didCreateFiles", types.WorkspaceDidCreateFilesParams{
 		Files: []types.WorkspaceDidCreateFilesParamsCreatedFile{
 			{URI: newFileURI},
 		},


### PR DESCRIPTION
Previously, we were using Call, this will wait for a request and can block. This PR uses Notify instead, which is non-blocking and follows the spec.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->