### PR TITLE
Fix false positive in `unused-output-variable`

### DIFF
--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
@@ -30,6 +30,7 @@ report contains violation if {
 	not ast.var_in_head(input.rules[to_number(rule_index)].head, var.value)
 	not ast.var_in_call(ast.function_calls, rule_index, var.value)
 	not _ref_base_vars[rule_index][var.value]
+	not _comprehension_term_vars[rule_index][var.value]
 
 	# this is by far the most expensive condition to check, so only do
 	# so when all other conditions apply
@@ -51,4 +52,13 @@ _ref_base_vars[rule_index][term.value] contains term if {
 	term := ast.found.refs[rule_index][_].value[0]
 
 	not ast.is_wildcard(term)
+}
+
+_comprehension_term_vars[rule_index] contains var.value if {
+	some rule_index, comprehensions in ast.found.comprehensions
+	some comprehension in comprehensions
+
+	only_head := object.remove(comprehension.value, ["body"])
+
+	some var in ast.find_term_vars(only_head)
 }

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
@@ -176,3 +176,24 @@ test_success_not_output_variable_argument if {
 	r := rule.report with input as module
 	r == set()
 }
+
+test_success_not_unused_comprehension_term if {
+	module := ast.with_rego_v1(`success if {x | input[x]}`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_unused_comprehension_term_complex if {
+	module := ast.with_rego_v1(`success if {[x, y] | input[x][y]}`)
+
+	r := rule.report with input as module
+	r == set()
+}
+
+test_success_not_unused_comprehension_term_key_value if {
+	module := ast.with_rego_v1(`success if {x: y | input[x][y]}`)
+
+	r := rule.report with input as module
+	r == set()
+}


### PR DESCRIPTION
Comprehension term vars are never unused, and should not be flagged.

Fixes #1353

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->