### PR TITLE
Add support for using input.yaml in Evaluate code lens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,12 @@ dist/
 /regal.exe
 
 # These two files are used by the Regal evaluation Code Lens, where input.json
-# defines the input to use for evaluation, and output.json is where the output
-# ends up unless the client supports presenting it in a different way.
+# (or input.yaml) defines the input to use for evaluation, and output.json is
+# where the output ends up unless the client supports presenting it in a
+# different way.
 input.json
+input.yaml
+
 output.json
 
 build/node_modules/

--- a/docs/language-server.md
+++ b/docs/language-server.md
@@ -173,10 +173,11 @@ the way it did, or where rule evaluation failed.
   src={require('./assets/lsp/evalcodelensprint.png').default}
   alt="Screenshot of evaluation with print call performed via code lens"/>
 
-Policy evaluation often depends on **input**. This can be provided via an `input.json` file which Regal will search
-for first in the same directory as the policy file evaluated. If not found there, Regal will proceed to search each
-parent directory up until the workspace root directory. It is recommended to add `input.json` to your `.gitignore`
-file so that you can work freely with evaluation in any directory without having your input accidentally committed.
+Policy evaluation often depends on **input**. This can be provided via an `input.json` or `input.yaml` file which
+Regal will search for first in the same directory as the policy file evaluated. If not found there, Regal will proceed
+to search each parent directory up until the workspace root directory. It is recommended to add `input.json/yaml` to
+your `.gitignore` file so that you can work freely with evaluation in any directory without having your input
+accidentally committed.
 
 #### Editor support
 

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -2,10 +2,8 @@ package providers
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 
 	"github.com/open-policy-agent/opa/ast"
@@ -70,20 +68,15 @@ func (p *Policy) Run(
 	inputContext["path_separator"] = string(os.PathSeparator)
 
 	workspacePath := uri.ToPath(opts.ClientIdentifier, opts.RootURI)
-	inputDotJSONPath, inputDotJSONReader := rio.FindInput(
+
+	inputDotJSONPath, inputDotJSONContent := rio.FindInput(
 		uri.ToPath(opts.ClientIdentifier, params.TextDocument.URI),
 		workspacePath,
 	)
 
-	if inputDotJSONReader != nil {
-		inputDotJSON := make(map[string]any)
-
-		if bs, err := io.ReadAll(inputDotJSONReader); err == nil {
-			if err = json.Unmarshal(bs, &inputDotJSON); err == nil {
-				inputContext["input_dot_json_path"] = inputDotJSONPath
-				inputContext["input_dot_json"] = inputDotJSON
-			}
-		}
+	if inputDotJSONPath != "" && inputDotJSONContent != nil {
+		inputContext["input_dot_json_path"] = inputDotJSONPath
+		inputContext["input_dot_json"] = inputDotJSONContent
 	}
 
 	input, err := rego2.ToInput(

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -4,10 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"strings"
-
-	"github.com/anderseknert/roast/pkg/encoding"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/bundle"
@@ -24,7 +21,7 @@ import (
 func (l *LanguageServer) Eval(
 	ctx context.Context,
 	query string,
-	input io.Reader,
+	input map[string]any,
 	printHook print.Hook,
 	dataBundles map[string]bundle.Bundle,
 ) (rego.ResultSet, error) {
@@ -88,20 +85,7 @@ func (l *LanguageServer) Eval(
 	}
 
 	if input != nil {
-		inputMap := make(map[string]any)
-
-		in, err := io.ReadAll(input)
-		if err != nil {
-			return nil, fmt.Errorf("failed reading input: %w", err)
-		}
-
-		json := encoding.JSON()
-
-		if err = json.Unmarshal(in, &inputMap); err != nil {
-			return nil, fmt.Errorf("failed unmarshalling input: %w", err)
-		}
-
-		return pq.Eval(ctx, rego.EvalInput(inputMap)) //nolint:wrapcheck
+		return pq.Eval(ctx, rego.EvalInput(input)) //nolint:wrapcheck
 	}
 
 	return pq.Eval(ctx) //nolint:wrapcheck
@@ -116,7 +100,7 @@ type EvalPathResult struct {
 func (l *LanguageServer) EvalWorkspacePath(
 	ctx context.Context,
 	query string,
-	input io.Reader,
+	input map[string]any,
 ) (EvalPathResult, error) {
 	resultQuery := "result := " + query
 


### PR DESCRIPTION
This addresses a request filed in the VS Code extension: https://github.com/open-policy-agent/vscode-opa/issues/308

Sadly this doesn't yet work for the debug feature as OPA currently only will do JSON decoding in that path, so next step is to submit a fix for that there.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->