### PR TITLE
perf: move config check out of loop

### DIFF
--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -43,12 +43,12 @@ lint.aggregate.violations := aggregate_report if {
 }
 
 _rules_to_run[category] contains title if {
+	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
+
 	some category, title
 	config.merged_config.rules[category][title]
 
 	config.for_rule(category, title).level != "ignore"
-
-	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
 
 	not config.excluded_file(
 		category,
@@ -105,20 +105,15 @@ report contains violation if {
 
 # Check custom rules
 report contains violation if {
+	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
+
 	some category, title
 
 	violation := data.custom.regal.rules[category][title].report[_]
 
 	config.for_rule(category, title).level != "ignore"
 
-	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
-
-	not config.excluded_file(
-		category,
-		title,
-		file_name_relative_to_root,
-	)
-
+	not config.excluded_file(category, title, file_name_relative_to_root)
 	not _ignored(violation, ast.ignore_directives)
 }
 


### PR DESCRIPTION
In main.rego there are two places where we extract a relative path from the input policy file. This was however done in a loop despite only using variables from outside of the loop. Turns out there was close to a million allocations hiding there, lol.

**BenchmarkRegalLintingItself-10 Before**
```
1875658375 ns/op    3539151104 B/op    70020076 allocs/op
```
**BenchmarkRegalLintingItself-10 After**
```
1821361667 ns/op    3499082704 B/op    69062781 allocs/op
```

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->