### PR TITLE
lsp: Ensure parse errors are saved as diagnostics correctly

### DIFF
--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -74,6 +74,24 @@ allow if { 1 == 1 }
 			}},
 			regoVersion: ast.RegoV0,
 		},
+		"unknown rego version, rego v1 code": {
+			fileURI: "file:///valid.rego",
+			content: `package test
+allow if { 1 == 1 }
+`,
+			expectModule:  true,
+			expectSuccess: true,
+			regoVersion:   ast.RegoUndefined,
+		},
+		"unknown rego version, rego v0 code": {
+			fileURI: "file:///valid.rego",
+			content: `package test
+allow[msg] { 1 == 1; msg := "hello" }
+`,
+			expectModule:  true,
+			expectSuccess: true,
+			regoVersion:   ast.RegoUndefined,
+		},
 	}
 
 	for testName, testData := range tests {

--- a/internal/lsp/lint_test.go
+++ b/internal/lsp/lint_test.go
@@ -5,12 +5,124 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/open-policy-agent/opa/v1/ast"
+
 	"github.com/styrainc/regal/internal/lsp/cache"
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/parse"
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/report"
 )
+
+func TestUpdateParse(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		fileURI string
+		content string
+
+		expectSuccess bool
+		// ParseErrors are formatted as another type/source of diagnostic
+		expectedParseErrors []types.Diagnostic
+		expectModule        bool
+		regoVersion         ast.RegoVersion
+	}{
+		"valid file": {
+			fileURI: "file:///valid.rego",
+			content: `package test
+allow if { 1 == 1 }
+`,
+			expectModule:  true,
+			expectSuccess: true,
+			regoVersion:   ast.RegoV1,
+		},
+		"parse error": {
+			fileURI: "file:///broken.rego",
+			content: `package test
+
+p = true { 1 == }
+`,
+			regoVersion: ast.RegoV1,
+			expectedParseErrors: []types.Diagnostic{{
+				Code:  "rego-parse-error",
+				Range: types.Range{Start: types.Position{Line: 2, Character: 13}, End: types.Position{Line: 2, Character: 13}},
+			}},
+			expectModule:  false,
+			expectSuccess: false,
+		},
+		"empty file": {
+			fileURI:     "file:///empty.rego",
+			content:     "",
+			regoVersion: ast.RegoV1,
+			expectedParseErrors: []types.Diagnostic{{
+				Code:  "rego-parse-error",
+				Range: types.Range{Start: types.Position{Line: 0, Character: 0}, End: types.Position{Line: 0, Character: 0}},
+			}},
+			expectModule:  false,
+			expectSuccess: false,
+		},
+		"parse error due to version": {
+			fileURI: "file:///valid.rego",
+			content: `package test
+allow if { 1 == 1 }
+`,
+			expectModule:  false,
+			expectSuccess: false,
+			expectedParseErrors: []types.Diagnostic{{
+				Code:  "rego-parse-error",
+				Range: types.Range{Start: types.Position{Line: 1, Character: 0}, End: types.Position{Line: 1, Character: 0}},
+			}},
+			regoVersion: ast.RegoV0,
+		},
+	}
+
+	for testName, testData := range tests {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			c := cache.NewCache()
+			c.SetFileContents(testData.fileURI, testData.content)
+
+			s := NewRegalStore()
+
+			success, err := updateParse(ctx, c, s, testData.fileURI, ast.BuiltinMap, testData.regoVersion)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if success != testData.expectSuccess {
+				t.Fatalf("expected success to be %v, got %v", testData.expectSuccess, success)
+			}
+
+			_, ok := c.GetModule(testData.fileURI)
+			if testData.expectModule && !ok {
+				t.Fatalf("expected module to be set, but it was not")
+			}
+
+			diags, _ := c.GetParseErrors(testData.fileURI)
+
+			if len(testData.expectedParseErrors) != len(diags) {
+				t.Fatalf("expected %v parse errors, got %v", len(testData.expectedParseErrors), len(diags))
+			}
+
+			for i, diag := range testData.expectedParseErrors {
+				if diag.Code != diags[i].Code {
+					t.Errorf("expected diagnostic code to be %v, got %v", diag.Code, diags[i].Code)
+				}
+
+				if diag.Range.Start.Line != diags[i].Range.Start.Line {
+					t.Errorf("expected diagnostic start line to be %v, got %v", diag.Range.Start.Line, diags[i].Range.Start.Line)
+				}
+
+				if diag.Range.End.Line != diags[i].Range.End.Line {
+					t.Errorf("expected diagnostic end line to be %v, got %v", diag.Range.End.Line, diags[i].Range.End.Line)
+				}
+			}
+		})
+	}
+}
 
 func TestConvertReportToDiagnostics(t *testing.T) {
 	t.Parallel()

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1659,6 +1659,11 @@ func (l *LanguageServer) handleTextDocumentInlayHint(params types.TextDocumentIn
 }
 
 func (l *LanguageServer) handleTextDocumentCodeLens(ctx context.Context, params types.CodeLensParams) (any, error) {
+	parseErrors, ok := l.cache.GetParseErrors(params.TextDocument.URI)
+	if ok && len(parseErrors) > 0 {
+		return []types.CodeLens{}, nil
+	}
+
 	contents, module, ok := l.cache.GetContentAndModule(params.TextDocument.URI)
 	if !ok {
 		return nil, nil // return a null response, as per the spec

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -71,6 +71,7 @@ const (
 
 var (
 	noCodeActions     = make([]types.CodeAction, 0)
+	noCodeLenses      = make([]types.CodeLens, 0)
 	noDocumentSymbols = make([]types.DocumentSymbol, 0)
 	noCompletionItems = make([]types.CompletionItem, 0)
 	noFoldingRanges   = make([]types.FoldingRange, 0)
@@ -1654,7 +1655,7 @@ func (l *LanguageServer) handleTextDocumentInlayHint(params types.TextDocumentIn
 func (l *LanguageServer) handleTextDocumentCodeLens(ctx context.Context, params types.CodeLensParams) (any, error) {
 	parseErrors, ok := l.cache.GetParseErrors(params.TextDocument.URI)
 	if ok && len(parseErrors) > 0 {
-		return []types.CodeLens{}, nil
+		return noCodeLenses, nil
 	}
 
 	contents, module, ok := l.cache.GetContentAndModule(params.TextDocument.URI)

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1161,14 +1161,7 @@ func (l *LanguageServer) templateContentsForFile(fileURI string) (string, error)
 		pkg += "_test"
 	}
 
-	version := ast.RegoUndefined
-	if l.loadedConfigAllRegoVersions != nil {
-		version = rules.RegoVersionFromVersionsMap(
-			l.loadedConfigAllRegoVersions.Clone(),
-			strings.TrimPrefix(uri.ToPath(l.clientIdentifier, fileURI), uri.ToPath(l.clientIdentifier, l.workspaceRootURI)),
-			ast.RegoUndefined,
-		)
-	}
+	version := l.regoVersionForURI(fileURI)
 
 	if version == ast.RegoV0 {
 		return fmt.Sprintf("package %s\n\nimport rego.v1\n", pkg), nil
@@ -1705,11 +1698,7 @@ func (l *LanguageServer) handleTextDocumentCompletion(ctx context.Context, param
 		ClientIdentifier: l.clientIdentifier,
 		RootURI:          l.workspaceRootURI,
 		Builtins:         l.builtinsForCurrentCapabilities(),
-		RegoVersion: rules.RegoVersionFromVersionsMap(
-			l.loadedConfigAllRegoVersions.Clone(),
-			strings.TrimPrefix(params.TextDocument.URI, l.workspaceRootURI),
-			ast.RegoUndefined,
-		),
+		RegoVersion:      l.regoVersionForURI(params.TextDocument.URI),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find completions: %w", err)
@@ -2009,11 +1998,7 @@ func (l *LanguageServer) handleTextDocumentFormatting(
 	switch formatter {
 	case "opa-fmt", "opa-fmt-rego-v1":
 		opts := format.Opts{
-			RegoVersion: rules.RegoVersionFromVersionsMap(
-				l.loadedConfigAllRegoVersions.Clone(),
-				strings.TrimPrefix(params.TextDocument.URI, l.workspaceRootURI),
-				ast.RegoUndefined,
-			),
+			RegoVersion: l.regoVersionForURI(params.TextDocument.URI),
 		}
 
 		if formatter == "opa-fmt-rego-v1" {


### PR DESCRIPTION
Fixes https://github.com/StyraInc/regal/issues/1344

Fixes https://github.com/StyraInc/regal/issues/1123

(in fact, the final two lsp bugs we have in the tracker: https://github.com/StyraInc/regal/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22language%20server%20protocol%22%20label%3Abug)