### PR TITLE
Fix false positive in `pointless-reassignment`

### DIFF
--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
@@ -26,7 +26,10 @@ report contains violation if {
 
 	not expr["with"]
 
-	ast.assignment_terms(expr)[1].type == "var"
+	[lhs, rhs] := ast.assignment_terms(expr)
+
+	lhs.type == "var"
+	rhs.type == "var"
 
 	violation := result.fail(rego.metadata.chain(), result.infix_expr_location(expr.terms))
 }

--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment_test.rego
@@ -7,7 +7,7 @@ import data.regal.config
 
 import data.regal.rules.style["pointless-reassignment"] as rule
 
-test_pointless_reassignment_in_rule_head if {
+test_fail_pointless_reassignment_in_rule_head if {
 	module := ast.with_rego_v1(`
 	foo := "foo"
 
@@ -37,7 +37,7 @@ test_pointless_reassignment_in_rule_head if {
 	}}
 }
 
-test_pointless_reassignment_in_rule_body if {
+test_fail_pointless_reassignment_in_rule_body if {
 	module := ast.with_rego_v1(`
 	rule if {
 		foo := "foo"
@@ -69,7 +69,7 @@ test_pointless_reassignment_in_rule_body if {
 	}}
 }
 
-test_pointless_reassignment_in_rule_body_using_with if {
+test_success_pointless_reassignment_in_rule_body_using_with if {
 	module := ast.with_rego_v1(`
 	foo := input
 
@@ -77,6 +77,19 @@ test_pointless_reassignment_in_rule_body_using_with if {
 		bar := foo with input as "wow"
 
 		bar == true
+	}
+	`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_pointless_reassignment_to_array if {
+	module := ast.with_rego_v1(`
+	parts := split(input.arr, ".")
+
+	rule := [b, a] if {
+		[a, b] := parts
 	}
 	`)
 


### PR DESCRIPTION
That would happen despite the left hand side not being a var

Fixes #1285

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->