### PR TITLE
Prepare docs for OPA 1.0 compatibility

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,17 @@
         "--dry-run",
         "bundle"
       ]
+    },
+    {
+      "name": "regal test bundle",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}",
+      "args": [
+        "test",
+        "bundle"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ development, whether you're an experienced Rego developer or just starting out.
 
 \- [Merriam Webster](https://www.merriam-webster.com/dictionary/regal)
 
+## **New!** Regal and OPA 1.0
+
+OPA 1.0 was [just released](https://blog.openpolicyagent.org/announcing-opa-1-0-a-new-standard-for-policy-as-code-a6d8427ee828),
+and starting from version v0.30.0, Regal supports working with both OPA 1.0 policies and Rego from earlier versions
+of OPA. While everything should work without additional configuration, we recommend checking out our documentation on
+using Regal with [OPA 1.0](https://docs.styra.com/regal/opa-one-dot-zero) for the best possible experience managing
+projects of any given Rego version, or even a mix of them.
+
 ## Goals
 
 - Deliver an outstanding policy development experience by providing the best possible tools for that purpose
@@ -104,8 +112,6 @@ First, author some Rego!
 **policy/authz.rego**
 ```rego
 package authz
-
-import rego.v1
 
 default allow = false
 
@@ -292,7 +298,9 @@ The following rules are currently available:
 
 <!-- RULES_TABLE_END -->
 
-By default, all rules except for those in the `custom` category are currently **enabled**.
+Rules in all category except for those in `custom` are **enabled** by default. Some rules however — like `use-contains`
+and `use-if` — are conditionally enabled only when a version of OPA/Rego before 1.0 is targeted. See the configuration
+options below if you want to use Regal to lint "legacy" policies.
 
 **Aggregate Rules**
 
@@ -509,8 +517,6 @@ alternatively on the same line to the right of the expression:
 
 ```rego
 package policy
-
-import rego.v1
 
 # regal ignore:prefer-snake-case
 camelCase := "yes"
@@ -824,6 +830,7 @@ in the near future:
 
 ### Linter
 
+- [x] Full support for both OPA 1.0 policies and older versions of Rego
 - [ ] Allow remediation of more `style` category rules using the `regal fix` command
 - [ ] Add [unused-rule](https://github.com/StyraInc/regal/issues/358) linter
 - [x] Add [unused-output-variable](https://github.com/StyraInc/regal/issues/60) linter

--- a/build/simplecov/simplecov.rego
+++ b/build/simplecov/simplecov.rego
@@ -4,8 +4,6 @@
 #  simplecov JSON, to be used for Codecov reports, et. al.
 package build.simplecov
 
-import rego.v1
-
 # METADATA
 # entrypoint: true
 from_opa := {"coverage": _coverage}

--- a/build/workflows/update_example_index.rego
+++ b/build/workflows/update_example_index.rego
@@ -7,8 +7,6 @@
 #     ref: file:///./../../.github/workflows/update-example-index.yaml
 package build.workflows
 
-import rego.v1
-
 # METADATA
 # entrypoint: true
 symbols := {"keywords": _keywords, "builtins": _builtins}

--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -8,8 +8,6 @@ test_find_vars if {
 	policy := `
 	package p
 
-	import rego.v1
-
 	global := "foo"
 
 	allow if {
@@ -57,8 +55,6 @@ test_find_vars_comprehension_lhs if {
 	policy := `
 	package p
 
-	import rego.v1
-
 	allow if {
 		a := [b | input[b]]
 		c := {d | input[d]}
@@ -82,8 +78,6 @@ test_find_vars_function_ret_return_args if {
 	policy := `
 	package p
 
-	import rego.v1
-
 	allow if {
 		walk(input, [path, value])
 	}
@@ -101,8 +95,6 @@ test_find_vars_function_ret_return_args if {
 # https://github.com/StyraInc/regal/issues/168
 test_function_decls_multiple_same_name if {
 	policy := `package p
-
-	import rego.v1
 
 	f(x) := x if true
 	f(y) := y if false
@@ -151,8 +143,6 @@ test_find_vars_in_local_scope if {
 	policy := `
 	package p
 
-	import rego.v1
-
 	global := "foo"
 
 	allow if {
@@ -189,8 +179,6 @@ test_find_vars_in_local_scope_complex_comprehension_term if {
 	policy := `
 	package p
 
-	import rego.v1
-
 	allow if {
 		a := [{"b": b} | c := input[b]]
 	}`
@@ -210,8 +198,6 @@ test_find_vars_in_local_scope_complex_comprehension_term if {
 test_find_names_in_scope if {
 	policy := `
 	package p
-
-	import rego.v1
 
 	bar := "baz"
 
@@ -242,8 +228,6 @@ test_find_names_in_scope if {
 test_find_some_decl_names_in_scope if {
 	policy := `package p
 
-	import rego.v1
-
 	allow if {
 		foo := 1
 		some x
@@ -254,8 +238,8 @@ test_find_some_decl_names_in_scope if {
 
 	module := regal.parse_module("p.rego", policy)
 
-	{"x"} == ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 8}) with input as module
-	{"x", "y", "z"} == ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 10}) with input as module
+	{"x"} == ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 6}) with input as module
+	{"x", "y", "z"} == ast.find_some_decl_names_in_scope(module.rules[0], {"col": 1, "row": 8}) with input as module
 }
 
 var_names(vars) := {var.value | some var in vars}
@@ -332,8 +316,6 @@ test_ref_static_to_string if {
 test_rule_head_locations if {
 	policy := `package policy
 
-import rego.v1
-
 default allow := false
 
 allow if true
@@ -351,10 +333,10 @@ ref_rule[foo] := true if {
 	result := ast.rule_head_locations with input as regal.parse_module("p.rego", policy)
 
 	result == {
-		"data.policy.allow": {{"col": 9, "row": 5}, {"col": 1, "row": 7}},
-		"data.policy.reasons": {{"col": 1, "row": 9}, {"col": 1, "row": 10}},
-		"data.policy.my_func": {{"col": 9, "row": 12}, {"col": 1, "row": 13}},
-		"data.policy.ref_rule": {{"col": 1, "row": 15}},
+		"data.policy.allow": {{"col": 9, "row": 3}, {"col": 1, "row": 5}},
+		"data.policy.reasons": {{"col": 1, "row": 7}, {"col": 1, "row": 8}},
+		"data.policy.my_func": {{"col": 9, "row": 10}, {"col": 1, "row": 11}},
+		"data.policy.ref_rule": {{"col": 1, "row": 13}},
 	}
 }
 

--- a/bundle/regal/ast/keywords_test.rego
+++ b/bundle/regal/ast/keywords_test.rego
@@ -22,7 +22,7 @@ test_keywords_package if {
 test_keywords_import if {
 	policy := `package policy
 
-import rego.v1`
+import data.foo`
 
 	kwds := ast.keywords with input as regal.parse_module("p.rego", policy)
 
@@ -41,9 +41,35 @@ import rego.v1`
 test_keywords_if if {
 	policy := `package policy
 
-import rego.v1
-
 allow if {
+	# if things
+	true
+}
+`
+
+	kwds := ast.keywords with input as object.union(
+		regal.parse_module("p.rego", policy),
+		{"regal": {"file": {"lines": split(policy, "\n")}}},
+	)
+
+	count(kwds) == 2 # lines with keywords
+
+	_keyword_on_row(
+		kwds,
+		3,
+		{
+			"name": "if",
+			"location": {"row": 3, "col": 7},
+		},
+	)
+}
+
+test_keywords_if_on_another_line if {
+	policy := `package policy
+
+allow contains {
+	"foo": true,
+} if {
 	# if things
 	true
 }
@@ -61,37 +87,7 @@ allow if {
 		5,
 		{
 			"name": "if",
-			"location": {"row": 5, "col": 7},
-		},
-	)
-}
-
-test_keywords_if_on_another_line if {
-	policy := `package policy
-
-import rego.v1
-
-allow contains {
-	"foo": true,
-} if {
-	# if things
-	true
-}
-`
-
-	kwds := ast.keywords with input as object.union(
-		regal.parse_module("p.rego", policy),
-		{"regal": {"file": {"lines": split(policy, "\n")}}},
-	)
-
-	count(kwds) == 4 # lines with keywords
-
-	_keyword_on_row(
-		kwds,
-		7,
-		{
-			"name": "if",
-			"location": {"row": 7, "col": 3},
+			"location": {"row": 5, "col": 3},
 		},
 	)
 }

--- a/bundle/regal/lsp/completion/providers/booleans/booleans_test.rego
+++ b/bundle/regal/lsp/completion/providers/booleans/booleans_test.rego
@@ -6,8 +6,6 @@ import data.regal.lsp.completion.providers.test_utils as utils
 test_suggested_in_head if {
 	workspace := {"file:///p.rego": `package policy
 
-import rego.v1
-
 allow := f`}
 
 	regal_module := {"regal": {
@@ -16,7 +14,7 @@ allow := f`}
 			"lines": split(workspace["file:///p.rego"], "\n"),
 		},
 		"context": {"location": {
-			"row": 5,
+			"row": 3,
 			"col": 10,
 		}},
 	}}
@@ -33,8 +31,6 @@ allow := f`}
 test_suggested_in_body if {
 	workspace := {"file:///p.rego": `package policy
 
-import rego.v1
-
 allow if {
   foo := t
 }`}
@@ -45,7 +41,7 @@ allow if {
 			"lines": split(workspace["file:///p.rego"], "\n"),
 		},
 		"context": {"location": {
-			"row": 6,
+			"row": 4,
 			"col": 10,
 		}},
 	}}
@@ -62,8 +58,6 @@ allow if {
 test_suggested_after_equals if {
 	workspace := {"file:///p.rego": `package policy
 
-import rego.v1
-
 allow if {
   foo == t
 }`}
@@ -74,7 +68,7 @@ allow if {
 			"lines": split(workspace["file:///p.rego"], "\n"),
 		},
 		"context": {"location": {
-			"row": 6,
+			"row": 4,
 			"col": 10,
 		}},
 	}}
@@ -91,8 +85,6 @@ allow if {
 test_not_suggested_at_start if {
 	workspace := {"file:///p.rego": `package policy
 
-import rego.v1
-
 allow if {
   t
 }`}
@@ -103,7 +95,7 @@ allow if {
 			"lines": split(workspace["file:///p.rego"], "\n"),
 		},
 		"context": {"location": {
-			"row": 6,
+			"row": 4,
 			"col": 3,
 		}},
 	}}

--- a/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
+++ b/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego
@@ -3,9 +3,22 @@
 package regal.rules.bugs["deprecated-builtin"]
 
 import data.regal.ast
+import data.regal.capabilities
 import data.regal.config
 import data.regal.result
 import data.regal.util
+
+# METADATA
+# description: |
+#   Since OPA 1.0, deprecated-builtin enabled only when provided a v0 policy,
+#   BUT please note that this may change in the future if new built-in functions
+#   are deprecated.
+# custom:
+#   severity: none
+notices contains result.notice(rego.metadata.chain()) if {
+	capabilities.is_opa_v1
+	input.regal.file.rego_version != "v0"
+}
 
 report contains violation if {
 	deprecated_builtins := {

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
@@ -2,7 +2,6 @@
 # description: Rule body could be made a one-liner
 package regal.rules.custom["one-liner-rule"]
 
-import data.regal.ast
 import data.regal.capabilities
 import data.regal.config
 import data.regal.result
@@ -15,9 +14,6 @@ import data.regal.util
 notices contains result.notice(rego.metadata.chain()) if not capabilities.has_if
 
 report contains violation if {
-	# No need to traverse rules here if we're not importing `if`
-	ast.imports_keyword(input.imports, "if")
-
 	# Note: this covers both rules and functions, which is what we want here
 	some rule in input.rules
 

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
@@ -8,8 +8,6 @@ import data.regal.rules.custom["one-liner-rule"] as rule
 test_fail_could_be_one_liner if {
 	module := ast.policy(`
 
-	import rego.v1
-
 	allow if {
 		input.yes
 	}
@@ -18,10 +16,10 @@ test_fail_could_be_one_liner if {
 
 	r == expected_with_location({
 		"col": 2,
-		"row": 7,
+		"row": 5,
 		"end": {
 			"col": 7,
-			"row": 7,
+			"row": 5,
 		},
 		"text": "\tallow if {",
 	})
@@ -29,8 +27,6 @@ test_fail_could_be_one_liner if {
 
 test_fail_could_be_one_liner_all_keywords if {
 	module := ast.policy(`
-
-	import rego.v1
 
 	allow if {
 		input.yes
@@ -41,10 +37,10 @@ test_fail_could_be_one_liner_all_keywords if {
 	r == expected_with_location({
 		"col": 2,
 		"file": "policy.rego",
-		"row": 7,
+		"row": 5,
 		"end": {
 			"col": 7,
-			"row": 7,
+			"row": 5,
 		},
 		"text": "\tallow if {",
 	})
@@ -52,8 +48,6 @@ test_fail_could_be_one_liner_all_keywords if {
 
 test_fail_could_be_one_liner_allman_style if {
 	module := ast.policy(`
-
-	import rego.v1
 
 	allow if
 	{
@@ -64,24 +58,13 @@ test_fail_could_be_one_liner_allman_style if {
 	r := rule.report with input as module with config.for_rule as {"level": "error"}
 	r == expected_with_location({
 		"col": 2,
-		"row": 7,
+		"row": 5,
 		"end": {
 			"col": 7,
-			"row": 7,
+			"row": 5,
 		},
 		"text": "\tallow if",
 	})
-}
-
-test_success_if_not_imported if {
-	module := ast.policy(`
-	allow := true if {
-		1 == 1
-	}
-	`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
-
-	r == set()
 }
 
 test_success_too_long_for_a_one_liner if {

--- a/bundle/regal/rules/imports/import-shadows-import/import_shadows_import.rego
+++ b/bundle/regal/rules/imports/import-shadows-import/import_shadows_import.rego
@@ -2,7 +2,17 @@
 # description: Import shadows another import
 package regal.rules.imports["import-shadows-import"]
 
+import data.regal.capabilities
 import data.regal.result
+
+# METADATA
+# description: Since OPA 1.0, import-shadows-import enabled only when provided a v0 policy,
+# custom:
+#   severity: none
+notices contains result.notice(rego.metadata.chain()) if {
+	capabilities.is_opa_v1
+	input.regal.file.rego_version != "v0"
+}
 
 # regular import
 _ident(imported) := regal.last(imported.path.value).value if not imported.alias

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -133,8 +133,6 @@ An example policy to implement this requirement might look something like this:
 # - input: schema.regal.ast
 package custom.regal.rules.naming["acme-corp-package"]
 
-import rego.v1
-
 import data.regal.result
 
 report contains violation if {
@@ -267,8 +265,6 @@ from files, and one that actually lints and reports violations using that data.
 # schemas:
 # - input: schema.regal.ast
 package custom.regal.rules.organizational["at-least-one-allow"]
-
-import rego.v1
 
 import data.regal.ast
 import data.regal.result

--- a/docs/opa-one-dot-zero.md
+++ b/docs/opa-one-dot-zero.md
@@ -1,0 +1,76 @@
+# OPA 1.0 and Regal
+
+While we always recommend using the latest version of OPA, we're well aware that there may be situations where — for
+one reason or another — that might not be possible. As we want everyone to benefit from Regal, we do our very best to
+ensure it works seamlessly with OPA versions both before and after 1.0, and even projects that use a mix of both! While
+this should mostly work out of the box and without additional configuration, it's good to be aware of how Regal parses
+and lints policies of different versions of Rego, and how you can tell Regal to target only a specific version.
+
+**Note:** This document does not cover the specifics of OPA 1.0, but rather how Regal works with it. If you want to
+learn more about what OPA 1.0 is and how to upgrade, see the [related resources](#related-resources) at the bottom of
+this page.
+
+## Telling Regal which Rego version to target
+
+While Regal pretty accurately guesses the Rego version of the policies it's linting — and will adapt how it parses and
+asseses Rego files accordingly — telling Regal which version to target is always going to produce the most reliable
+results — and much faster too! Guessing which Rego version to target often involves multiple passes of parsing, and
+as some files are both valid Rego v0 and v1, there will always be some ambiguity. In order to avoid this, our
+recommendation is to always provide Regal with the Rego version(s) targeted. This can be done in a couple of ways, and
+the precedence of these methods is as listed below:
+
+1. Setting the `rego-version` configuration option under `project.roots` attribute
+2. Setting the `rego-version` configuration option under `project` attribute
+3. Setting the `rego_version` in a `.manifest` file in any directory (will apply to that directory and any below it)
+
+Note that it's is perfectly possible to use different `rego-version`s for different roots of a project:
+
+```yaml
+project:
+  rego-version: 1
+  roots:
+    # lib/legacy overriding project version to set versin 0
+    - path: lib/legacy
+      rego-version: 0
+    # main directory will inherit version 1 from project
+    - path: main
+```
+
+See the documentation covering Regal's [configuration](https://docs.styra.com/regal#configuration) for more information
+on [configuring Rego version](https://docs.styra.com/regal#configuring-rego-version) for your project.
+
+Finally, Regal will automatically parse and lint any file with a `_v0.rego` suffix as Rego v0. This is intended only
+for testing and development, where you sometimes may want to try something out using and older Rego version without
+configuration. Note that this has lower precedence than Rego versions set by other means, and should not be considered
+as anything but a convenience for testing.
+
+## Rules disabled with OPA 1.0
+
+Some linter rules don't really make sense to enforce post OPA 1.0, as they are now either enforced by OPA itself or
+otherwise no longer relevant. The following rules are now disabled by default, unless Regal is configured to target
+Rego versions before 1.0, or in the case where no configuration is provided, Regal determines that the project being
+linted is not yet using OPA 1.0:
+
+- [deprecated-builtin](https://docs.styra.com/regal/rules/bugs/deprecated-builtin)
+- [import-shadows-import](https://docs.styra.com/regal/rules/imports/import-shadows-import)
+- [rule-named-if](https://docs.styra.com/regal/rules/bugs/rule-named-if)
+- [use-contains](https://docs.styra.com/regal/rules/idiomatic/use-contains)
+- [use-if](https://docs.styra.com/regal/rules/idiomatic/use-if)
+- [use-rego-v1](https://docs.styra.com/regal/rules/imports/use-rego-v1)
+
+Except for the `deprecated-bultin` rule — which is disabled simply because there currently are no deprecated built-ins
+in OPA 1.0 — these rules are now enforced automatically by OPA, and so there's no reason for Regal to duplicate that
+effort.
+
+## Related Resources
+
+- OPA Docs: [Upgrading to v1.0](https://www.openpolicyagent.org/docs/latest/v0-upgrade/)
+- OPA Docs: [v0 Backwards Compatibility](https://www.openpolicyagent.org/docs/latest/v0-compatibility/)
+- Styra Blog: [Renovating Rego](https://www.styra.com/blog/renovating-rego/)
+- OPA Blog: [OPA 1.0 Is Coming, Here's What You Need to Know](https://blog.openpolicyagent.org/opa-1-0-is-coming-heres-what-you-need-to-know-c8fb0d258368)
+- OPA Blog: [Announcing OPA 1.0: A New Standard for Policy as Code](https://blog.openpolicyagent.org/announcing-opa-1-0-a-new-standard-for-policy-as-code-a6d8427ee828)
+
+## Community
+
+If you have any questions related to OPA 1.0 and Regal, please join the Styra community on
+[Slack](https://communityinviter.com/apps/styracommunity/signup) and we'll be happy to help you out!

--- a/docs/rules/bugs/annotation-without-metadata.md
+++ b/docs/rules/bugs/annotation-without-metadata.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # description: allow allows
 allow if {
     # ... some conditions
@@ -19,8 +17,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 # METADATA
 # description: allow allows

--- a/docs/rules/bugs/argument-always-wildcard.md
+++ b/docs/rules/bugs/argument-always-wildcard.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # there's only one definition of the last_name function in
 # this package, and the second argument is never used
 last_name(name, _) := lname if {
@@ -21,8 +19,6 @@ last_name(name, _) := lname if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 last_name(name) := lname if {
     parts := split(name, " ")
@@ -38,8 +34,6 @@ are used in that definition of the function. This is particularly useful for inc
 
 ```rego
 package policy
-
-import rego.v1
 
 default authorized(_, _) := false
 
@@ -59,8 +53,6 @@ cleaner definition. More likely, the argument was meant to be _used_, if only in
 
 ```rego
 package policy
-
-import rego.v1
 
 default authorized(_, _) := false
 

--- a/docs/rules/bugs/constant-condition.md
+++ b/docs/rules/bugs/constant-condition.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     1 == 1
 }

--- a/docs/rules/bugs/deprecated-builtin.md
+++ b/docs/rules/bugs/deprecated-builtin.md
@@ -4,6 +4,19 @@
 
 **Category**: Bugs
 
+## Notice: Rule disabled with OPA 1.0
+
+Since Regal v0.30.0, this rule is only enabled for projects that have either been explicitly configured to target
+versions of OPA before 1.0, or if no configuration is provided — where Regal is able to determine that an older version
+of OPA/Rego is being targeted. Consult the documentation on Regal's
+[configuration](https://docs.styra.com/regal#configuration) for information on how to best work with older versions of
+OPA and Rego.
+
+Since OPA v1.0, this rule is automatically disabled, as there currently are no deprecated built-in functions
+in that version, and trying to use a previously deprecated function will result in a parser error. Note however that
+this may change if later OPA versions deprecate current built-in functions. If/when that happens, this rule will be
+re-enabled.
+
 **Avoid**
 ```rego
 package policy

--- a/docs/rules/bugs/duplicate-rule.md
+++ b/docs/rules/bugs/duplicate-rule.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if user.is_admin
 
 allow if user.is_developer
@@ -21,8 +19,6 @@ allow if user.is_admin
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if user.is_admin
 

--- a/docs/rules/bugs/if-empty-object.md
+++ b/docs/rules/bugs/if-empty-object.md
@@ -12,8 +12,6 @@ the sake of posterity.**
 ```rego
 package policy
 
-import rego.v1
-
 allow if {}
 ```
 

--- a/docs/rules/bugs/if-object-literal.md
+++ b/docs/rules/bugs/if-object-literal.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # {} interpreted as object, not a rule body
 allow if {}
 

--- a/docs/rules/bugs/impossible-not.md
+++ b/docs/rules/bugs/impossible-not.md
@@ -10,8 +10,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 report contains violation if {
     # ... some conditions
 }
@@ -19,8 +17,6 @@ report contains violation if {
 
 ```rego
 package policy_test
-
-import rego.v1
 
 import data.policy
 
@@ -34,8 +30,6 @@ test_report_is_empty {
 ```rego
 package policy
 
-import rego.v1
-
 report contains violation if {
     # ... some conditions
 }
@@ -43,8 +37,6 @@ report contains violation if {
 
 ```rego
 package policy_test
-
-import rego.v1
 
 import data.policy
 

--- a/docs/rules/bugs/inconsistent-args.md
+++ b/docs/rules/bugs/inconsistent-args.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 find_vars(rule, node) if node in rule
 
 # Order of arguments changed, or at least it looks like it
@@ -22,8 +20,6 @@ find_vars(node, rule) if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 find_vars(rule, node) if node in rule
 
@@ -45,8 +41,6 @@ Using wildcards (`_`) in place of unused arguments is always allowed, and in fac
 
 ```rego
 package policy
-
-import rego.v1
 
 find_vars(rule, node) if node in rule
 

--- a/docs/rules/bugs/internal-entrypoint.md
+++ b/docs/rules/bugs/internal-entrypoint.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # METADATA
 # entrypoint: true
 _authorized if {
@@ -20,8 +18,6 @@ _authorized if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 # METADATA
 # entrypoint: true

--- a/docs/rules/bugs/not-equals-in-loop.md
+++ b/docs/rules/bugs/not-equals-in-loop.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 deny if {
     "admin" != input.user.roles[_]
 }
@@ -18,8 +16,6 @@ deny if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 deny if {
     not "admin" in input.user.roles
@@ -37,8 +33,6 @@ day. If it doesn't mean "not in", what does it mean?
 
 ```rego
 package policy
-
-import rego.v1
 
 deny if {
     "admin" != input.user.roles[_]

--- a/docs/rules/bugs/redundant-existence-check.md
+++ b/docs/rules/bugs/redundant-existence-check.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 employee if {
     input.user.email
     endswith(input.user.email, "@acmecorp.com")
@@ -24,8 +22,6 @@ is_admin(user) if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 employee if {
     endswith(input.user.email, "@acmecorp.com")

--- a/docs/rules/bugs/rule-assigns-default.md
+++ b/docs/rules/bugs/rule-assigns-default.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 default allow := false
 
 # this rule assigns the same value as the default
@@ -22,8 +20,6 @@ allow := false if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 default allow := false
 

--- a/docs/rules/bugs/rule-named-if.md
+++ b/docs/rules/bugs/rule-named-if.md
@@ -4,6 +4,17 @@
 
 **Category**: Bugs
 
+## Notice: Rule made obsolete by OPA 1.0
+
+Since Regal v0.30.0, this rule is only enabled for projects that have either been explicitly configured to target
+versions of OPA before 1.0, or if no configuration is provided — where Regal is able to determine that an older version
+of OPA/Rego is being targeted. Consult the documentation on Regal's
+[configuration](https://docs.styra.com/regal#configuration) for information on how to best work with older versions of
+OPA and Rego.
+
+Since OPA v1.0, this rule is automatically disabled, as the parser itself will throw an error if a rule is named `if`,
+as that is made a keyword in Rego v1.0.
+
 **Avoid**
 ```rego
 package policy
@@ -16,8 +27,6 @@ allow := true if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow := true if {
     authorized

--- a/docs/rules/bugs/sprintf-arguments-mismatch.md
+++ b/docs/rules/bugs/sprintf-arguments-mismatch.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 max_issues := 1
 
 report contains warning if {
@@ -23,8 +21,6 @@ report contains warning if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 max_issues := 1
 

--- a/docs/rules/bugs/unassigned-return-value.md
+++ b/docs/rules/bugs/unassigned-return-value.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     # return value not assigned
     lower(input.user.name)

--- a/docs/rules/bugs/var-shadows-builtin.md
+++ b/docs/rules/bugs/var-shadows-builtin.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # variable `http` shadows `http.send` built-in function
 allow if {
     http := startswith(input.url, "http://")
@@ -20,8 +18,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 # variable `is_http` doesn't shadow any built-in function
 allow if {

--- a/docs/rules/custom/missing-metadata.md
+++ b/docs/rules/custom/missing-metadata.md
@@ -8,8 +8,6 @@
 ```rego
 package acmecorp.authz
 
-import rego.v1
-
 authorized_users contains user if {
     # logic to determine authorized users
 }
@@ -20,8 +18,6 @@ authorized_users contains user if {
 # METADATA
 # description: The `acmecorp.authz` module provides authorization logic for the AcmeCorp application.
 package acmecorp.authz
-
-import rego.v1
 
 # METADATA
 # description: Provides a set of all authorized users given the conditions in `input`.

--- a/docs/rules/custom/one-liner-rule.md
+++ b/docs/rules/custom/one-liner-rule.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     is_admin
 }
@@ -22,8 +20,6 @@ is_admin if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if is_admin
 

--- a/docs/rules/custom/prefer-value-in-head.md
+++ b/docs/rules/custom/prefer-value-in-head.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 pin_as_number := val if {
     is_number(input.pin_code)
     val := to_number(input.pin_code)
@@ -24,8 +22,6 @@ deny contains message if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 pin_as_number := to_number(input.pin_code) if is_number(input.pin_code)
 

--- a/docs/rules/idiomatic/ambiguous-scope.md
+++ b/docs/rules/idiomatic/ambiguous-scope.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # METADATA
 # description: allow is true if the user is admin, or the requested resource is public
 allow if user_is_admin
@@ -20,8 +18,6 @@ allow if public_resource
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 # METADATA
 # description: allow is true if the user is admin, or the requested resource is public
@@ -35,8 +31,6 @@ allow if public_resource
 ```rego
 package policy
 
-import rego.v1
-
 # METADATA
 # description: allow is true if the user is admin
 allow if user_is_admin
@@ -49,8 +43,6 @@ allow if public_resource
 **Or (scope `rule` explicit)**
 ```rego
 package policy
-
-import rego.v1
 
 # METADATA
 # description: allow is true if the user is admin

--- a/docs/rules/idiomatic/boolean-assignment.md
+++ b/docs/rules/idiomatic/boolean-assignment.md
@@ -8,16 +8,12 @@
 ```rego
 package policy
 
-import rego.v1
-
 more_than_one_member := count(input.members) > 1
 ```
 
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 more_than_one_member if count(input.members) > 1
 ```
@@ -32,8 +28,6 @@ input:
 
 ```rego
 package policy
-
-import rego.v1
 
 default more_than_one_member := false
 

--- a/docs/rules/idiomatic/custom-has-key-construct.md
+++ b/docs/rules/idiomatic/custom-has-key-construct.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 mfa if has_key(input.claims, "mfa")
 
 has_key(map, key) if {
@@ -20,8 +18,6 @@ has_key(map, key) if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 mfa if "mfa" in object.keys(input.claims)
 ```

--- a/docs/rules/idiomatic/custom-in-construct.md
+++ b/docs/rules/idiomatic/custom-in-construct.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if has_value(input.user.roles, "admin")
 
 # This custom function was commonly seen before the introduction
@@ -22,8 +20,6 @@ has_value(arr, item) if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if "admin" in input.user.roles
 ```

--- a/docs/rules/idiomatic/equals-pattern-matching.md
+++ b/docs/rules/idiomatic/equals-pattern-matching.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 readable_number(x) := "one" if x == 1
 readable_number(x) := "two" if x == 2
 ```
@@ -31,8 +29,6 @@ moving the equality check to match on the function call itself. This means that 
 ```rego
 package policy
 
-import rego.v1
-
 normalize_role(role) := "admin" if {
     role == "administrator"
 }
@@ -48,8 +44,6 @@ the equality "pattern":
 ```rego
 package policy
 
-import rego.v1
-
 normalize_role("administrator") := "admin"
 
 normalize_role("root") := "admin"
@@ -59,8 +53,6 @@ Rules that evaluate to `true` may even have the assignment removed altogether, i
 
 ```rego
 package policy
-
-import rego.v1
 
 is_admin(role) if role == "admin"
 

--- a/docs/rules/idiomatic/no-defined-entrypoint.md
+++ b/docs/rules/idiomatic/no-defined-entrypoint.md
@@ -10,8 +10,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 default allow := false
 
 # Nothing wrong with this rule, but an
@@ -33,8 +31,6 @@ public_resource_read if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 default allow := false
 

--- a/docs/rules/idiomatic/non-raw-regex-pattern.md
+++ b/docs/rules/idiomatic/non-raw-regex-pattern.md
@@ -33,8 +33,6 @@ try to "resolve" patterns assigned to variables. The following example would as 
 ```rego
 package policy
 
-import rego.v1
-
 # Pattern assigned to variable
 pattern := "[\\d]+"
 

--- a/docs/rules/idiomatic/prefer-set-or-object-rule.md
+++ b/docs/rules/idiomatic/prefer-set-or-object-rule.md
@@ -8,8 +8,6 @@
 ````rego
 package policy
 
-import rego.v1
-
 # top level set comprehension
 developers := {developer |
     some user in input.users
@@ -27,8 +25,6 @@ user_roles_mapping := {user: roles |
 **Prefer**
 ````rego
 package policy
-
-import rego.v1
 
 # set generating rule
 developers contains developer if {
@@ -69,8 +65,6 @@ or unconditionally.
 ```rego
 package policy
 
-import rego.v1
-
 # Getting developers from input
 developers contains developer if {
     some user in input.users
@@ -98,8 +92,6 @@ than one rule contributing to a single key-value pair.
 
 ```rego
 package policy
-
-import rego.v1
 
 novels[title] := content if {
     some document in input.documents
@@ -129,8 +121,6 @@ This rule will also ignore simple comprehensions used solely for the purpose of 
 
 ```rego
 package policy
-
-import rego.v1
 
 # Convert set to array. This is fine.
 my_set := {item | some item in arr}

--- a/docs/rules/idiomatic/use-contains.md
+++ b/docs/rules/idiomatic/use-contains.md
@@ -4,6 +4,17 @@
 
 **Category**: Idiomatic
 
+## Notice: Rule made obsolete by OPA 1.0
+
+Since Regal v0.30.0, this rule is only enabled for projects that have either been explicitly configured to target
+versions of OPA before 1.0, or if no configuration is provided — where Regal is able to determine that an older version
+of OPA/Rego is being targeted. Consult the documentation on Regal's
+[configuration](https://docs.styra.com/regal#configuration) for information on how to best work with older versions of
+OPA and Rego.
+
+Since OPA v1.0, this rule is no longer needed as the Rego v1 syntax is now mandatory, and using `contains` is now the
+de-facto way to define multi-value rules.
+
 **Avoid**
 ```rego
 package policy

--- a/docs/rules/idiomatic/use-if.md
+++ b/docs/rules/idiomatic/use-if.md
@@ -4,6 +4,15 @@
 
 **Category**: Idiomatic
 
+## Notice: Rule made obsolete by OPA 1.0
+
+Since Regal v0.30.0, this rule is only enabled for projects explicitly configured to target versions of OPA before 1.0.
+Consult the documentation on Regal's [configuration](https://docs.styra.com/regal#configuration) for information on how
+to best work with older versions of OPA and Rego.
+
+Since OPA v1.0, this rule is no longer needed simply because the Rego v1 syntax is made mandatory, and the use of `if`
+is now enforced before all rule bodies.
+
 **Avoid**
 ```rego
 package policy

--- a/docs/rules/idiomatic/use-in-operator.md
+++ b/docs/rules/idiomatic/use-in-operator.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # "Old" way of checking for membership - iteration + comparison
 allow if {
     "admin" == input.user.roles[_]
@@ -19,8 +17,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if {
     "admin" in input.user.roles

--- a/docs/rules/idiomatic/use-strings-count.md
+++ b/docs/rules/idiomatic/use-strings-count.md
@@ -8,16 +8,12 @@
 ```rego
 package policy
 
-import rego.v1
-
 num_as := count(indexof_n("foobarbaz", "a"))
 ```
 
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 num_as := strings.count("foobarbaz", "a")
 ```

--- a/docs/rules/imports/avoid-importing-input.md
+++ b/docs/rules/imports/avoid-importing-input.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # This is always redundant
 import input
 
@@ -26,8 +24,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if "admin" in input.user.roles
 
@@ -48,8 +44,6 @@ like a Terraform plan. Aliasing of specific input attributes should however be a
 
 ```rego
 package policy
-
-import rego.v1
 
 # This is acceptable
 import input as tfplan

--- a/docs/rules/imports/circular-import.md
+++ b/docs/rules/imports/circular-import.md
@@ -16,8 +16,6 @@ graph LR
 # authz.rego
 package authz
 
-import rego.v1
-
 import data.shared
 
 admins := {
@@ -62,8 +60,6 @@ graph LR
 ```rego
 # authz.rego
 package authz
-
-import rego.v1
 
 import data.shared
 

--- a/docs/rules/imports/ignored-import.md
+++ b/docs/rules/imports/ignored-import.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 import data.authz.roles
 
 allow if {
@@ -22,8 +20,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 import data.authz.roles
 

--- a/docs/rules/imports/import-shadows-builtin.md
+++ b/docs/rules/imports/import-shadows-builtin.md
@@ -39,8 +39,6 @@ longer form. Provided a simple policy like this:
 ```rego
 package policy
 
-import rego.v1
-
 import data.http
 
 allow if {

--- a/docs/rules/imports/import-shadows-import.md
+++ b/docs/rules/imports/import-shadows-import.md
@@ -4,6 +4,17 @@
 
 **Category**: Imports
 
+## Notice: Rule made obsolete by OPA 1.0
+
+Since Regal v0.30.0, this rule is only enabled for projects that have either been explicitly configured to target
+versions of OPA before 1.0, or if no configuration is provided — where Regal is able to determine that an older version
+of OPA/Rego is being targeted. Consult the documentation on Regal's
+[configuration](https://docs.styra.com/regal#configuration) for information on how to best work with older versions of
+OPA and Rego.
+
+Since OPA v1.0, this rule is automatically disabled as OPA itself now forbids this, and shadowed imports will result in
+a parse error.
+
 **Avoid**
 ```rego
 package policy

--- a/docs/rules/imports/prefer-package-imports.md
+++ b/docs/rules/imports/prefer-package-imports.md
@@ -10,8 +10,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # Rule imported directly
 import data.users.first_names
 
@@ -24,8 +22,6 @@ has_waldo if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 # Package imported rather than rule
 import data.users

--- a/docs/rules/imports/use-rego-v1.md
+++ b/docs/rules/imports/use-rego-v1.md
@@ -6,6 +6,17 @@
 
 **Automatically fixable**: [Yes](/regal/fixing)
 
+## Notice: Rule made obsolete by OPA 1.0
+
+Since Regal v0.30.0, this rule is only enabled for projects that have either been explicitly configured to target
+versions of OPA before 1.0, or if no configuration is provided — where Regal is able to determine that an older version
+of OPA/Rego is being targeted. Consult the documentation on Regal's
+[configuration](https://docs.styra.com/regal#configuration) for information on how to best work with older versions of
+OPA and Rego.
+
+Since OPA v1.0, this rule is no longer needed simply because the Rego v1 syntax is made mandatory, and no additional
+imports are required.
+
 **Avoid**
 ```rego
 package policy
@@ -23,7 +34,8 @@ report contains item if {
 ```rego
 package policy
 
-# with OPA v0.59.0 and later, use this instead
+# with OPA v0.59.0 and later, use import rego.v1 instead
+# with OPA v1.0 and later, this import is unnecessary
 import rego.v1
 
 report contains item if {

--- a/docs/rules/performance/defer-assignment.md
+++ b/docs/rules/performance/defer-assignment.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     resp := http.send({"method": "GET", "url": "http://example.com"})
 
@@ -27,8 +25,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if {
     input.user.name in allowed_users

--- a/docs/rules/performance/walk-no-path.md
+++ b/docs/rules/performance/walk-no-path.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     # traverse potentially nested permissions structure looking
     # for an admin role, but notice how the path is never referenced
@@ -24,8 +22,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if {
     # replacing `path` with a wildcard variable tells the evaluator that it won't
@@ -60,8 +56,6 @@ This rule can only optimize `walk` calls where the path/value array is provided 
 
 ```rego
 package policy
-
-import rego.v1
 
 allow if {
     # this can't be optimized, as the `walk` function can't

--- a/docs/rules/performance/with-outside-test-context.md
+++ b/docs/rules/performance/with-outside-test-context.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     some user in data.users
 
@@ -29,8 +27,6 @@ allowed_user := input.user if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if {
     some user in data.users

--- a/docs/rules/style/comprehension-term-assignment.md
+++ b/docs/rules/style/comprehension-term-assignment.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 names := [name |
     some user in input.users
     name := user.name # redundant assignment
@@ -19,8 +17,6 @@ names := [name |
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 names := [user.name |
     some user in input.users

--- a/docs/rules/style/default-over-else.md
+++ b/docs/rules/style/default-over-else.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 permissions := ["read", "write"] if {
     input.user == "admin"
 } else := ["read"]
@@ -18,8 +16,6 @@ permissions := ["read", "write"] if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 default permissions := ["read"]
 

--- a/docs/rules/style/default-over-not.md
+++ b/docs/rules/style/default-over-not.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 username := input.user.name
 
 username := "anonymous" if not input.user.name

--- a/docs/rules/style/detached-metadata.md
+++ b/docs/rules/style/detached-metadata.md
@@ -8,8 +8,6 @@
 ```rego
 package authz
 
-import rego.v1
-
  # METADATA
  # description: allow any requests by admin users
 
@@ -21,8 +19,6 @@ allow if {
 **Prefer**
 ```rego
 package authz
-
-import rego.v1
 
 # METADATA
 # description: allow any requests by admin users

--- a/docs/rules/style/double-negative.md
+++ b/docs/rules/style/double-negative.md
@@ -8,8 +8,6 @@
 ```rego
 package negative
 
-import rego.v1
-
 fine if not not_fine
 
 with_friends if not without_friends
@@ -22,8 +20,6 @@ without_friends if count(input.friends) == 0
 **Prefer**
 ```rego
 package negative
-
-import rego.v1
 
 fine if input.fine == true
 

--- a/docs/rules/style/external-reference.md
+++ b/docs/rules/style/external-reference.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # Depends on both `input` and `data`
 is_preferred_login_method(method) if {
     preferred_login_methods := {login_method |
@@ -23,8 +21,6 @@ is_preferred_login_method(method) if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 # Depends only on function arguments
 is_preferred_login_method(method, user, all_login_methods) if {
@@ -52,8 +48,6 @@ other way to import them into the function body.
 
 ```rego
 package policy
-
-import rego.v1
 
 first_name(full_name) := capitalized {
     first_name := split(full_name, " ")[0]

--- a/docs/rules/style/function-arg-return.md
+++ b/docs/rules/style/function-arg-return.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 has_email(user) if {
     indexof(user.email, "@", i)
     i != -1
@@ -20,8 +18,6 @@ has_email(user) if {
 
 ```rego
 package policy
-
-import rego.v1
 
 has_email(user) if {
     i := indexof(user.email, "@")

--- a/docs/rules/style/no-whitespace-comment.md
+++ b/docs/rules/style/no-whitespace-comment.md
@@ -11,8 +11,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 #Deny by default
 default allow := false
 
@@ -24,8 +22,6 @@ allow if "admin" in input.user.roles
 
 ```rego
 package policy
-
-import rego.v1
 
 # Deny by default
 default allow := false

--- a/docs/rules/style/prefer-snake-case.md
+++ b/docs/rules/style/prefer-snake-case.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 # camelCase rule name
 userIsAdmin if "admin" in input.user.roles
 ```
@@ -17,8 +15,6 @@ userIsAdmin if "admin" in input.user.roles
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 # snake_case rule name
 user_is_admin if "admin" in input.user.roles

--- a/docs/rules/style/prefer-some-in-iteration.md
+++ b/docs/rules/style/prefer-some-in-iteration.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 engineering_roles := {"engineer", "dba", "developer"}
 
 engineers contains employee if {
@@ -21,8 +19,6 @@ engineers contains employee if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 engineering_roles := {"engineer", "dba", "developer"}
 
@@ -80,8 +76,6 @@ Deeply nested iteration is often easier to read using the more compact form.
 ```rego
 package policy
 
-import rego.v1
-
 # These rules are equivalent, but the more compact form is arguably easier to read
 
 any_user_is_admin if {
@@ -108,8 +102,6 @@ one of the variables (including wildcards: `_`) is an output variable bound in i
 
 ```rego
 package policy
-
-import rego.v1
 
 example_users contains user if {
     domain := "example.com"

--- a/docs/rules/style/rule-name-repeats-package.md
+++ b/docs/rules/style/rule-name-repeats-package.md
@@ -8,8 +8,6 @@
 ```rego
 package policy.authz
 
-import rego.v1
-
 authz_allow if {
     user.is_admin
 }
@@ -18,8 +16,6 @@ authz_allow if {
 **Prefer**
 ```rego
 package policy.authz
-
-import rego.v1
 
 allow if {
     user.is_admin

--- a/docs/rules/style/trailing-default-rule.md
+++ b/docs/rules/style/trailing-default-rule.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     # some conditions
 }
@@ -20,8 +18,6 @@ default allow := false
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 default allow := false
 

--- a/docs/rules/style/unconditional-assignment.md
+++ b/docs/rules/style/unconditional-assignment.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 full_name := name if {
     name := concat(", ", [input.first_name, input.last_name])
 }
@@ -26,8 +24,6 @@ names contains name if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 full_name := concat(", ", [input.first_name, input.last_name])
 

--- a/docs/rules/style/unnecessary-some.md
+++ b/docs/rules/style/unnecessary-some.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 is_developer if some "developer" in input.user.roles
 ```
 
@@ -17,8 +15,6 @@ is_developer if some "developer" in input.user.roles
 
 ```rego
 package policy
-
-import rego.v1
 
 is_developer if "developer" in input.user.roles
 ```
@@ -35,8 +31,6 @@ should match for the loop assignment to succeed. This is not commonly needed, bu
 
 ```rego
 package policy
-
-import rego.v1
 
 developers contains name if {
     # name will only be bound when the value is "developer"

--- a/docs/rules/style/use-assignment-operator.md
+++ b/docs/rules/style/use-assignment-operator.md
@@ -10,8 +10,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 default allow = false
 
 first_name(name) = split(name, " ")[0]
@@ -25,8 +23,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 default allow := false
 

--- a/docs/rules/style/yoda-condition.md
+++ b/docs/rules/style/yoda-condition.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     "GET" == input.request.method
     "users" == input.request.path[0]
@@ -19,8 +17,6 @@ allow if {
 **Prefer**
 ```rego
 package policy
-
-import rego.v1
 
 allow if {
     input.request.method == "GET"

--- a/docs/rules/testing/print-or-trace-call.md
+++ b/docs/rules/testing/print-or-trace-call.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 reasons contains sprintf("%q is a dog!", [user.name]) if {
     some user in input.users
     user.species == "canine"

--- a/docs/rules/testing/test-outside-test-package.md
+++ b/docs/rules/testing/test-outside-test-package.md
@@ -8,8 +8,6 @@
 ```rego
 package policy
 
-import rego.v1
-
 allow if {
     "admin" in input.user.roles
 }
@@ -24,8 +22,6 @@ test_allow_if_admin {
 ```rego
 # Tests in separate package with _test suffix
 package policy_test
-
-import rego.v1
 
 import data.policy
 

--- a/docs/rules/testing/todo-test.md
+++ b/docs/rules/testing/todo-test.md
@@ -8,8 +8,6 @@
 ```rego
 package policy_test
 
-import rego.v1
-
 import data.policy
 
 # Make sure this passes

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -205,6 +205,8 @@ func TestLintV1Violations(t *testing.T) {
 		"file-length":              {},
 		"rule-named-if":            {},
 		"use-rego-v1":              {},
+		"deprecated-builtin":       {},
+		"import-shadows-import":    {},
 	}
 
 	cfg := readProvidedConfig(t)

--- a/e2e/testdata/aggregates/custom/regal/rules/testcase/aggregates/custom_rules_using_aggregates.rego
+++ b/e2e/testdata/aggregates/custom/regal/rules/testcase/aggregates/custom_rules_using_aggregates.rego
@@ -2,8 +2,6 @@
 # description: Collect data in aggregates and validate it
 package custom.regal.rules.testcase["aggregates"]
 
-import rego.v1
-
 import data.regal.result
 
 aggregate contains result.aggregate(rego.metadata.chain(), {})

--- a/e2e/testdata/aggregates/custom/regal/rules/testcase/empty_aggregate/empty_aggregate.rego
+++ b/e2e/testdata/aggregates/custom/regal/rules/testcase/empty_aggregate/empty_aggregate.rego
@@ -6,8 +6,6 @@
 #     ref: https://github.com/StyraInc/regal/issues/1259
 package custom.regal.rules.testcase.empty_aggregates
 
-import rego.v1
-
 import data.regal.result
 
 aggregate contains result.aggregate(rego.metadata.chain(), {}) if {

--- a/e2e/testdata/ast_type_failure/custom_type_fail.rego
+++ b/e2e/testdata/ast_type_failure/custom_type_fail.rego
@@ -4,8 +4,6 @@
 # - input: schema.regal.ast
 package custom.regal.rules.naming.type_fail
 
-import rego.v1
-
 report contains foo if {
 	# There is no "foo" attribute in the AST,
 	# so this should fail at compile time

--- a/internal/ast/rule_test.go
+++ b/internal/ast/rule_test.go
@@ -42,7 +42,7 @@ func TestGetRuleDetail(t *testing.T) {
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 
-			mod := parse.MustParseModule("package example\nimport rego.v1\n" + tc.input)
+			mod := parse.MustParseModule("package example\n" + tc.input)
 
 			if len(mod.Rules) != 1 {
 				t.Fatalf("Expected 1 rule, got %d", len(mod.Rules))

--- a/internal/embeds/templates/builtin/builtin.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin.rego.tpl
@@ -2,8 +2,6 @@
 # description: Add description of rule here!
 package regal.rules.{{.Category}}{{.Name}}
 
-import rego.v1
-
 import data.regal.ast
 import data.regal.result
 

--- a/internal/embeds/templates/builtin/builtin_test.rego.tpl
+++ b/internal/embeds/templates/builtin/builtin_test.rego.tpl
@@ -1,7 +1,5 @@
 package regal.rules.{{.Category}}{{.NameTest}}
 
-import rego.v1
-
 import data.regal.ast
 import data.regal.config
 

--- a/internal/embeds/templates/custom/custom.rego.tpl
+++ b/internal/embeds/templates/custom/custom.rego.tpl
@@ -4,8 +4,6 @@
 # - input: schema.regal.ast
 package custom.regal.rules.{{.Category}}{{.Name}}
 
-import rego.v1
-
 import data.regal.ast
 import data.regal.result
 

--- a/internal/embeds/templates/custom/custom_test.rego.tpl
+++ b/internal/embeds/templates/custom/custom_test.rego.tpl
@@ -1,7 +1,5 @@
 package custom.regal.rules.{{.Category}}{{.NameTest}}
 
-import rego.v1
-
 import data.custom.regal.rules.{{.Category}}{{.Name}} as rule
 
 # Example test, replace with your own

--- a/internal/lsp/completions/providers/policy_test.go
+++ b/internal/lsp/completions/providers/policy_test.go
@@ -21,8 +21,6 @@ func TestPolicyProvider_Example1(t *testing.T) {
 
 	policy := `package p
 
-import rego.v1
-
 allow if {
 	user := data.users[0]
 	# try completion on next line
@@ -53,7 +51,7 @@ allow if {
 			URI: testCaseFileURI,
 		},
 		Position: types.Position{
-			Line:      7,
+			Line:      5,
 			Character: 11,
 		},
 	}
@@ -84,13 +82,9 @@ func TestPolicyProvider_Example2(t *testing.T) {
 
 	file1 := ast.MustParseModule(`package example
 
-import rego.v1
-
 foo := true
 `)
 	file2 := ast.MustParseModule(`package example2
-
-import rego.v1
 
 import data.example
 `)
@@ -111,8 +105,6 @@ import data.example
 	locals := NewPolicy(context.Background(), store)
 	fileEdited := `package example2
 
-import rego.v1
-
 import data.example
 
 allow if {
@@ -128,7 +120,7 @@ allow if {
 			URI: "file:///file2.rego",
 		},
 		Position: types.Position{
-			Line:      7,
+			Line:      5,
 			Character: 11,
 		},
 	}

--- a/internal/lsp/completions/providers/rulehead_test.go
+++ b/internal/lsp/completions/providers/rulehead_test.go
@@ -22,8 +22,6 @@ func TestRuleHead(t *testing.T) {
 	regoFiles := map[string]string{
 		"file:///foo/foo.rego": `package foo
 
-import rego.v1
-
 default allow := false
 
 allow if count(deny) == 0

--- a/internal/lsp/completions/refs/defined_test.go
+++ b/internal/lsp/completions/refs/defined_test.go
@@ -106,8 +106,6 @@ func TestRefsForModule_Rules(t *testing.T) {
 
 	mod := rparse.MustParseModule(`package example
 
-import rego.v1
-
 # METADATA
 # title: An allow rule
 # description: A rule for things that should be allowed

--- a/internal/lsp/completions/refs/used_test.go
+++ b/internal/lsp/completions/refs/used_test.go
@@ -14,8 +14,6 @@ func TestUsedInModule(t *testing.T) {
 	mod := rparse.MustParseModule(`
 package example
 
-import rego.v1
-
 import data.foo as wow
 import data.bar
 

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -24,8 +24,6 @@ func TestEvalWorkspacePath(t *testing.T) {
 
 	policy1 := `package policy1
 
-	import rego.v1
-
 	import data.policy2
 
 	default allow := false
@@ -34,8 +32,6 @@ func TestEvalWorkspacePath(t *testing.T) {
 	`
 
 	policy2 := `package policy2
-
-	import rego.v1
 
 	allow if input.exists
 	`

--- a/internal/lsp/foldingrange_test.go
+++ b/internal/lsp/foldingrange_test.go
@@ -9,8 +9,6 @@ func TestTokenFoldingRanges(t *testing.T) {
 
 	policy := `package p
 
-	import rego.v1
-
 rule if {
 	arr := [
 		1,
@@ -32,32 +30,32 @@ rule if {
 
 	arr := foldingRanges[0]
 
-	if arr.StartLine != 5 || *arr.StartCharacter != 9 {
-		t.Errorf("Expected start line 5 and start character 9, got %d and %d", arr.StartLine, *arr.StartCharacter)
+	if arr.StartLine != 3 || *arr.StartCharacter != 9 {
+		t.Errorf("Expected start line 3 and start character 9, got %d and %d", arr.StartLine, *arr.StartCharacter)
 	}
 
-	if arr.EndLine != 8 {
-		t.Errorf("Expected end line 8, got %d", arr.EndLine)
+	if arr.EndLine != 6 {
+		t.Errorf("Expected end line 6, got %d", arr.EndLine)
 	}
 
 	parens := foldingRanges[1]
 
-	if parens.StartLine != 10 || *parens.StartCharacter != 9 {
-		t.Errorf("Expected start line 10 and start character 9, got %d and %d", parens.StartLine, *parens.StartCharacter)
+	if parens.StartLine != 8 || *parens.StartCharacter != 9 {
+		t.Errorf("Expected start line 8 and start character 9, got %d and %d", parens.StartLine, *parens.StartCharacter)
 	}
 
-	if parens.EndLine != 13 {
-		t.Errorf("Expected end line 13, got %d", parens.EndLine)
+	if parens.EndLine != 11 {
+		t.Errorf("Expected end line 11, got %d", parens.EndLine)
 	}
 
 	rule := foldingRanges[2]
 
-	if rule.StartLine != 4 || *rule.StartCharacter != 9 {
-		t.Errorf("Expected start line 4 and start character 9, got %d and %d", rule.StartLine, *rule.StartCharacter)
+	if rule.StartLine != 2 || *rule.StartCharacter != 9 {
+		t.Errorf("Expected start line 2 and start character 9, got %d and %d", rule.StartLine, *rule.StartCharacter)
 	}
 
-	if rule.EndLine != 14 {
-		t.Errorf("Expected end line 7, got %d", rule.EndLine)
+	if rule.EndLine != 12 {
+		t.Errorf("Expected end line 12, got %d", rule.EndLine)
 	}
 }
 

--- a/internal/lsp/inlayhint_test.go
+++ b/internal/lsp/inlayhint_test.go
@@ -60,8 +60,6 @@ func TestGetInlayHintsAstTerms(t *testing.T) {
 
 	policy := `package p
 
-	import rego.v1
-
 	allow if {
 		is_string("yes")
 	}`

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -83,7 +83,7 @@ func TestLintWithConfigIgnoreWildcards(t *testing.T) {
 		},
 	}
 
-	contents := "package p\n\nimport rego.v1\n\ncamelCase := 1\n"
+	contents := "package p\n\ncamelCase := 1\n"
 	module := parse.MustParseModule(contents)
 	workspaceRootURI := "file:///workspace"
 	fileURI := "file:///workspace/ignore/p.rego"

--- a/internal/lsp/rego/rego_test.go
+++ b/internal/lsp/rego/rego_test.go
@@ -12,8 +12,6 @@ func TestCodeLenses(t *testing.T) {
 
 	contents := `package p
 
-	import rego.v1
-
 	allow if "foo" in input.bar`
 
 	module := parse.MustParseModule(contents)
@@ -34,8 +32,6 @@ func TestAllRuleHeadLocations(t *testing.T) {
 	t.Parallel()
 
 	contents := `package p
-
-	import rego.v1
 
 	default allow := false
 
@@ -70,7 +66,7 @@ func TestAllKeywords(t *testing.T) {
 
 	contents := `package p
 
-	import rego.v1
+	import data.foo
 
 	my_set contains "x" if true
 	`

--- a/internal/lsp/server_config_test.go
+++ b/internal/lsp/server_config_test.go
@@ -32,7 +32,7 @@ func TestLanguageServerParentDirConfig(t *testing.T) {
 
 	mainRegoContents := `package main
 
-import rego.v1
+import data.test
 allow := true
 `
 

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -40,6 +40,10 @@ func ModuleWithOpts(path, policy string, opts ast.ParserOptions) (*ast.Module, e
 		err    error
 	)
 
+	if opts.RegoVersion == ast.RegoUndefined && strings.HasSuffix(path, "_v0.rego") {
+		opts.RegoVersion = ast.RegoV0
+	}
+
 	if opts.RegoVersion != ast.RegoUndefined {
 		module, err = ast.ParseModuleWithOpts(path, policy, opts)
 		if err != nil {

--- a/internal/update/update.rego
+++ b/internal/update/update.rego
@@ -2,8 +2,6 @@
 # description: utility module to help determine if an update of Regal should be recommended
 package update
 
-import rego.v1
-
 default needs_update := false
 
 # METADATA

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -26,8 +26,6 @@ func TestLintWithDefaultBundle(t *testing.T) {
 
 	input := test.InputPolicy("p/p.rego", `package p
 
-import rego.v1
-
 # TODO: fix this
 camelCase if {
 	input.one == 1
@@ -47,7 +45,7 @@ camelCase if {
 		t.Errorf("expected first violation to be 'todo-comments', got %s", result.Violations[0].Title)
 	}
 
-	if result.Violations[0].Location.Row != 5 {
+	if result.Violations[0].Location.Row != 3 {
 		t.Errorf("expected first violation to be on line 3, got %d", result.Violations[0].Location.Row)
 	}
 
@@ -63,7 +61,7 @@ camelCase if {
 		t.Errorf("expected second violation to be 'prefer-snake-case', got %s", result.Violations[1].Title)
 	}
 
-	if result.Violations[1].Location.Row != 6 {
+	if result.Violations[1].Location.Row != 4 {
 		t.Errorf("expected second violation to be on line 4, got %d", result.Violations[1].Location.Row)
 	}
 

--- a/pkg/linter/testdata/custom.rego
+++ b/pkg/linter/testdata/custom.rego
@@ -5,8 +5,6 @@
 #   ref: https://www.acmecorp.example.org/docs/regal/package
 package custom.regal.rules.naming["acme-corp-package"]
 
-import rego.v1
-
 import data.regal.result
 
 report contains violation if {

--- a/pkg/linter/testdata/printer.rego
+++ b/pkg/linter/testdata/printer.rego
@@ -5,8 +5,6 @@
 #   ref: https://www.acmecorp.example.org/docs/regal/package
 package custom.regal.rules.utils["printer"]
 
-import rego.v1
-
 report contains "never happens" if {
 	print(input.regal.file.name)
 


### PR DESCRIPTION
- Remove `import rego.v1` from examples
- Add new page covering Regal and OPA 1.0
- Update logic of any rules obsolete in 1.0 to make sure they're automatically disabled when 1.0 is targeted, and continue to work when older versions are linted
- Update a few tests to remove `import rego.v1`
- Many minor fixes related to this theme

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->