### PR TITLE
lsp/completions: No rego.v1 import when in v1 file

### DIFF
--- a/bundle/regal/lsp/completion/providers/regov1/regov1.rego
+++ b/bundle/regal/lsp/completion/providers/regov1/regov1.rego
@@ -11,6 +11,7 @@ import data.regal.lsp.completion.location
 # description: completion suggestion for rego.v1
 items contains item if {
 	not strings.any_prefix_match(input.regal.file.lines, "import rego.v1")
+	not input.regal.context.rego_version == 3 # the rego.v1 import is not used in v1 rego
 
 	position := location.to_position(input.regal.context.location)
 	line := input.regal.file.lines[position.line]

--- a/bundle/regal/lsp/completion/providers/regov1/regov1_test.rego
+++ b/bundle/regal/lsp/completion/providers/regov1/regov1_test.rego
@@ -8,7 +8,7 @@ test_regov1_completion_on_typing if {
 	policy := `package policy
 
 import r`
-	items := provider.items with input as util.input_with_location(policy, {"row": 3, "col": 9})
+	items := provider.items with input as util.input_with_location_and_version(policy, {"row": 3, "col": 9}, 0)
 	items == {{
 		"label": "rego.v1",
 		"kind": 9,
@@ -33,7 +33,7 @@ test_regov1_completion_on_invoked if {
 	policy := `package policy
 
 import `
-	items := provider.items with input as util.input_with_location(policy, {"row": 3, "col": 8})
+	items := provider.items with input as util.input_with_location_and_version(policy, {"row": 3, "col": 8}, 0)
 	items == {{
 		"label": "rego.v1",
 		"kind": 9,
@@ -60,6 +60,18 @@ test_no_regov1_completion_if_already_imported if {
 import rego.v1
 
 import r`
-	items := provider.items with input as util.input_with_location(policy, {"row": 5, "col": 9})
+	items := provider.items with input as util.input_with_location_and_version(policy, {"row": 5, "col": 9}, 0)
+	items == set()
+}
+
+test_no_regov1_completion_if_v1_file if {
+	policy := `package policy
+
+import r`
+	items := provider.items with input as util.input_with_location_and_version(
+		policy,
+		{"row": 3, "col": 9},
+		3, # RegoV1
+	)
 	items == set()
 }

--- a/bundle/regal/lsp/completion/providers/test_utils/test_utils.rego
+++ b/bundle/regal/lsp/completion/providers/test_utils/test_utils.rego
@@ -28,3 +28,16 @@ input_with_location(policy, location) := {"regal": {
 	},
 	"context": {"location": location},
 }}
+
+# METADATA
+# description: same as input_with_location but with option to set rego_version too
+input_with_location_and_version(policy, location, rego_version) := {"regal": {
+	"file": {
+		"name": "p.rego",
+		"lines": split(policy, "\n"),
+	},
+	"context": {
+		"location": location,
+		"rego_version": rego_version,
+	},
+}}

--- a/internal/embeds/schemas/regal-ast.json
+++ b/internal/embeds/schemas/regal-ast.json
@@ -413,6 +413,11 @@
             },
             "input_dot_json_path": {
               "type": "string"
+            },
+            "rego_version": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 3
             }
           }
         }

--- a/internal/lsp/completions/providers/options.go
+++ b/internal/lsp/completions/providers/options.go
@@ -12,4 +12,5 @@ type Options struct {
 	Builtins         map[string]*ast.Builtin
 	RootURI          string
 	ClientIdentifier clients.Identifier
+	RegoVersion      ast.RegoVersion
 }

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -67,6 +67,7 @@ func (p *Policy) Run(
 	inputContext["client_identifier"] = opts.ClientIdentifier
 	inputContext["workspace_root"] = uri.ToPath(opts.ClientIdentifier, opts.RootURI)
 	inputContext["path_separator"] = rio.PathSeparator
+	inputContext["rego_version"] = opts.RegoVersion
 
 	workspacePath := uri.ToPath(opts.ClientIdentifier, opts.RootURI)
 

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"github.com/open-policy-agent/opa/v1/ast"
+
 	"github.com/styrainc/regal/internal/lsp/types/completion"
 	"github.com/styrainc/regal/internal/lsp/types/symbols"
 )
@@ -129,6 +131,7 @@ type CompletionParams struct {
 	TextDocument TextDocumentIdentifier `json:"textDocument"`
 	Context      CompletionContext      `json:"context"`
 	Position     Position               `json:"position"`
+	RegoVersion  ast.RegoVersion        `json:"regoVersion"`
 }
 
 type CompletionContext struct {


### PR DESCRIPTION
Also, use new version cache to determine version for formatting

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->