### PR TITLE
Don't return error from `regal.last`

### DIFF
--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -2,7 +2,6 @@
 package builtins
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/anderseknert/roast/pkg/encoding"
@@ -86,8 +85,6 @@ func RegalParseModule(_ rego.BuiltinContext, filename *ast.Term, policy *ast.Ter
 	return term, nil
 }
 
-var errAiob = errors.New("array index out of bounds")
-
 // RegalLast regal.last returns the last element of an array.
 func RegalLast(_ rego.BuiltinContext, arr *ast.Term) (*ast.Term, error) {
 	arrOp, err := builtins.ArrayOperand(arr.Value, 1)
@@ -95,11 +92,13 @@ func RegalLast(_ rego.BuiltinContext, arr *ast.Term) (*ast.Term, error) {
 		return nil, err
 	}
 
-	if arrOp.Len() == 0 {
-		return nil, errAiob
+	if arrOp.Len() > 0 {
+		return arrOp.Elem(arrOp.Len() - 1), nil
 	}
 
-	return arrOp.Elem(arrOp.Len() - 1), nil
+	// index out of bounds, but returning an error allocates
+	// and we have no use for this information anyway.
+	return nil, nil //nolint:nilnil
 }
 
 // TestContextBuiltins returns the list of builtins as expected by the test runner.


### PR DESCRIPTION
Not so much about performance this time (although of course, it saves a handful of allocations ;) but the fact that it's occasionally helpful to check the strict built-in errors logged. Since this built-in is frequently called on empty arrays, this is noisy.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->