### PR TITLE
Avoid allocations by not calling custom functions on hot path

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -347,8 +347,11 @@ all_function_names := object.keys(all_functions)
 
 # METADATA
 # description: set containing all negated expressions in input AST
-negated_expressions[rule] contains value if {
-	some rule in input.rules
+negated_expressions[rule_index] contains value if {
+	some i, rule in _rules
+
+	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
+	rule_index := sprintf("%d", [i])
 
 	walk(rule, [_, value])
 

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
@@ -26,8 +26,8 @@ _multivalue_rules contains path if {
 }
 
 _negated_refs contains negated_ref if {
-	some rule, value
-	ast.negated_expressions[rule][value]
+	some rule_index, value
+	ast.negated_expressions[rule_index][value]
 
 	# if terms is an array, it's a function call, and most likely not "impossible"
 	is_object(value.terms)
@@ -39,6 +39,8 @@ _negated_refs contains negated_ref if {
 	every path in util.rest(ref) {
 		path.type == "string"
 	}
+
+	rule := input.rules[to_number(rule_index)]
 
 	# ignore negated local vars
 	not ref[0].value in ast.function_arg_names(rule)


### PR DESCRIPTION
This is absolutely wild 🙃

**Before**
```
BenchmarkRegalLintingItself-10	1	3245668375 ns/op	6689411656 B/op	127195706 allocs/op
```

**After**
```
BenchmarkRegalLintingItself-10  1	2777580459 ns/op	5235852824 B/op	107686435 allocs/op
```

And
```
hyperfine -i --warmup 1 'regal lint bundle' 'regal-new lint bundle'
Benchmark 1: regal lint bundle
  Time (mean ± σ):      3.232 s ±  0.046 s    [User: 22.535 s, System: 0.623 s]
  Range (min … max):    3.169 s …  3.296 s    10 runs

Benchmark 2: regal-new lint bundle
  Time (mean ± σ):      2.754 s ±  0.046 s    [User: 18.641 s, System: 0.472 s]
  Range (min … max):    2.689 s …  2.813 s    10 runs

Summary
  regal-new lint bundle ran
    1.17 ± 0.03 times faster than regal lint bundle
```

No @srenatus, I will not use benchstat! 🤣

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->