### PR TITLE
dependabot: Update GHA dependencies in groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,21 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  groups:
-    dependencies:
-      patterns:
-      - "*"
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: "monthly"
-  ignore:
-  # update OPA manually to bump version in README too
-  - dependency-name: "github.com/open-policy-agent/opa"
-  groups:
-    dependencies:
-      patterns:
-      - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    ignore:
+      # update OPA manually to bump version in README too
+      - dependency-name: "github.com/open-policy-agent/opa"
+    groups:
+      dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,21 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-    ignore:
-      # update OPA manually to bump version in README too
-      - dependency-name: "github.com/open-policy-agent/opa"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    dependencies:
+      patterns:
+      - "*"
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  ignore:
+  # update OPA manually to bump version in README too
+  - dependency-name: "github.com/open-policy-agent/opa"
+  groups:
+    dependencies:
+      patterns:
+      - "*"


### PR DESCRIPTION
This should reduce the number of PRs we have when there are many updates to GHA deps, not just for go.mod deps.

<img width="928" alt="Screenshot 2025-01-06 at 11 19 14" src="https://github.com/user-attachments/assets/5245be09-7c6b-42e6-8d55-2ef83b5872ce" />

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->