### PR TITLE
lsp: Use nested workspace configuration if found

### DIFF
--- a/internal/lsp/config/find.go
+++ b/internal/lsp/config/find.go
@@ -10,7 +10,7 @@ import (
 // FindConfigRoots will search for all config roots in the given path. A config
 // root is a directory that contains a .regal.yaml file or a .regal/config.yaml
 // file. This is intended to be used to by the language server when determining
-// the most suitable workspace root for the server to operate on.
+// the most suitable config root for the server to operate on.
 func FindConfigRoots(path string) ([]string, error) {
 	var foundRoots []string
 

--- a/internal/lsp/config/find.go
+++ b/internal/lsp/config/find.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FindConfigRoots will search for all config roots in the given path. A config
+// root is a directory that contains a .regal.yaml file or a .regal/config.yaml
+// file. This is intended to be used to by the language server when determining
+// the most suitable workspace root for the server to operate on.
+func FindConfigRoots(path string) ([]string, error) {
+	var foundRoots []string
+
+	err := filepath.WalkDir(path, func(path string, info os.DirEntry, _ error) error {
+		if info.IsDir() || !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+
+		if filepath.Base(path) == ".regal.yaml" {
+			foundRoots = append(foundRoots, filepath.Dir(path))
+		}
+
+		if strings.HasSuffix(path, ".regal/config.yaml") {
+			foundRoots = append(foundRoots, filepath.Dir(filepath.Dir(path)))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to walk directory: %w", err)
+	}
+
+	return foundRoots, nil
+}

--- a/internal/lsp/config/find_test.go
+++ b/internal/lsp/config/find_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"cmp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/util/test"
+)
+
+func TestFindConfigRoots(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		FS       map[string]string
+		Expected []string
+	}{
+		"no config roots": {
+			FS:       map[string]string{},
+			Expected: []string{},
+		},
+		"single config root at root": {
+			FS: map[string]string{
+				".regal/config.yaml": "",
+			},
+			Expected: []string{"/"},
+		},
+		"single config root at root with .regal.yaml": {
+			FS: map[string]string{
+				".regal.yaml": "",
+			},
+			Expected: []string{"/"},
+		},
+		"two config roots, one higher": {
+			FS: map[string]string{
+				".regal/config.yaml": "",
+				"foo/.regal.yaml":    "",
+			},
+			Expected: []string{
+				"/",
+				"/foo",
+			},
+		},
+		"two config roots, one higher, not in root dir": {
+			FS: map[string]string{
+				"foo/.regal.yaml":            "",
+				"bar/baz/.regal/config.yaml": "",
+			},
+			Expected: []string{
+				"/bar/baz",
+				"/foo",
+			},
+		},
+		"two config roots, equal depth": {
+			FS: map[string]string{
+				"bar/.regal/config.yaml": "",
+				"foo/.regal.yaml":        "",
+			},
+			Expected: []string{
+				"/bar",
+				"/foo",
+			},
+		},
+	}
+
+	for testName, testData := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+			test.WithTempFS(testData.FS, func(root string) {
+				got, err := FindConfigRoots(root)
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+
+				gotTrimmed := make([]string, len(got))
+
+				for i, path := range got {
+					trimmed := cmp.Or(strings.TrimPrefix(path, root), "/")
+					gotTrimmed[i] = trimmed
+				}
+
+				if !slices.Equal(gotTrimmed, testData.Expected) {
+					t.Fatalf("Expected %v, got %v", testData.Expected, gotTrimmed)
+				}
+			})
+		})
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2467,7 +2467,8 @@ func (l *LanguageServer) handleWorkspaceDidChangeWatchedFiles(
 ) (any, error) {
 	// this handles the case of a new config file being created when one did
 	// not exist before
-	if len(params.Changes) > 0 && strings.HasSuffix(params.Changes[0].URI, ".regal/config.yaml") {
+	if len(params.Changes) > 0 && (strings.HasSuffix(params.Changes[0].URI, ".regal/config.yaml") ||
+		strings.HasSuffix(params.Changes[0].URI, ".regal.yaml")) {
 		configFile, err := config.FindConfig(l.workspacePath())
 		if err == nil {
 			l.configWatcher.Watch(configFile.Name())

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2203,10 +2203,42 @@ func (l *LanguageServer) handleWorkspaceDiagnostic() (any, error) {
 }
 
 func (l *LanguageServer) handleInitialize(ctx context.Context, params types.InitializeParams) (any, error) {
+	l.clientIdentifier = clients.DetermineClientIdentifier(params.ClientInfo.Name)
+
 	// params.RootURI is not expected to have a trailing slash, but if one is
 	// present it will be removed for consistency.
-	l.workspaceRootURI = strings.TrimSuffix(params.RootURI, rio.PathSeparator)
-	l.clientIdentifier = clients.DetermineClientIdentifier(params.ClientInfo.Name)
+	rootURI := strings.TrimSuffix(params.RootURI, rio.PathSeparator)
+
+	if rootURI == "" {
+		return nil, errors.New("rootURI was not set by the client but is required")
+	}
+
+	workspaceRootPath := uri.ToPath(l.clientIdentifier, rootURI)
+
+	configRoots, err := lsconfig.FindConfigRoots(workspaceRootPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find config roots: %w", err)
+	}
+
+	l.workspaceRootURI = rootURI
+
+	switch {
+	case len(configRoots) > 1:
+		l.logf(
+			log.LevelMessage,
+			"warning: multiple config roots found in workspace:\n%s\nusing %q as root",
+			strings.Join(configRoots, "\n"),
+			configRoots[0],
+		)
+
+		l.workspaceRootURI = uri.FromPath(l.clientIdentifier, configRoots[0])
+	case len(configRoots) == 1:
+		l.logf(log.LevelMessage, "using workspace directory %q as root", configRoots[0])
+
+		l.workspaceRootURI = uri.FromPath(l.clientIdentifier, configRoots[0])
+	default:
+		l.logf(log.LevelMessage, "using supplied root: %q, config may be inherited from parent directory", workspaceRootPath)
+	}
 
 	if l.clientIdentifier == clients.IdentifierGeneric {
 		l.logf(


### PR DESCRIPTION
This makes the configuration for the server closer to the configuration for the lint command. A config directory or file found within the
    client-supplied workspace root is used instead of only searching
    upwards.

If more than one .regal* root is found within the dir, then the first is used. Ideally, we'd support many different config files but this is harder to implement.

If none are found, then the previous behavior of searching upwards is used.


Fixes https://github.com/StyraInc/regal/issues/1365
