### PR TITLE
config: Use global user config if required

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,8 +403,8 @@ project:
 Regal will automatically search for a configuration file (`.regal/config.yaml`
 or `.regal.yaml`) in the current directory, and if not found, traverse the
 parent directories either until either one is found, or the top of the directory
-hierarchy is reached. If no configuration file is found, Regal will use the
-default configuration.
+hierarchy is reached. If no configuration file is found, and no file is found at
+`~/.config/regal/config.yaml` either, Regal will use the default configuration.
 
 A custom configuration may be also be provided using the `--config-file`/`-c`
 option for `regal lint`, which when provided will be used to override the

--- a/README.md
+++ b/README.md
@@ -410,6 +410,19 @@ A custom configuration may be also be provided using the `--config-file`/`-c`
 option for `regal lint`, which when provided will be used to override the
 default configuration.
 
+### User-level Configuration
+
+Generally, users will want to commit their Regal configuration file to the repo
+containing their Rego source code. This allows configurations to be shared
+among team members and makes the configuration options available to Regal when
+running as a [CI linter](https://docs.styra.com/regal/cicd) too.
+
+Sometimes however it can be handy to have some user defaults when a project
+configuration file is not found, hasn't been created yet or is not applicable.
+
+In such cases Regal will check for a configuration file at
+`~/.config/regal/config.yaml` instead.
+
 ## Ignoring Rules
 
 If one of Regal's rules doesn't align with your team's preferences, don't worry! Regal is not meant to be the law,

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -362,7 +362,7 @@ func updateCheckAndWarn(params *lintCommandParams, regalRules *bundle.Bundle, us
 			CurrentVersion: version.Version,
 			CurrentTime:    time.Now().UTC(),
 			Debug:          params.debug,
-			StateDir:       config.GlobalDir(),
+			StateDir:       config.GlobalConfigDir(true),
 		}, os.Stderr)
 	}
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/styrainc/regal/pkg/config"
@@ -27,6 +28,20 @@ func readUserConfig(params configFileParams, searchPath string) (userConfig *os.
 		}
 
 		userConfig, err = config.FindConfig(searchPath)
+	}
+
+	// if there is no config found, attempt to load the user's global config if
+	// it exists
+	if err != nil {
+		globalConfigDir := config.GlobalConfigDir(false)
+		if globalConfigDir != "" {
+			globalConfigFile := filepath.Join(globalConfigDir, "config.yaml")
+
+			userConfig, err = os.Open(globalConfigFile)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open global config file %w", err)
+			}
+		}
 	}
 
 	return userConfig, err //nolint:wrapcheck

--- a/pkg/config/global.go
+++ b/pkg/config/global.go
@@ -5,10 +5,11 @@ import (
 	"path/filepath"
 )
 
-// GlobalDir is the config directory that will be used for user-wide configuration.
-// This is different from the .regal directories that are searched for when
-// linting.
-func GlobalDir() string {
+// GlobalConfigDir is the config directory that will be used for user-wide
+// configuration. This is different from the .regal directories that are
+// searched for when linting. If create is false, the function will return an
+// empty string if the directory does not exist.
+func GlobalConfigDir(create bool) string {
 	cfgDir, err := os.UserHomeDir()
 	if err != nil {
 		return ""
@@ -16,6 +17,10 @@ func GlobalDir() string {
 
 	regalDir := filepath.Join(cfgDir, ".config", "regal")
 	if _, err := os.Stat(regalDir); os.IsNotExist(err) {
+		if !create {
+			return ""
+		}
+
 		if err := os.Mkdir(regalDir, os.ModePerm); err != nil {
 			return ""
 		}


### PR DESCRIPTION
If a config file is not found in a parent of the workspace, then we attempt to load the user's global default file instead.

Fixes https://github.com/StyraInc/regal/issues/1075

<img width="749" alt="Screenshot 2025-01-29 at 14 23 56" src="https://github.com/user-attachments/assets/8884e225-c8af-48b1-b4c4-b5743cba0102" />

LS will also log the location of the file used.
<img width="1511" alt="Screenshot 2025-01-29 at 14 22 10" src="https://github.com/user-attachments/assets/135fbd13-15cd-4e17-9095-96d327b9ea10" />

