### PR TITLE
Consistently use new `Set` type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,9 @@
     "${workspaceFolder}/bundle"
   ],
   "opa.strictMode": true,
-  "go.lintTool": "golangci-lint"
+  "go.lintTool": "golangci-lint",
+  "go.buildFlags": [
+    "-tags",
+    "e2e"
+  ]
 }

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -360,21 +360,17 @@ func fix(args []string, params *fixCommandParams) error {
 		}
 
 		// if the fixer is being run in a git repo, we must not fix files that have changes
-		changedFiles := make(map[string]struct{})
-
 		cf, err := git.GetChangedFiles(gitRepo)
 		if err != nil {
 			return fmt.Errorf("failed to get changed files: %w", err)
 		}
 
-		for _, f := range cf {
-			changedFiles[f] = struct{}{}
-		}
+		changedFiles := util.NewSet(cf...)
 
 		var conflictingFiles []string
 
 		for _, file := range fileProvider.ModifiedFiles() {
-			if _, ok := changedFiles[file]; ok {
+			if changedFiles.Contains(file) {
 				conflictingFiles = append(conflictingFiles, file)
 			}
 		}

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -95,7 +95,7 @@ func createTable(args []string) (io.Reader, error) {
 
 	tableMap := map[string][][]string{}
 
-	traversedTitles := map[string]struct{}{}
+	traversedTitles := util.NewSet[string]()
 
 	for _, entry := range flattened {
 		annotations := entry.Annotations
@@ -117,11 +117,11 @@ func createTable(args []string) (io.Reader, error) {
 		category := path[2]
 		title := path[3]
 
-		if _, ok := traversedTitles[title]; ok {
+		if traversedTitles.Contains(title) {
 			continue
 		}
 
-		traversedTitles[title] = struct{}{}
+		traversedTitles.Add(title)
 
 		tableMap[category] = append(tableMap[category], []string{
 			category,

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -142,11 +142,11 @@ func DeleteEmptyDirs(dir string) error {
 func DirCleanUpPaths(target string, preserve []string) ([]string, error) {
 	dirs := make([]string, 0)
 
-	preserveDirs := make(map[string]struct{})
+	preserveDirs := NewSet[string]()
 
 	for _, p := range preserve {
 		for {
-			preserveDirs[p] = struct{}{}
+			preserveDirs.Add(p)
 
 			p = filepath.Dir(p)
 
@@ -154,7 +154,7 @@ func DirCleanUpPaths(target string, preserve []string) ([]string, error) {
 				break
 			}
 
-			if _, ok := preserveDirs[p]; ok {
+			if preserveDirs.Contains(p) {
 				break
 			}
 		}
@@ -164,8 +164,7 @@ func DirCleanUpPaths(target string, preserve []string) ([]string, error) {
 
 	for {
 		// check if we reached the preserved dir
-		_, ok := preserveDirs[dir]
-		if ok {
+		if preserveDirs.Contains(dir) {
 			break
 		}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 	"github.com/open-policy-agent/opa/v1/bundle"
-	outil "github.com/open-policy-agent/opa/v1/util"
 
 	"github.com/styrainc/regal/internal/capabilities"
 	rio "github.com/styrainc/regal/internal/io"
@@ -877,8 +876,6 @@ func (rule *Rule) mapToConfig(result any) error {
 func GetPotentialRoots(paths ...string) ([]string, error) {
 	var err error
 
-	dirMap := make(map[string]struct{})
-
 	absDirPaths := make([]string, len(paths))
 
 	for i, path := range paths {
@@ -898,22 +895,22 @@ func GetPotentialRoots(paths ...string) ([]string, error) {
 		}
 	}
 
+	dirMap := util.NewSet[string]()
+
 	for _, dir := range absDirPaths {
 		brds, err := FindBundleRootDirectories(dir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find bundle root directories in %s: %w", dir, err)
 		}
 
-		for _, brd := range brds {
-			dirMap[brd] = struct{}{}
-		}
+		dirMap.Add(brds...)
 	}
 
-	if len(dirMap) == 0 {
+	if dirMap.Size() == 0 {
 		return absDirPaths, nil
 	}
 
-	return outil.Keys(dirMap), nil
+	return dirMap.Items(), nil
 }
 
 func isDir(path string) bool {

--- a/pkg/fixer/fileprovider/cache_test.go
+++ b/pkg/fixer/fileprovider/cache_test.go
@@ -45,11 +45,11 @@ func TestCacheFileProvider(t *testing.T) {
 		t.Fatalf("failed to rename file: %s", err)
 	}
 
-	if _, ok := cfp.deletedFiles["file:///tmp/foo.rego"]; !ok {
+	if !cfp.deletedFiles.Contains("file:///tmp/foo.rego") {
 		t.Fatalf("expected file to be deleted")
 	}
 
-	if _, ok := cfp.modifiedFiles["file:///tmp/wow.rego"]; !ok {
+	if !cfp.modifiedFiles.Contains("file:///tmp/wow.rego") {
 		t.Fatalf("expected file to be modified")
 	}
 

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -15,10 +15,11 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"github.com/owenrumney/go-sarif/v2/sarif"
 
-	"github.com/open-policy-agent/opa/v1/util"
+	outil "github.com/open-policy-agent/opa/v1/util"
 
 	"github.com/styrainc/regal/internal/mode"
 	"github.com/styrainc/regal/internal/novelty"
+	"github.com/styrainc/regal/internal/util"
 	"github.com/styrainc/regal/pkg/fixer"
 	"github.com/styrainc/regal/pkg/fixer/fixes"
 	"github.com/styrainc/regal/pkg/report"
@@ -165,21 +166,16 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 	f := fixer.NewFixer()
 	f.RegisterFixes(fixes.NewDefaultFixes()...)
 
-	fixableViolations := make(map[string]struct{})
-	fixableViolationsCount := 0
+	fixableViolations := util.NewSet[string]()
 
 	for _, violation := range r.Violations {
 		if fix, ok := f.GetFixForName(violation.Title); ok {
-			if _, ok := fixableViolations[fix.Name()]; !ok {
-				fixableViolations[fix.Name()] = struct{}{}
-			}
-
-			fixableViolationsCount++
+			fixableViolations.Add(fix.Name())
 		}
 	}
 
-	if fixableViolationsCount > 0 {
-		violationKeys := util.Keys(fixableViolations)
+	if fixableViolations.Size() > 0 {
+		violationKeys := fixableViolations.Items()
 		slices.Sort(violationKeys)
 
 		_, err = fmt.Fprintf(
@@ -188,7 +184,7 @@ func (tr PrettyReporter) Publish(_ context.Context, r report.Report) error {
 Hint: %d/%d violations can be automatically fixed (%s)
       Run regal fix --help for more details.
 `,
-			fixableViolationsCount,
+			fixableViolations.Size(),
 			r.Summary.NumViolations,
 			strings.Join(violationKeys, ", "),
 		)
@@ -329,7 +325,7 @@ func (tr JSONReporter) Publish(_ context.Context, r report.Report) error {
 		return fmt.Errorf("json marshalling of report failed: %w", err)
 	}
 
-	_, err = fmt.Fprintln(tr.out, util.ByteSliceToString(bs))
+	_, err = fmt.Fprintln(tr.out, outil.ByteSliceToString(bs))
 
 	return err
 }


### PR DESCRIPTION
This was added by @charlieegan3 yesterday, and I much prefer the ergonomics of this compared to using `map[T]struct{}` directly. So let's do it!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->