### PR TITLE
fix: better location reporting in `use-if` rule

### DIFF
--- a/bundle/regal/rules/idiomatic/use-if/use_if.rego
+++ b/bundle/regal/rules/idiomatic/use-if/use_if.rego
@@ -34,5 +34,5 @@ report contains violation if {
 
 	not startswith(text, "if")
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(rule.head.ref))
 }

--- a/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
+++ b/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
@@ -22,8 +22,8 @@ test_fail_should_use_if if {
 			"file": "policy_v0.rego",
 			"row": 3,
 			"end": {
-				"col": 3,
-				"row": 7,
+				"col": 5,
+				"row": 3,
 			},
 			"text": "rule := [true |",
 		},


### PR DESCRIPTION
Fixes #1361

Instead of highlighting the whole rule, we now only highlight the rule ref

![Screenshot 2025-01-23 at 19 42 19](https://github.com/user-attachments/assets/e7b2f856-50fb-4f4a-8422-38c48f9adb25)
