### PR TITLE
Add workspace folder type, and "support" that capability

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2476,7 +2476,7 @@ func (l *LanguageServer) handleInitialize(
 					// where they have the client start one instance of the server per workspace folder:
 					// https://github.com/microsoft/vscode-extension-samples/tree/main/lsp-multi-server-sample
 					// That seems like a reasonable approach to take, and means we won't have to deal with workspace
-					// folders throughout the rest of the codebase. But the quesstion then is — what is the point of
+					// folders throughout the rest of the codebase. But the question then is — what is the point of
 					// this capability, and what does it mean to say we support it? Clearly we don't in the server as
 					// *there is no way* to support it here.
 					Supported: true,

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2469,6 +2469,18 @@ func (l *LanguageServer) handleInitialize(
 						Filters: []types.FileOperationFilter{regoFilter},
 					},
 				},
+				WorkspaceFolders: types.WorkspaceFoldersServerCapabilities{
+					// NOTE(anders): The language server protocol doesn't go into detail about what this is meant to
+					// entail, and there's nothing else in the request/response payloads that carry workspace folder
+					// information. The best source I've found on the this topic is this example repo from VS Code,
+					// where they have the client start one instance of the server per workspace folder:
+					// https://github.com/microsoft/vscode-extension-samples/tree/main/lsp-multi-server-sample
+					// That seems like a reasonable approach to take, and means we won't have to deal with workspace
+					// folders throughout the rest of the codebase. But the quesstion then is — what is the point of
+					// this capability, and what does it mean to say we support it? Clearly we don't in the server as
+					// *there is no way* to support it here.
+					Supported: true,
+				},
 			},
 			InlayHintProvider: types.InlayHintOptions{
 				ResolveProvider: false,

--- a/internal/lsp/types/types.go
+++ b/internal/lsp/types/types.go
@@ -40,7 +40,7 @@ type InitializeParams struct {
 	RootPath              string                 `json:"rootPath"`
 	RootURI               string                 `json:"rootUri"`
 	Trace                 string                 `json:"trace"`
-	WorkspaceFolders      []WorkspaceFolder      `json:"workspaceFolders"`
+	WorkspaceFolders      *[]WorkspaceFolder     `json:"workspaceFolders"`
 	Capabilities          ClientCapabilities     `json:"capabilities"`
 	ProcessID             int                    `json:"processId"`
 }
@@ -175,8 +175,13 @@ type CompletionItemLabelDetails struct {
 	Detail      string `json:"detail"`
 }
 
+type WorkspaceFoldersServerCapabilities struct {
+	Supported bool `json:"supported"`
+}
+
 type WorkspaceOptions struct {
-	FileOperations FileOperationsServerCapabilities `json:"fileOperations"`
+	FileOperations   FileOperationsServerCapabilities   `json:"fileOperations"`
+	WorkspaceFolders WorkspaceFoldersServerCapabilities `json:"workspaceFolders"`
 }
 
 type CodeActionOptions struct {


### PR DESCRIPTION
Ironic quotes on support since this seems to be a client feature only, but I figured we'd still document that in the code rather than elsewhere, for reference next time we look into that.

Next up to look into supporting this in the OPA VS Code extension.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->