### PR TITLE
fix: filter out `regal.debug` codelens

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1736,7 +1736,7 @@ func (l *LanguageServer) handleTextDocumentCodeLens(
 
 	for _, lens := range lenses {
 		if lens.Command.Command != "regal.debug" {
-			lenses = append(lenses, lens)
+			filteredLenses = append(filteredLenses, lens)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->

This PR fixes a bug with filtering out `regal.debug` codelens when `enableDebugCodelens != true`
I ran into it a few days ago and it seems like it has been here since the implementation (https://github.com/StyraInc/regal/pull/1176) 