### PR TITLE
docs: opa-fmt v1/v0 notes

### DIFF
--- a/docs/rules/style/opa-fmt.md
+++ b/docs/rules/style/opa-fmt.md
@@ -30,6 +30,23 @@ indent_style = tab
 indent_size = 4
 ```
 
+## OPA Format with Rego v1 and v0
+
+OPA 1.0 makes Rego v1 the default. This change mandated some changes to the
+functionality of the `opa fmt` command and a number of new options for working
+with mixed version code bases. See the
+[OPA documentation](https://www.openpolicyagent.org/docs/latest/cli/#opa-fmt)
+for the command's options.
+
+In Regal, a v0 file will have the `opa-fmt` violation unless it's been formatted
+with `opa fmt --v0-v1`. A v1 file will have the `opa-fmt` violation unless it's
+been formatted with `opa fmt` (the rego.v1 keyword is permitted but not added).
+
+When formatting, a file expected to be v1 based on the configuration, but with
+v0 syntax is still formatted as `opa fmt –-v0-v1`. Please see
+[Configuring Rego Version](https://docs.styra.com/regal#configuring-rego-version)
+for more configuration help for multi version projects.
+
 ## Configuration Options
 
 This linter rule provides the following configuration options:


### PR DESCRIPTION
This explains the different behaviour of `opa fmt` between v0 and v1 when working with v0/v1 files in Rego.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->