### PR TITLE
config: Search for .regal.yaml and use for roots

### DIFF
--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -237,7 +237,7 @@ func fix(args []string, params *fixCommandParams) error {
 
 	var userConfig config.Config
 
-	userConfigFile, err := readUserConfig(params, regalDir)
+	userConfigFile, err := readUserConfig(params, configSearchPath)
 
 	switch {
 	case err == nil:

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -299,7 +299,7 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 
 	var userConfig config.Config
 
-	userConfigFile, err := readUserConfig(params, regalDir)
+	userConfigFile, err := readUserConfig(params, configSearchPath)
 
 	switch {
 	case err == nil:

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -15,21 +15,18 @@ type configFileParams interface {
 	getConfigFile() string
 }
 
-func readUserConfig(params configFileParams, regalDir *os.File) (userConfig *os.File, err error) {
+func readUserConfig(params configFileParams, searchPath string) (userConfig *os.File, err error) {
 	if cfgFile := params.getConfigFile(); cfgFile != "" {
 		userConfig, err = os.Open(cfgFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to open config file %w", err)
 		}
 	} else {
-		searchPath, _ := os.Getwd()
-		if regalDir != nil {
-			searchPath = regalDir.Name()
+		if searchPath == "" {
+			searchPath, _ = os.Getwd()
 		}
 
-		if searchPath != "" {
-			userConfig, err = config.FindConfig(searchPath)
-		}
+		userConfig, err = config.FindConfig(searchPath)
 	}
 
 	return userConfig, err //nolint:wrapcheck

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -175,7 +175,42 @@ project:
 		expected := util.Map(util.FilepathJoiner(root), []string{"", ".regal/rules", "baz", "bundle", "foo/bar"})
 
 		if !slices.Equal(expected, locations) {
-			t.Errorf("expected %v, got %v", expected, locations)
+			t.Errorf("expected\n%s\ngot\n%s", strings.Join(expected, "\n"), strings.Join(locations, "\n"))
+		}
+	})
+}
+
+func TestFindBundleRootDirectoriesWithStandaloneConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := `
+project:
+  roots:
+  - foo/bar
+  - baz
+`
+
+	fs := map[string]string{
+		"/.regal.yaml":             cfg, // root from config
+		"/bundle/.manifest":        "",  // bundle from .manifest
+		"/foo/bar/baz/policy.rego": "",  // foo/bar from config
+		"/baz":                     "",  // baz from config
+	}
+
+	test.WithTempFS(fs, func(root string) {
+		locations, err := FindBundleRootDirectories(root)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(locations) != 4 {
+			t.Errorf("expected 5 locations, got %d", len(locations))
+		}
+
+		expected := util.Map(util.FilepathJoiner(root), []string{"", "baz", "bundle", "foo/bar"})
+
+		if !slices.Equal(expected, locations) {
+			t.Errorf("expected\n%s\ngot\n%s", strings.Join(expected, "\n"), strings.Join(locations, "\n"))
 		}
 	})
 }


### PR DESCRIPTION
This updates the search for config to correctly look for .regal.yaml too. It also correctly uses .regal.yaml files for root determination.

```
$ cat foo.rego
───────┬────────────────────────────────────────────────────────────────────
       │ File: foo.rego
───────┼────────────────────────────────────────────────────────────────────
   1   │ package foo
   2   │
   3   │ allow if      true
───────┴────────────────────────────────────────────────────────────────────
$ cat .regal.yaml
───────┬────────────────────────────────────────────────────────────────────
       │ File: .regal.yaml
───────┼────────────────────────────────────────────────────────────────────
   1   │ rules:
   2   │   style:
   3   │     opa-fmt:
   4   │       level: ignore
───────┴────────────────────────────────────────────────────────────────────
$ ../regal fix --force foo.rego
1 fix applied:
In project root: /Users/charlieegan3/Code/regal/temp
foo.rego -> foo/foo.rego:
- directory-package-mismatch
```

Fixes https://github.com/StyraInc/regal/issues/1342