### PR TITLE
Small fixes

### DIFF
--- a/bundle/regal/config/exclusion.rego
+++ b/bundle/regal/config/exclusion.rego
@@ -13,9 +13,9 @@ excluded_file(category, title, file) if {
 	_exclude(pattern, file)
 }
 
-_global_ignore_patterns := data.eval.params.ignore_files
-
-_global_ignore_patterns := merged_config.ignore.files if not data.eval.params.ignore_files
+_global_ignore_patterns := data.eval.params.ignore_files if {
+	count(data.eval.params.ignore_files) > 0
+} else := merged_config.ignore.files
 
 # exclude imitates .gitignore pattern matching as best it can
 # ref: https://git-scm.com/docs/gitignore#_pattern_format

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -133,7 +133,6 @@ func prepareQuery(ctx context.Context, store storage.Store, query string) (*rego
 
 func prepareRegoArgs(store storage.Store, query ast.Body) []func(*rego.Rego) {
 	return []func(*rego.Rego){
-		rego.StoreReadAST(true),
 		rego.Store(store),
 		rego.ParsedQuery(query),
 		rego.ParsedBundle("regal", &rbundle.LoadedBundle),

--- a/internal/lsp/store.go
+++ b/internal/lsp/store.go
@@ -20,7 +20,7 @@ func NewRegalStore() storage.Store {
 			// we'll need to conform to the most basic "JSON" format understood by the store
 			"defined_refs": map[string]any{},
 		},
-	}, inmem.OptRoundTripOnWrite(false))
+	}, inmem.OptRoundTripOnWrite(false), inmem.OptReturnASTValuesOnRead(true))
 }
 
 func transact(ctx context.Context, store storage.Store, writeMode bool, op func(txn storage.Transaction) error) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -760,7 +760,7 @@ func fromOPABuiltin(builtin ast.Builtin) *Builtin {
 func fromOPACapabilities(capabilities *ast.Capabilities) *Capabilities {
 	var result Capabilities
 
-	result.Builtins = make(map[string]*Builtin)
+	result.Builtins = make(map[string]*Builtin, len(capabilities.Builtins))
 
 	for _, builtin := range capabilities.Builtins {
 		result.Builtins[builtin.Name] = fromOPABuiltin(*builtin)


### PR DESCRIPTION
- Use `count` on `data.eval.params.ignore_files` as it's now always defined
- Set `inmem.OptReturnASTValuesOnRead(true)` on the LSP inmem store for a substantial performance boost!
- Remove `rego.StoreReadAST(true)` which was ignored since we set the store explicitly

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->