### PR TITLE
cmd/languageserver: Log path & version at startup

### DIFF
--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
 
 	"github.com/styrainc/regal/internal/lsp"
 	"github.com/styrainc/regal/internal/lsp/log"
+	"github.com/styrainc/regal/pkg/version"
 )
 
 func init() {
@@ -24,6 +26,23 @@ func init() {
 		RunE: wrapProfiling(func([]string) error {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
+
+			exe, err := os.Executable()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, "error getting executable:", err)
+			} else {
+				absPath, err := filepath.Abs(exe)
+				if err != nil {
+					fmt.Fprintln(os.Stderr, "error getting executable path:", err)
+				} else {
+					v := version.Version
+					if v == "" {
+						v = "Unknown"
+					}
+
+					fmt.Fprintf(os.Stderr, "Regal Language Server (path: %s, version: %s)", absPath, v)
+				}
+			}
 
 			opts := &lsp.LanguageServerOptions{
 				LogWriter: os.Stderr,


### PR DESCRIPTION
Fixes https://github.com/StyraInc/regal/issues/1324

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->