### PR TITLE
Less frequent, and grouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,15 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     ignore:
       # update OPA manually to bump version in README too
       - dependency-name: "github.com/open-policy-agent/opa"
+    groups:
+      dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Monthly may seem like an excaggeration, but our only real dependency is OPA, and we update that ourselves anyway. The rest are just peripheral, and security related updates will be suggested immediately regardless.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->