### PR TITLE
fix: non-raw regex pattern

### DIFF
--- a/bundle/regal/lsp/codelens/codelens.rego
+++ b/bundle/regal/lsp/codelens/codelens.rego
@@ -33,7 +33,7 @@ _eval_lenses contains {
 	},
 }
 
-_eval_lenses contains _rule_lens(rule, "regal.eval", "Evaluate") if {
+_eval_lenses contains _rule_lens(input.regal.file.name, rule, "regal.eval", "Evaluate") if {
 	some rule in ast.rules
 }
 
@@ -50,20 +50,20 @@ _debug_lenses contains {
 	},
 }
 
-_debug_lenses contains _rule_lens(rule, "regal.debug", "Debug") if {
+_debug_lenses contains _rule_lens(input.regal.file.name, rule, "regal.debug", "Debug") if {
 	some rule in ast.rules
 
 	# no need to add a debug lens for a rule like `pi := 3.14`
 	not _unconditional_constant(rule)
 }
 
-_rule_lens(rule, command, title) := {
+_rule_lens(filename, rule, command, title) := {
 	"range": location.to_range(result.location(rule).location),
 	"command": {
 		"title": title,
 		"command": command,
 		"arguments": [json.marshal({
-			"target": input.regal.file.name,
+			"target": filename,
 			"path": sprintf("%s.%s", [ast.ref_to_string(input["package"].path), ast.ref_static_to_string(rule.head.ref)]),
 			"row": util.to_location_object(rule.head.location).row,
 		})],

--- a/bundle/regal/lsp/codelens/codelens.rego
+++ b/bundle/regal/lsp/codelens/codelens.rego
@@ -25,11 +25,11 @@ _eval_lenses contains {
 	"command": {
 		"title": "Evaluate",
 		"command": "regal.eval",
-		"arguments": [
-			input.regal.file.name,
-			ast.ref_to_string(input["package"].path),
-			util.to_location_object(input["package"].location).row,
-		],
+		"arguments": [json.marshal({
+			"target": input.regal.file.name,
+			"path": ast.ref_to_string(input["package"].path),
+			"row": util.to_location_object(input["package"].location).row,
+		})],
 	},
 }
 
@@ -42,11 +42,11 @@ _debug_lenses contains {
 	"command": {
 		"title": "Debug",
 		"command": "regal.debug",
-		"arguments": [
-			input.regal.file.name,
-			ast.ref_to_string(input["package"].path),
-			util.to_location_object(input["package"].location).row,
-		],
+		"arguments": [json.marshal({
+			"target": input.regal.file.name,
+			"path": ast.ref_to_string(input["package"].path),
+			"row": util.to_location_object(input["package"].location).row,
+		})],
 	},
 }
 
@@ -62,11 +62,11 @@ _rule_lens(rule, command, title) := {
 	"command": {
 		"title": title,
 		"command": command,
-		"arguments": [
-			input.regal.file.name, # regal ignore:external-reference
-			sprintf("%s.%s", [ast.ref_to_string(input["package"].path), ast.ref_static_to_string(rule.head.ref)]),
-			util.to_location_object(rule.head.location).row,
-		],
+		"arguments": [json.marshal({
+			"target": input.regal.file.name,
+			"path": sprintf("%s.%s", [ast.ref_to_string(input["package"].path), ast.ref_static_to_string(rule.head.ref)]),
+			"row": util.to_location_object(rule.head.location).row,
+		})],
 	},
 }
 

--- a/bundle/regal/lsp/codelens/codelens_test.rego
+++ b/bundle/regal/lsp/codelens/codelens_test.rego
@@ -18,7 +18,11 @@ test_code_lenses_for_module if {
 	lenses == [
 		{
 			"command": {
-				"arguments": ["policy.rego", "data.foo", 2],
+				"arguments": [json.marshal({
+					"target": "policy.rego",
+					"path": "data.foo",
+					"row": 2,
+				})],
 				"command": "regal.eval",
 				"title": "Evaluate",
 			},
@@ -26,7 +30,11 @@ test_code_lenses_for_module if {
 		},
 		{
 			"command": {
-				"arguments": ["policy.rego", "data.foo.rule1", 6],
+				"arguments": [json.marshal({
+					"target": "policy.rego",
+					"path": "data.foo.rule1",
+					"row": 6,
+				})],
 				"command": "regal.eval",
 				"title": "Evaluate",
 			},
@@ -34,14 +42,22 @@ test_code_lenses_for_module if {
 		},
 		{
 			"command": {
-				"arguments": ["policy.rego", "data.foo.rule2", 8],
+				"arguments": [json.marshal({
+					"target": "policy.rego",
+					"path": "data.foo.rule2",
+					"row": 8,
+				})],
 				"command": "regal.eval", "title": "Evaluate",
 			},
 			"range": {"end": {"character": 24, "line": 7}, "start": {"character": 1, "line": 7}},
 		},
 		{
 			"command": {
-				"arguments": ["policy.rego", "data.foo", 2],
+				"arguments": [json.marshal({
+					"target": "policy.rego",
+					"path": "data.foo",
+					"row": 2,
+				})],
 				"command": "regal.debug",
 				"title": "Debug",
 			},
@@ -49,7 +65,11 @@ test_code_lenses_for_module if {
 		},
 		{
 			"command": {
-				"arguments": ["policy.rego", "data.foo.rule2", 8],
+				"arguments": [json.marshal({
+					"target": "policy.rego",
+					"path": "data.foo.rule2",
+					"row": 8,
+				})],
 				"command": "regal.debug",
 				"title": "Debug",
 			},

--- a/docs/fixing.md
+++ b/docs/fixing.md
@@ -17,10 +17,11 @@ committing the fixes.
 Currently, the following rules are automatically fixable:
 
 - [opa-fmt](/regal/rules/style/opa-fmt)
-- [use-rego-v1](/regal/rules/imports/use-rego-v1)
+- [non-raw-regex-pattern](/regal/rules/idiomatic/non-raw-regex-pattern)
 - [use-assignment-operator](/regal/rules/style/use-assignment-operator)
 - [no-whitespace-comment](/regal/rules/style/no-whitespace-comment)
 - [directory-package-mismatch](https://docs.styra.com/regal/rules/idiomatic/directory-package-mismatch)
+- [use-rego-v1](/regal/rules/imports/use-rego-v1) (v0 Rego only)
 
 So, how do you go on about automatically fixing reported violations?
 
@@ -79,15 +80,15 @@ Example of code action in VS Code, where available fixes can be listed either by
 right, or by clicking "Quick Fix..." in the tooltip window:
 
 <img
-  src={require('./assets/lsp/code_action_show.png').default}
-  alt="Screenshot of code action displayed in VS Code"/>
+src={require('./assets/lsp/code_action_show.png').default}
+alt="Screenshot of code action displayed in VS Code"/>
 
 Example of suggested Code Action for the
 [use-assignment-operator](https://docs.styra.com/regal/rules/style/use-assignment-operator) rule. Click to fix!
 
 <img
-  src={require('./assets/lsp/code_action_fix.png').default}
-  alt="Screenshot of code action fix suggestion displayed in VS Code"/>
+src={require('./assets/lsp/code_action_fix.png').default}
+alt="Screenshot of code action fix suggestion displayed in VS Code"/>
 
 ### Limitations
 

--- a/docs/rules/idiomatic/non-raw-regex-pattern.md
+++ b/docs/rules/idiomatic/non-raw-regex-pattern.md
@@ -4,6 +4,8 @@
 
 **Category**: Idiomatic
 
+**Automatically fixable**: [Yes](/regal/fixing)
+
 **Avoid**
 ```rego
 all_digits if {

--- a/internal/lsp/command.go
+++ b/internal/lsp/command.go
@@ -1,8 +1,13 @@
 package lsp
 
-import "github.com/styrainc/regal/internal/lsp/types"
+import (
+	"encoding/json"
 
-func toAnySlice(a []string) *[]any {
+	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/internal/util"
+)
+
+func toAnySlice(a ...string) *[]any {
 	b := make([]any, len(a))
 	for i := range a {
 		b[i] = a[i]
@@ -11,47 +16,89 @@ func toAnySlice(a []string) *[]any {
 	return &b
 }
 
-func FmtCommand(args []string) types.Command {
+type commandArgs struct {
+	Target     string            `json:"target"`
+	Diagnostic *types.Diagnostic `json:"diagnostic,omitempty"`
+}
+
+func FmtCommand(target string) types.Command {
+	bs := util.Must(json.Marshal(commandArgs{
+		Target: target,
+	}))
+
 	return types.Command{
 		Title:     "Format using opa-fmt",
 		Command:   "regal.fix.opa-fmt",
 		Tooltip:   "Format using opa-fmt",
-		Arguments: toAnySlice(args),
+		Arguments: toAnySlice(string(bs)),
 	}
 }
 
-func FmtV1Command(args []string) types.Command {
+func FmtV1Command(target string) types.Command {
+	bs := util.Must(json.Marshal(commandArgs{
+		Target: target,
+	}))
+
 	return types.Command{
 		Title:     "Format for Rego v1 using opa-fmt",
 		Command:   "regal.fix.use-rego-v1",
 		Tooltip:   "Format for Rego v1 using opa-fmt",
-		Arguments: toAnySlice(args),
+		Arguments: toAnySlice(string(bs)),
 	}
 }
 
-func UseAssignmentOperatorCommand(args []string) types.Command {
+func UseAssignmentOperatorCommand(target string, diag types.Diagnostic) types.Command {
+	bs := util.Must(json.Marshal(commandArgs{
+		Target:     target,
+		Diagnostic: &diag,
+	}))
+
 	return types.Command{
 		Title:     "Replace = with := in assignment",
 		Command:   "regal.fix.use-assignment-operator",
 		Tooltip:   "Replace = with := in assignment",
-		Arguments: toAnySlice(args),
+		Arguments: toAnySlice(string(bs)),
 	}
 }
 
-func NoWhiteSpaceCommentCommand(args []string) types.Command {
+func NoWhiteSpaceCommentCommand(target string, diag types.Diagnostic) types.Command {
+	bs := util.Must(json.Marshal(commandArgs{
+		Target:     target,
+		Diagnostic: &diag,
+	}))
+
 	return types.Command{
 		Title:     "Format comment to have leading whitespace",
 		Command:   "regal.fix.no-whitespace-comment",
 		Tooltip:   "Format comment to have leading whitespace",
-		Arguments: toAnySlice(args),
+		Arguments: toAnySlice(string(bs)),
 	}
 }
 
-func DirectoryStructureMismatchCommand(args []string) types.Command {
+func DirectoryStructureMismatchCommand(target string, diag types.Diagnostic) types.Command {
+	bs := util.Must(json.Marshal(commandArgs{
+		Target:     target,
+		Diagnostic: &diag,
+	}))
+
 	return types.Command{
 		Title:     "Fix directory structure / package path mismatch",
 		Command:   "regal.fix.directory-package-mismatch",
 		Tooltip:   "Fix directory structure / package path mismatch",
-		Arguments: toAnySlice(args),
+		Arguments: toAnySlice(string(bs)),
+	}
+}
+
+func NonRawRegexPatternCommand(target string, diag types.Diagnostic) types.Command {
+	bs := util.Must(json.Marshal(commandArgs{
+		Target:     target,
+		Diagnostic: &diag,
+	}))
+
+	return types.Command{
+		Title:     "Replace \" with ` in regex pattern",
+		Command:   "regal.fix.non-raw-regex-pattern",
+		Tooltip:   "Replace \" with ` in regex pattern",
+		Arguments: toAnySlice(string(bs)),
 	}
 }

--- a/internal/lsp/command.go
+++ b/internal/lsp/command.go
@@ -1,7 +1,7 @@
 package lsp
 
 import (
-	"encoding/json"
+	"github.com/anderseknert/roast/pkg/encoding"
 
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/util"
@@ -22,7 +22,7 @@ type commandArgs struct {
 }
 
 func FmtCommand(target string) types.Command {
-	bs := util.Must(json.Marshal(commandArgs{
+	bs := util.Must(encoding.JSON().Marshal(commandArgs{
 		Target: target,
 	}))
 
@@ -35,7 +35,7 @@ func FmtCommand(target string) types.Command {
 }
 
 func FmtV1Command(target string) types.Command {
-	bs := util.Must(json.Marshal(commandArgs{
+	bs := util.Must(encoding.JSON().Marshal(commandArgs{
 		Target: target,
 	}))
 
@@ -48,7 +48,7 @@ func FmtV1Command(target string) types.Command {
 }
 
 func UseAssignmentOperatorCommand(target string, diag types.Diagnostic) types.Command {
-	bs := util.Must(json.Marshal(commandArgs{
+	bs := util.Must(encoding.JSON().Marshal(commandArgs{
 		Target:     target,
 		Diagnostic: &diag,
 	}))
@@ -62,7 +62,7 @@ func UseAssignmentOperatorCommand(target string, diag types.Diagnostic) types.Co
 }
 
 func NoWhiteSpaceCommentCommand(target string, diag types.Diagnostic) types.Command {
-	bs := util.Must(json.Marshal(commandArgs{
+	bs := util.Must(encoding.JSON().Marshal(commandArgs{
 		Target:     target,
 		Diagnostic: &diag,
 	}))
@@ -76,7 +76,7 @@ func NoWhiteSpaceCommentCommand(target string, diag types.Diagnostic) types.Comm
 }
 
 func DirectoryStructureMismatchCommand(target string, diag types.Diagnostic) types.Command {
-	bs := util.Must(json.Marshal(commandArgs{
+	bs := util.Must(encoding.JSON().Marshal(commandArgs{
 		Target:     target,
 		Diagnostic: &diag,
 	}))
@@ -90,7 +90,7 @@ func DirectoryStructureMismatchCommand(target string, diag types.Diagnostic) typ
 }
 
 func NonRawRegexPatternCommand(target string, diag types.Diagnostic) types.Command {
-	bs := util.Must(json.Marshal(commandArgs{
+	bs := util.Must(encoding.JSON().Marshal(commandArgs{
 		Target:     target,
 		Diagnostic: &diag,
 	}))

--- a/internal/lsp/command_test.go
+++ b/internal/lsp/command_test.go
@@ -1,0 +1,52 @@
+package lsp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+func TestUseAssignmentOperatorCommand(t *testing.T) {
+	t.Parallel()
+
+	target := "file:///example.rego"
+	diag := types.Diagnostic{
+		Code:    "use-assignment-operator",
+		Message: "Replace = with := in assignment",
+	}
+
+	expectedArgs, err := json.Marshal(commandArgs{Target: target, Diagnostic: &diag})
+	if err != nil {
+		t.Fatalf("Unexpected error marshalling command arguments: %s", err)
+	}
+
+	expectedCommand := types.Command{
+		Title:     "Replace = with := in assignment",
+		Command:   "regal.fix.use-assignment-operator",
+		Tooltip:   "Replace = with := in assignment",
+		Arguments: toAnySlice(string(expectedArgs)),
+	}
+
+	result := UseAssignmentOperatorCommand(target, diag)
+
+	if exp, got := expectedCommand.Title, result.Title; exp != got {
+		t.Fatalf("Expected Title %q, got %q", exp, got)
+	}
+
+	if exp, got := expectedCommand.Command, result.Command; exp != got {
+		t.Fatalf("Expected Command %q, got %q", exp, got)
+	}
+
+	if exp, got := expectedCommand.Tooltip, result.Tooltip; exp != got {
+		t.Fatalf("Expected Tooltip %q, got %q", exp, got)
+	}
+
+	if exp, got := len(*expectedCommand.Arguments), len(*result.Arguments); exp != got {
+		t.Fatalf("Expected %d arguments, got %d", exp, got)
+	}
+
+	if exp, got := (*expectedCommand.Arguments)[0], (*result.Arguments)[0]; exp != got {
+		t.Fatalf("Expected argument \n%s\n%s", exp, got)
+	}
+}

--- a/internal/lsp/commands/parse.go
+++ b/internal/lsp/commands/parse.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/open-policy-agent/opa/v1/ast"
-
 	"github.com/styrainc/regal/internal/lsp/types"
+	"github.com/styrainc/regal/pkg/report"
 )
 
 type ParseOptions struct {
@@ -17,7 +16,7 @@ type ParseOptions struct {
 }
 
 type ParseResult struct {
-	Location *ast.Location
+	Location *report.Location
 	Target   string
 }
 
@@ -42,7 +41,7 @@ func Parse(params types.ExecuteCommandParams, opts ParseOptions) (*ParseResult, 
 		}, nil
 	}
 
-	var loc *ast.Location
+	var loc *report.Location
 
 	if opts.RowArgIndex < len(params.Arguments) && opts.ColArgIndex < len(params.Arguments) {
 		var row, col int
@@ -75,9 +74,9 @@ func Parse(params types.ExecuteCommandParams, opts ParseOptions) (*ParseResult, 
 			return nil, fmt.Errorf("unexpected type for col: %T", params.Arguments[opts.ColArgIndex])
 		}
 
-		loc = &ast.Location{
-			Row: row,
-			Col: col,
+		loc = &report.Location{
+			Row:    row,
+			Column: col,
 		}
 	}
 

--- a/internal/lsp/commands/parse_test.go
+++ b/internal/lsp/commands/parse_test.go
@@ -35,6 +35,15 @@ func TestParse(t *testing.T) {
 			ExpectedTarget:   "target",
 			ExpectedLocation: &ast.Location{Row: 1, Col: 2},
 		},
+		"extract from JSON": {
+			ExecuteCommandParams: types.ExecuteCommandParams{
+				Command:   "example",
+				Arguments: []interface{}{"target", "1", 2}, // different types for testing, but should be strings
+			},
+			ParseOptions:     ParseOptions{TargetArgIndex: 0, RowArgIndex: 1, ColArgIndex: 2},
+			ExpectedTarget:   "target",
+			ExpectedLocation: &ast.Location{Row: 1, Col: 2},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -63,8 +72,8 @@ func TestParse(t *testing.T) {
 					t.Fatalf("expected row %d, got %d", tc.ExpectedLocation.Row, result.Location.Row)
 				}
 
-				if result.Location.Col != tc.ExpectedLocation.Col {
-					t.Fatalf("expected col %d, got %d", tc.ExpectedLocation.Col, result.Location.Col)
+				if result.Location.Column != tc.ExpectedLocation.Col {
+					t.Fatalf("expected col %d, got %d", tc.ExpectedLocation.Col, result.Location.Column)
 				}
 			}
 		})

--- a/internal/lsp/handle_text_document_code_action_test.go
+++ b/internal/lsp/handle_text_document_code_action_test.go
@@ -1,0 +1,83 @@
+package lsp
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/styrainc/regal/internal/lsp/clients"
+	"github.com/styrainc/regal/internal/lsp/types"
+)
+
+func TestHandleTextDocumentCodeAction(t *testing.T) {
+	t.Parallel()
+
+	l := &LanguageServer{clientIdentifier: clients.IdentifierGeneric}
+
+	uri := "file:///example.rego"
+
+	diag := types.Diagnostic{
+		Code:    ruleNameUseAssignmentOperator,
+		Message: "foobar",
+		Range: types.Range{
+			Start: types.Position{Line: 2, Character: 4},
+			End:   types.Position{Line: 2, Character: 10},
+		},
+	}
+
+	params := types.CodeActionParams{
+		TextDocument: types.TextDocumentIdentifier{
+			URI: uri,
+		},
+		Context: types.CodeActionContext{
+			Diagnostics: []types.Diagnostic{diag},
+		},
+	}
+
+	expectedAction := types.CodeAction{
+		Title:       "Replace = with := in assignment",
+		Kind:        "quickfix",
+		Diagnostics: params.Context.Diagnostics,
+		IsPreferred: truePtr,
+		Command:     UseAssignmentOperatorCommand(uri, diag),
+	}
+
+	result, err := l.handleTextDocumentCodeAction(params)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	actions, ok := result.([]types.CodeAction)
+	if !ok {
+		t.Errorf("Expected result to be of type []types.CodeAction, got %T", result)
+	}
+
+	if exp, got := 1, len(actions); exp != got {
+		t.Fatalf("Expected %d action, got %d", exp, got)
+	}
+
+	actualAction := actions[0]
+
+	if exp, got := expectedAction.Title, actualAction.Title; exp != got {
+		t.Fatalf("expected Title %q, got %q", exp, got)
+	}
+
+	if exp, got := expectedAction.Kind, actualAction.Kind; exp != got {
+		t.Fatalf("expected Kind %q, got %q", exp, got)
+	}
+
+	if exp, got := len(expectedAction.Diagnostics), len(actualAction.Diagnostics); exp != got {
+		t.Fatalf("expected %d diagnostics, got %d", exp, got)
+	}
+
+	if exp, got := *expectedAction.IsPreferred, *actualAction.IsPreferred; actualAction.IsPreferred == nil || exp != got {
+		t.Fatalf("expected IsPreferred to be %v, got %v", exp, actualAction.IsPreferred)
+	}
+
+	if exp, got := expectedAction.Command.Command, actualAction.Command.Command; exp != got {
+		t.Fatalf("expected Command %q, got %q", exp, got)
+	}
+
+	if exp, got := *expectedAction.Command.Arguments, *actualAction.Command.Arguments; !slices.Equal(exp, got) {
+		t.Fatalf("expected Arguments %v, got %v", exp, got)
+	}
+}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1211,11 +1211,11 @@ func (l *LanguageServer) fixEditParams(
 	if args.Diagnostic != nil {
 		rto.Locations = []report.Location{
 			{
-				Row:    int(args.Diagnostic.Range.Start.Line + 1),
-				Column: int(args.Diagnostic.Range.Start.Character + 1),
+				Row:    util.SafeUintToInt(args.Diagnostic.Range.Start.Line + 1),
+				Column: util.SafeUintToInt(args.Diagnostic.Range.Start.Character + 1),
 				End: &report.Position{
-					Row:    int(args.Diagnostic.Range.End.Line + 1),
-					Column: int(args.Diagnostic.Range.End.Character + 1),
+					Row:    util.SafeUintToInt(args.Diagnostic.Range.End.Line + 1),
+					Column: util.SafeUintToInt(args.Diagnostic.Range.End.Character + 1),
 				},
 			},
 		}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -216,4 +217,14 @@ func DirCleanUpPaths(target string, preserve []string) ([]string, error) {
 	}
 
 	return dirs, nil
+}
+
+// SafeUintToInt will convert a uint to an int, clamping the result to
+// math.MaxInt.
+func SafeUintToInt(u uint) int {
+	if u > math.MaxInt {
+		return math.MaxInt // Clamp to prevent overflow
+	}
+
+	return int(u)
 }

--- a/pkg/fixer/fixer.go
+++ b/pkg/fixer/fixer.go
@@ -164,11 +164,8 @@ func (f *Fixer) FixViolations(
 		fixResults, err := fixInstance.Fix(&fixCandidate, &fixes.RuntimeOptions{
 			BaseDir: util.FindClosestMatchingRoot(abs, f.registeredRoots),
 			Config:  config,
-			Locations: []ast.Location{
-				{
-					Row: violation.Location.Row,
-					Col: violation.Location.Column,
-				},
+			Locations: []report.Location{
+				violation.Location,
 			},
 		})
 		if err != nil {
@@ -341,11 +338,8 @@ func (f *Fixer) applyLinterFixes(
 			fixResults, err := fixInstance.Fix(&fixCandidate, &fixes.RuntimeOptions{
 				BaseDir: util.FindClosestMatchingRoot(abs, f.registeredRoots),
 				Config:  config,
-				Locations: []ast.Location{
-					{
-						Row: violation.Location.Row,
-						Col: violation.Location.Column,
-					},
+				Locations: []report.Location{
+					violation.Location,
 				},
 			})
 			if err != nil {

--- a/pkg/fixer/fixes/fixes.go
+++ b/pkg/fixer/fixes/fixes.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/styrainc/regal/internal/lsp/clients"
 	"github.com/styrainc/regal/pkg/config"
+	"github.com/styrainc/regal/pkg/report"
 )
 
 // NewDefaultFixes returns a list of default fixes that are applied by the fix command.
@@ -20,6 +21,7 @@ func NewDefaultFixes() []Fix {
 		&UseAssignmentOperator{},
 		&NoWhitespaceComment{},
 		&DirectoryPackageMismatch{},
+		&NonRawRegexPattern{},
 	}
 }
 
@@ -30,6 +32,7 @@ func NewDefaultFormatterFixes() []Fix {
 		&Fmt{},
 		&UseAssignmentOperator{},
 		&NoWhitespaceComment{},
+		&NonRawRegexPattern{},
 	}
 }
 
@@ -48,7 +51,7 @@ type RuntimeOptions struct {
 	// BaseDir is the base directory for the files being fixed. This is often the same as the
 	// workspace root directory, but not necessarily.
 	BaseDir   string
-	Locations []ast.Location
+	Locations []report.Location
 	Client    clients.Identifier
 }
 

--- a/pkg/fixer/fixes/nonrawregexpattern.go
+++ b/pkg/fixer/fixes/nonrawregexpattern.go
@@ -47,7 +47,11 @@ func (u *NonRawRegexPattern) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixR
 			fileChanged = true
 		}
 
-		lines[loc.Row-1] = string(line)
+		// Replace "\\" with "\" between startIdx and endIdx
+		segment := strings.ReplaceAll(string(line[startIdx:endIdx]), `\\`, `\`)
+		replacement := []rune(segment)
+
+		lines[loc.Row-1] = string(append(line[:startIdx], append(replacement, line[endIdx:]...)...))
 	}
 
 	if !fileChanged {

--- a/pkg/fixer/fixes/nonrawregexpattern.go
+++ b/pkg/fixer/fixes/nonrawregexpattern.go
@@ -1,0 +1,64 @@
+package fixes
+
+import (
+	"errors"
+	"strings"
+)
+
+type NonRawRegexPattern struct{}
+
+func (*NonRawRegexPattern) Name() string {
+	return "non-raw-regex-pattern"
+}
+
+func (u *NonRawRegexPattern) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]FixResult, error) {
+	if opts == nil {
+		return nil, errors.New("missing runtime options")
+	}
+
+	if len(opts.Locations) == 0 {
+		return []FixResult{}, nil
+	}
+
+	lines := strings.Split(fc.Contents, "\n")
+
+	fileChanged := false
+
+	for _, loc := range opts.Locations {
+		if loc.Row-1 < 0 || loc.Row-1 >= len(lines) {
+			continue
+		}
+
+		line := []rune(lines[loc.Row-1])
+		startIdx := loc.Column - 1
+		endIdx := loc.End.Column - 2
+
+		if startIdx < 0 || endIdx > len(line) || startIdx >= endIdx {
+			continue
+		}
+
+		if line[startIdx] == '"' {
+			line[startIdx] = '`'
+			fileChanged = true
+		}
+
+		if line[endIdx] == '"' {
+			line[endIdx] = '`'
+			fileChanged = true
+		}
+
+		lines[loc.Row-1] = string(line)
+	}
+
+	if !fileChanged {
+		return []FixResult{}, nil
+	}
+
+	newContents := strings.Join(lines, "\n")
+
+	return []FixResult{{
+		Title:    u.Name(),
+		Root:     opts.BaseDir,
+		Contents: newContents,
+	}}, nil
+}

--- a/pkg/fixer/fixes/nonrawregexpattern_test.go
+++ b/pkg/fixer/fixes/nonrawregexpattern_test.go
@@ -19,13 +19,13 @@ func TestNonRawRegexPattern(t *testing.T) {
 			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
 
 all_digits if {
-    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+    regex.match(` + "`" + `[\d]+` + "`" + `, "12345")
 }
 `},
 			contentAfterFix: `package test
 
 all_digits if {
-    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+    regex.match(` + "`" + `[\d]+` + "`" + `, "12345")
 }
 `,
 			fixExpected: false,
@@ -37,13 +37,13 @@ all_digits if {
 			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
 
 all_digits if {
-    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+    regex.match(` + "`" + `[\d]+` + "`" + `, "12345")
 }
 `},
 			contentAfterFix: `package test
 
 all_digits if {
-    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+    regex.match(` + "`" + `[\d]+` + "`" + `, "12345")
 }
 `,
 			fixExpected: false,
@@ -54,7 +54,7 @@ all_digits if {
 						Column: 17,
 						End: &report.Position{
 							Row:    4,
-							Column: 25,
+							Column: 24,
 						},
 					},
 				},
@@ -97,7 +97,7 @@ all_digits if {
 			contentAfterFix: `package test
 
 all_digits if {
-    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+    regex.match(` + "`" + `[\d]+` + "`" + `, "12345")
 }
 `,
 			fixExpected: true,
@@ -144,6 +144,41 @@ all_digits if {
 						End: &report.Position{
 							Row:    4,
 							Column: 27,
+						},
+					},
+				},
+			},
+		},
+		"two on one line with backslashes": {
+			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
+
+all_digits if {
+  set := { regex.match("\\d+", "1"), regex.match("\\d*", "2") }
+}
+`},
+			contentAfterFix: `package test
+
+all_digits if {
+  set := { regex.match(` + "`" + `\d+` + "`" + `, "1"), regex.match(` + "`" + `\d*` + "`" + `, "2") }
+}
+`,
+			fixExpected: true,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{
+					{
+						Row:    4,
+						Column: 50,
+						End: &report.Position{
+							Row:    4,
+							Column: 56,
+						},
+					},
+					{
+						Row:    4,
+						Column: 24,
+						End: &report.Position{
+							Row:    4,
+							Column: 30,
 						},
 					},
 				},

--- a/pkg/fixer/fixes/nonrawregexpattern_test.go
+++ b/pkg/fixer/fixes/nonrawregexpattern_test.go
@@ -1,0 +1,229 @@
+package fixes
+
+import (
+	"testing"
+
+	"github.com/styrainc/regal/pkg/report"
+)
+
+func TestNonRawRegexPattern(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		contentAfterFix string
+		fc              *FixCandidate
+		fixExpected     bool
+		runtimeOptions  *RuntimeOptions
+	}{
+		"none needed, no location": {
+			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
+
+all_digits if {
+    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+}
+`},
+			contentAfterFix: `package test
+
+all_digits if {
+    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+}
+`,
+			fixExpected: false,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{},
+			},
+		},
+		"none needed, but location given": {
+			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
+
+all_digits if {
+    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+}
+`},
+			contentAfterFix: `package test
+
+all_digits if {
+    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+}
+`,
+			fixExpected: false,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{
+					{
+						Row:    4,
+						Column: 17,
+						End: &report.Position{
+							Row:    4,
+							Column: 25,
+						},
+					},
+				},
+			},
+		},
+		"bad request, but location given": {
+			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
+
+all_digits if {
+	# this is a comment, not a violation of the rule
+}
+`},
+			contentAfterFix: `package test
+
+all_digits if {
+	# this is a comment, not a violation of the rule
+}
+`,
+			fixExpected: false,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{
+					{
+						Row:    4,
+						Column: 17,
+						End: &report.Position{
+							Row:    4,
+							Column: 25,
+						},
+					},
+				},
+			},
+		},
+		"simple case": {
+			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
+
+all_digits if {
+    regex.match("[\\d]+", "12345")
+}
+`},
+			contentAfterFix: `package test
+
+all_digits if {
+    regex.match(` + "`" + `[\\d]+` + "`" + `, "12345")
+}
+`,
+			fixExpected: true,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{
+					{
+						Row:    4,
+						Column: 17,
+						End: &report.Position{
+							Row:    4,
+							Column: 25,
+						},
+					},
+				},
+			},
+		},
+		"two on one line": {
+			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
+
+all_digits if {
+  set := { regex.match("*", "1"), regex.match("+", "2") }
+}
+`},
+			contentAfterFix: `package test
+
+all_digits if {
+  set := { regex.match(` + "`" + `*` + "`" + `, "1"), regex.match(` + "`" + `+` + "`" + `, "2") }
+}
+`,
+			fixExpected: true,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{
+					{
+						Row:    4,
+						Column: 47,
+						End: &report.Position{
+							Row:    4,
+							Column: 50,
+						},
+					},
+					{
+						Row:    4,
+						Column: 24,
+						End: &report.Position{
+							Row:    4,
+							Column: 27,
+						},
+					},
+				},
+			},
+		},
+		"two on separate lines": {
+			fc: &FixCandidate{Filename: "test.rego", Contents: `package test
+
+all_digits if {
+  set := {
+    regex.match("*", "1"),
+    regex.match("+", "2"),
+  }
+}
+`},
+			contentAfterFix: `package test
+
+all_digits if {
+  set := {
+    regex.match(` + "`" + `*` + "`" + `, "1"),
+    regex.match(` + "`" + `+` + "`" + `, "2"),
+  }
+}
+`,
+			fixExpected: true,
+			runtimeOptions: &RuntimeOptions{
+				Locations: []report.Location{
+					{
+						Row:    5,
+						Column: 17,
+						End: &report.Position{
+							Row:    5,
+							Column: 20,
+						},
+					},
+					{
+						Row:    6,
+						Column: 17,
+						End: &report.Position{
+							Row:    4,
+							Column: 20,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			f := NonRawRegexPattern{}
+
+			fixResults, err := f.Fix(tc.fc, tc.runtimeOptions)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !tc.fixExpected && len(fixResults) != 0 {
+				t.Fatalf("unexpected fix applied")
+			}
+
+			if !tc.fixExpected {
+				return
+			}
+
+			if len(fixResults) == 0 {
+				t.Fatalf("expected fix to be applied")
+			}
+
+			fixedContent := fixResults[0].Contents
+
+			if tc.fixExpected && fixedContent != tc.contentAfterFix {
+				t.Fatalf(
+					"unexpected content, got:\n%s---\nexpected:\n%s---",
+					fixedContent,
+					tc.contentAfterFix,
+				)
+			}
+		})
+	}
+}

--- a/pkg/fixer/fixes/nowhitespacecomment.go
+++ b/pkg/fixer/fixes/nowhitespacecomment.go
@@ -26,18 +26,18 @@ func (n *NoWhitespaceComment) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]Fix
 			continue
 		}
 
-		if loc.Col > len(lines[loc.Row-1]) || loc.Col < 1 {
+		if loc.Column > len(lines[loc.Row-1]) || loc.Column < 1 {
 			continue
 		}
 
 		line := lines[loc.Row-1]
 
 		// unexpected character at location column, skipping
-		if line[loc.Col-1] != byte('#') {
+		if line[loc.Column-1] != byte('#') {
 			continue
 		}
 
-		lines[loc.Row-1] = line[0:loc.Col] + " " + line[loc.Col:]
+		lines[loc.Row-1] = line[0:loc.Column] + " " + line[loc.Column:]
 		fixed = true
 	}
 

--- a/pkg/fixer/fixes/nowhitespacecomment_test.go
+++ b/pkg/fixer/fixes/nowhitespacecomment_test.go
@@ -3,7 +3,7 @@ package fixes
 import (
 	"testing"
 
-	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/styrainc/regal/pkg/report"
 )
 
 func TestNoWhitespaceComment(t *testing.T) {
@@ -27,10 +27,8 @@ func TestNoWhitespaceComment(t *testing.T) {
 
 # this is a comment
 `,
-			fixExpected: false,
-			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{},
-			},
+			fixExpected:    false,
+			runtimeOptions: &RuntimeOptions{},
 		},
 		"single change": {
 			fc: &FixCandidate{
@@ -46,10 +44,10 @@ func TestNoWhitespaceComment(t *testing.T) {
 `,
 			fixExpected: true,
 			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
+				Locations: []report.Location{
 					{
-						Row: 3,
-						Col: 1,
+						Row:    3,
+						Column: 1,
 					},
 				},
 			},
@@ -72,18 +70,18 @@ func TestNoWhitespaceComment(t *testing.T) {
 `,
 			fixExpected: true,
 			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
+				Locations: []report.Location{
 					{
-						Row: 3,
-						Col: 1,
+						Row:    3,
+						Column: 1,
 					},
 					{
-						Row: 4,
-						Col: 1,
+						Row:    4,
+						Column: 1,
 					},
 					{
-						Row: 5,
-						Col: 1,
+						Row:    5,
+						Column: 1,
 					},
 				},
 			},
@@ -106,18 +104,18 @@ func TestNoWhitespaceComment(t *testing.T) {
 `,
 			fixExpected: true,
 			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
+				Locations: []report.Location{
 					{
-						Row: 3,
-						Col: 1,
+						Row:    3,
+						Column: 1,
 					},
 					{
-						Row: 4,
-						Col: 2,
+						Row:    4,
+						Column: 2,
 					},
 					{
-						Row: 5,
-						Col: 3,
+						Row:    5,
+						Column: 3,
 					},
 				},
 			},

--- a/pkg/fixer/fixes/useassignmentoperator.go
+++ b/pkg/fixer/fixes/useassignmentoperator.go
@@ -27,16 +27,16 @@ func (u *UseAssignmentOperator) Fix(fc *FixCandidate, opts *RuntimeOptions) ([]F
 
 		line := lines[loc.Row-1]
 
-		if loc.Col-1 < 0 || loc.Col-1 >= len(line) {
+		if loc.Column-1 < 0 || loc.Column-1 >= len(line) {
 			continue
 		}
 
 		// unexpected character at location column, skipping
-		if line[loc.Col-1] != '=' {
+		if line[loc.Column-1] != '=' {
 			continue
 		}
 
-		lines[loc.Row-1] = line[0:loc.Col-1] + ":" + line[loc.Col-1:]
+		lines[loc.Row-1] = line[0:loc.Column-1] + ":" + line[loc.Column-1:]
 		fixed = true
 	}
 

--- a/pkg/fixer/fixes/useassignmentoperator_test.go
+++ b/pkg/fixer/fixes/useassignmentoperator_test.go
@@ -3,7 +3,7 @@ package fixes
 import (
 	"testing"
 
-	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/styrainc/regal/pkg/report"
 )
 
 func TestUseAssignmentOperator(t *testing.T) {
@@ -50,10 +50,10 @@ allow := true
 `,
 			fixExpected: true,
 			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
+				Locations: []report.Location{
 					{
-						Row: 3,
-						Col: 7,
+						Row:    3,
+						Column: 7,
 					},
 				},
 			},
@@ -72,10 +72,10 @@ allow = true
 `,
 			fixExpected: false,
 			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
+				Locations: []report.Location{
 					{
-						Row: 1,
-						Col: 1,
+						Row:    1,
+						Column: 1,
 					},
 				},
 			},
@@ -98,14 +98,14 @@ allow := true if { u = 2 }
 `,
 			fixExpected: true,
 			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
+				Locations: []report.Location{
 					{
-						Row: 3,
-						Col: 7,
+						Row:    3,
+						Column: 7,
 					},
 					{
-						Row: 5,
-						Col: 7,
+						Row:    5,
+						Column: 7,
 					},
 				},
 			},
@@ -128,18 +128,18 @@ allow := true
 `,
 			fixExpected: true,
 			runtimeOptions: &RuntimeOptions{
-				Locations: []ast.Location{
+				Locations: []report.Location{
 					{
-						Row: 3,
-						Col: 7,
+						Row:    3,
+						Column: 7,
 					},
 					{
-						Row: 4,
-						Col: 6,
+						Row:    4,
+						Column: 6,
 					},
 					{
-						Row: 5,
-						Col: 12,
+						Row:    5,
+						Column: 12,
 					},
 				},
 			},


### PR DESCRIPTION
Also update the lsp commands to support the end locations so that we can operate more accurately rather than guessing the end of the target range.

Fixes https://github.com/StyraInc/regal/issues/1380