### PR TITLE
perf: always include `ignore_files` in data

### DIFF
--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -698,10 +698,7 @@ func (l Linter) paramsToRulesConfig() map[string]any {
 		"enable_all":       l.enableAll,
 		"enable_category":  util.NullToEmpty(l.enableCategory),
 		"enable":           util.NullToEmpty(l.enable),
-	}
-
-	if l.ignoreFiles != nil {
-		params["ignore_files"] = l.ignoreFiles
+		"ignore_files":     util.NullToEmpty(l.ignoreFiles),
 	}
 
 	return map[string]any{


### PR DESCRIPTION
Found out just last night that querying a data path that isn't found is treated as `error` by the storage module, and as such a source of allocations. So let's avoid it where we can.

```
Before  3519103080 B/op	 69457852 allocs/op
After   3508152464 B/op  69203795 allocs/op
```

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->