### PR TITLE
Language server refactoring

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
       - uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
         if: matrix.os.name == 'linux'
         with:
-          version: v1.63.1
+          version: v1.63.4
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: regal-${{ matrix.os.name }}

--- a/internal/lsp/cache/cache.go
+++ b/internal/lsp/cache/cache.go
@@ -106,6 +106,20 @@ func (c *Cache) SetModule(fileURI string, module *ast.Module) {
 	c.modules.Set(fileURI, module)
 }
 
+func (c *Cache) GetContentAndModule(fileURI string) (string, *ast.Module, bool) {
+	content, ok := c.GetFileContents(fileURI)
+	if !ok {
+		return "", nil, false
+	}
+
+	module, ok := c.GetModule(fileURI)
+	if !ok {
+		return "", nil, false
+	}
+
+	return content, module, true
+}
+
 func (c *Cache) Rename(oldKey, newKey string) {
 	if content, ok := c.fileContents.Get(oldKey); ok {
 		c.fileContents.Set(newKey, content)

--- a/internal/lsp/handler/handler.go
+++ b/internal/lsp/handler/handler.go
@@ -1,0 +1,44 @@
+package handler
+
+import (
+	"context"
+
+	"github.com/anderseknert/roast/pkg/encoding"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type handlerFunc[T any] func(T) (any, error)
+
+type handlerContextFunc[T any] func(context.Context, T) (any, error)
+
+var ErrInvalidParams = &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams}
+
+func Decode[T any](req *jsonrpc2.Request, params *T) error {
+	if req.Params == nil {
+		return ErrInvalidParams
+	}
+
+	if err := encoding.JSON().Unmarshal(*req.Params, &params); err != nil {
+		return &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams, Message: err.Error()}
+	}
+
+	return nil
+}
+
+func WithParams[T any](req *jsonrpc2.Request, h handlerFunc[T]) (any, error) {
+	var params T
+	if err := Decode(req, &params); err != nil {
+		return nil, err
+	}
+
+	return h(params)
+}
+
+func WithContextAndParams[T any](ctx context.Context, req *jsonrpc2.Request, h handlerContextFunc[T]) (any, error) {
+	var params T
+	if err := Decode(req, &params); err != nil {
+		return nil, err
+	}
+
+	return h(ctx, params)
+}

--- a/internal/lsp/server_formatting_test.go
+++ b/internal/lsp/server_formatting_test.go
@@ -2,7 +2,6 @@ package lsp
 
 import (
 	"context"
-	"encoding/json"
 	"path/filepath"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestFormatting(t *testing.T) {
 		return struct{}{}, nil
 	}
 
-	ls, connClient, err := createAndInitServer(ctx, newTestLogger(t), tempDir, map[string]string{}, clientHandler)
+	ls, _, err := createAndInitServer(ctx, newTestLogger(t), tempDir, map[string]string{}, clientHandler)
 	if err != nil {
 		t.Fatalf("failed to create and init language server: %s", err)
 	}
@@ -39,19 +38,12 @@ func TestFormatting(t *testing.T) {
 `
 	ls.cache.SetFileContents(mainRegoURI, content)
 
-	bs, err := json.Marshal(&types.DocumentFormattingParams{
+	params := types.DocumentFormattingParams{
 		TextDocument: types.TextDocumentIdentifier{URI: mainRegoURI},
 		Options:      types.FormattingOptions{},
-	})
-	if err != nil {
-		t.Fatalf("failed to marshal document formatting params: %v", err)
 	}
 
-	var msg json.RawMessage = bs
-
-	req := &jsonrpc2.Request{Params: &msg}
-
-	res, err := ls.handleTextDocumentFormatting(ctx, connClient, req)
+	res, err := ls.handleTextDocumentFormatting(ctx, params)
 	if err != nil {
 		t.Fatalf("failed to format document: %s", err)
 	}


### PR DESCRIPTION
While there's more to do here, we've got to start somewhere.

- Simplify handlers by extracting shared logic
- Use "global" vars for static slices to avoid needless allocations
- No named return values
- Add GetContentAndModule convenience function to reduce boilerplate
- Various fixes

This should not change behavior of anything, just nake server.go a little more manageable.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->