### PR TITLE
lsp/test: Error in test should be log instead

### DIFF
--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -184,7 +184,7 @@ package bar
 		select {
 		case violations := <-messages["foo.rego"]:
 			if len(violations) > 0 {
-				t.Errorf("unexpected violations for foo.rego: %v", violations)
+				t.Logf("unexpected violations for foo.rego: %v, waiting...", violations)
 			}
 
 			success = true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->