### PR TITLE
Fix missing annotations in LSP parsing

### DIFF
--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
@@ -30,16 +30,23 @@ _rule_annotations[rule_path] contains annotated if {
 	annotated := count(object.get(rule, "annotations", [])) > 0
 }
 
-_rule_locations[rule_path] := util.to_location_object(location) if {
+_rule_locations[rule_path] := location if {
 	some rule_path, annotated in _rule_annotations
 
 	# we only care about locations of non-annotated rules
 	not true in annotated
 
-	location := [h.location |
-		h := ast.public_rules_and_functions[_].head
-		concat(".", [ast.package_name, ast.ref_static_to_string(h.ref)]) == rule_path
+	first_rule_index := [i |
+		some i
+
+		# false positive: https://github.com/StyraInc/regal/issues/1353
+		# regal ignore:unused-output-variable
+		ref := ast.public_rules_and_functions[i].head.ref
+		concat(".", [ast.package_name, ast.ref_static_to_string(ref)]) == rule_path
 	][0]
+
+	ref := ast.public_rules_and_functions[first_rule_index].head.ref
+	location := object.remove(result.ranged_from_ref(ref).location, ["file"])
 }
 
 # METADATA

--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
@@ -38,7 +38,7 @@ none := false
 				"col": 1,
 				"row": 9,
 				"end": {
-					"col": 14,
+					"col": 5,
 					"row": 9,
 				},
 				"text": "none := false",
@@ -143,7 +143,7 @@ baz := true
 			"file": "p.rego",
 			"row": 5,
 			"end": {
-				"col": 12,
+				"col": 4,
 				"row": 5,
 			},
 			"text": "baz := true",

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -37,13 +37,10 @@ func updateParse(
 	}
 
 	lines := strings.Split(content, "\n")
+	options := rparse.ParserOptions()
+	options.RegoVersion = version
 
-	var (
-		err    error
-		module *ast.Module
-	)
-
-	module, err = rparse.ModuleWithOpts(fileURI, content, ast.ParserOptions{RegoVersion: version})
+	module, err := rparse.ModuleWithOpts(fileURI, content, options)
 	if err == nil {
 		// if the parse was ok, clear the parse errors
 		cache.SetParseErrors(fileURI, []types.Diagnostic{})


### PR DESCRIPTION
Also, update the missing-metadata rule to report violation locations on the rule head ref and not the whole rule head.