### PR TITLE
Upgrade Roast to v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.3
 
 require (
 	dario.cat/mergo v1.0.1
-	github.com/anderseknert/roast v0.5.0
+	github.com/anderseknert/roast v0.6.0
 	github.com/coreos/go-semver v0.3.1
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/ProtonMail/go-crypto v1.1.3 h1:nRBOetoydLeUb4nHajyO2bKqMLfWQ/ZPwkXqXx
 github.com/ProtonMail/go-crypto v1.1.3/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
 github.com/agnivade/levenshtein v1.2.0 h1:U9L4IOT0Y3i0TIlUIDJ7rVUziKi/zPbrJGaFrtYH3SY=
 github.com/agnivade/levenshtein v1.2.0/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
-github.com/anderseknert/roast v0.5.0 h1:2TJ3kX+OCeesArnK3ieRmMFf9nLrWYfVeIR0Ol9mon0=
-github.com/anderseknert/roast v0.5.0/go.mod h1:9RXWYE5aTdo1Ro1FZzf26shaPUMm2fH0ibKrY9DH224=
+github.com/anderseknert/roast v0.6.0 h1:/CltHr28Jv1piPw6599OOP4I7K1sHtfUCeCoNYCLvXA=
+github.com/anderseknert/roast v0.6.0/go.mod h1:nUxsa/73myaxBe4xSx1LgTIsR/bGbwlxCZ0ADyocpV4=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=

--- a/internal/lsp/opa/oracle/oracle.go
+++ b/internal/lsp/opa/oracle/oracle.go
@@ -142,18 +142,14 @@ func walkToFirstOccurrence(node ast.Node, needle ast.Var) (match *ast.Term) {
 }
 
 func compileUpto(stage string, modules map[string]*ast.Module, bs []byte, filename string) (*ast.Compiler, *ast.Module, error) {
-	compiler := compile.NewCompilerWithRegalBuiltins()
-
-	if stage != "" {
-		compiler = compiler.WithStageAfter(stage, ast.CompilerStageDefinition{
-			Name: "halt",
-			Stage: func(c *ast.Compiler) *ast.Error {
-				return &ast.Error{
-					Code: "halt",
-				}
-			},
-		})
-	}
+	compiler := compile.NewCompilerWithRegalBuiltins().WithStageAfter(stage, ast.CompilerStageDefinition{
+		Name: "halt",
+		Stage: func(c *ast.Compiler) *ast.Error {
+			return &ast.Error{
+				Code: "halt",
+			}
+		},
+	})
 
 	var module *ast.Module
 

--- a/pkg/builtins/builtins_test.go
+++ b/pkg/builtins/builtins_test.go
@@ -19,7 +19,7 @@ func BenchmarkRegalLast(b *testing.B) {
 
 	var res *ast.Term
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		var err error
 
 		res, err = builtins.RegalLast(bctx, arr)
@@ -42,7 +42,7 @@ func BenchmarkRegalLastEmptyArr(b *testing.B) {
 
 	var err error
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err = builtins.RegalLast(bctx, arr)
 	}
 

--- a/pkg/builtins/builtins_test.go
+++ b/pkg/builtins/builtins_test.go
@@ -1,0 +1,52 @@
+package builtins_test
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/rego"
+
+	"github.com/styrainc/regal/pkg/builtins"
+)
+
+// Can't be much faster than this..
+// BenchmarkRegalLast-10    163252460    7.218 ns/op    0 B/op    0 allocs/op
+// ...
+func BenchmarkRegalLast(b *testing.B) {
+	bctx := rego.BuiltinContext{}
+	ta, tb, tc := ast.StringTerm("a"), ast.StringTerm("b"), ast.StringTerm("c")
+	arr := ast.ArrayTerm(ta, tb, tc)
+
+	var res *ast.Term
+
+	for i := 0; i < b.N; i++ {
+		var err error
+
+		res, err = builtins.RegalLast(bctx, arr)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	if res.Value.Compare(tc.Value) != 0 {
+		b.Fatalf("expected c, got %v", res)
+	}
+}
+
+// Likewise for the empty array case.
+// BenchmarkRegalLastEmptyArr-10    160589398    7.498 ns/op    0 B/op    0 allocs/op
+// ...
+func BenchmarkRegalLastEmptyArr(b *testing.B) {
+	bctx := rego.BuiltinContext{}
+	arr := ast.ArrayTerm()
+
+	var err error
+
+	for i := 0; i < b.N; i++ {
+		_, err = builtins.RegalLast(bctx, arr)
+	}
+
+	if err == nil {
+		b.Fatal("expected error, got nil")
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -713,7 +713,7 @@ func ToMap(config Config) map[string]any {
 	return confMap
 }
 
-func (rule Rule) MarshalJSON() ([]byte, error) {
+func (rule *Rule) MarshalJSON() ([]byte, error) {
 	result, err := rule.MarshalYAML()
 	if err != nil {
 		return nil, fmt.Errorf("marshalling rule failed %w", err)
@@ -736,7 +736,7 @@ func (rule *Rule) UnmarshalJSON(data []byte) error {
 	return rule.mapToConfig(result)
 }
 
-func (rule Rule) MarshalYAML() (interface{}, error) {
+func (rule *Rule) MarshalYAML() (interface{}, error) {
 	result := make(map[string]any)
 	result[keyLevel] = rule.Level
 

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -783,7 +783,6 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 	}
 }
 
-// BenchmarkRegalNoEnabledRules-10    	       4	 283181990 ns/op	504195068 B/op	 9537285 allocs/op.
 func BenchmarkRegalNoEnabledRules(b *testing.B) {
 	linter := NewLinter().
 		WithInputPaths([]string{"../../bundle"}).


### PR DESCRIPTION
Roast now also on OPA 1.0, and v0.6.0 brings slightly faster serialization of terms as well.

Included in this PR too some minor fixes that don't deserve their own PR.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->