### PR TITLE
The compact output format should include a summary #1364

### DIFF
--- a/p.rego
+++ b/p.rego
@@ -1,0 +1,7 @@
+package p
+
+camelCase := "hello"
+
+foo := true
+
+bar := foo

--- a/p.rego
+++ b/p.rego
@@ -1,7 +1,0 @@
-package p
-
-camelCase := "hello"
-
-foo := true
-
-bar := foo

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -297,11 +297,22 @@ func (tr CompactReporter) Publish(_ context.Context, r report.Report) error {
 	for _, violation := range r.Violations {
 		table.Append([]string{violation.Location.String(), violation.Description})
 	}
+	// plurals
+	pluralScanned := ""
+	if r.Summary.FilesScanned > 1 || r.Summary.FilesScanned == 0 {
+		pluralScanned = "s"
+	}
+	pluralViolations := ""
+	if r.Summary.NumViolations > 1 || r.Summary.NumViolations == 0 {
+		pluralViolations = "s"
+	}
 
+	summary := fmt.Sprintf("%d file%s linted , %d violation%s found. \n",
+		r.Summary.FilesScanned, pluralScanned,
+		r.Summary.NumViolations, pluralViolations)
+	// rendering the table
 	table.Render()
-
-	_, err := fmt.Fprintln(tr.out, strings.TrimSuffix(sb.String(), " "))
-
+	_, err := fmt.Fprintln(tr.out, strings.TrimSuffix(sb.String(), ""), summary)
 	return err
 }
 

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -307,7 +307,7 @@ func (tr CompactReporter) Publish(_ context.Context, r report.Report) error {
 		pluralViolations = "s"
 	}
 
-	summary := fmt.Sprintf("%d file%s linted , %d violation%s found. \n",
+	summary := fmt.Sprintf("%d file%s linted , %d violation%s found.",
 		r.Summary.FilesScanned, pluralScanned,
 		r.Summary.NumViolations, pluralViolations)
 	// rendering the table

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -165,8 +165,9 @@ func TestCompactReporterPublish(t *testing.T) {
 | a.rego:1:1   | Rego must not break the law! |
 | b.rego:22:18 | Questionable decision found  |
 +--------------+------------------------------+
-
+ 3 files linted , 2 violations found.
 `
+
 	if buf.String() != expect {
 		t.Errorf("expected %s, got %s", expect, buf.String())
 	}


### PR DESCRIPTION
ref: #1364 

Thanks to @anderseknert  for guiding me on this.

heres how the copmact reoprt looked like before :

![image](https://github.com/user-attachments/assets/f2d9bda1-acea-4ec5-b6b2-91e879c31625)


heres what it will look like now :



![Screenshot From 2025-01-25 22-32-40](https://github.com/user-attachments/assets/3ddc9e29-b35b-41ba-902c-8b4b75c77c8f)


special mention to my roomates who dont have a github, for choosing which one of the styles looked better.
