### PR TITLE
e2e: Fix CLI test for 1.0 preparations and defaults

### DIFF
--- a/e2e/testdata/configs/v0-with-import-rego-v1.yaml
+++ b/e2e/testdata/configs/v0-with-import-rego-v1.yaml
@@ -1,3 +1,5 @@
+project:
+  rego-version: 0
 capabilities:
   from:
     engine: opa


### PR DESCRIPTION
Mainly, this is ensuring the configs for each test are correct.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->