### PR TITLE
fix: [#1275] Return version if regal installed using go install

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,6 @@
     "OPA_CHECK_CAPABILITIES": "${workspacePath}/build/capabilities.json",
     "OPA_EVAL_CAPABILITIES": "${workspacePath}/build/capabilities.json"
   },
-  "opa.roots": [
-    "${workspaceFolder}/bundle"
-  ],
+  "opa.roots": ["${workspaceFolder}/bundle"],
   "opa.strictMode": true
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -51,7 +51,7 @@ func (vi Info) String() string {
 
 func New() Info {
 	return Info{
-		Version:   unknownString(Version),
+		Version:   unknownVersionString(Version),
 		GoVersion: goVersion,
 		Platform:  platform,
 		Commit:    unknownString(Commit),
@@ -63,6 +63,14 @@ func New() Info {
 func unknownString(s string) string {
 	if s == "" {
 		return "unknown"
+	}
+
+	return s
+}
+
+func unknownVersionString(s string) string {
+	if s == "" {
+		return "v.29.3"
 	}
 
 	return s


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->

Return version if regal is installed using `go install`.