### PR TITLE
lsp: show parse errors in diagnostics

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -2516,9 +2516,12 @@ func (l *LanguageServer) handleWorkspaceDidChangeWatchedFiles(
 }
 
 func (l *LanguageServer) sendFileDiagnostics(ctx context.Context, fileURI string) error {
-	fileDiags, ok := l.cache.GetFileDiagnostics(fileURI)
-	if !ok {
-		fileDiags = []types.Diagnostic{}
+	// first, set the diagnostics for the file to the current parse errors
+	fileDiags, _ := l.cache.GetParseErrors(fileURI)
+
+	// if there are no parse errors, then we can check for lint errors
+	if len(fileDiags) == 0 {
+		fileDiags, _ = l.cache.GetFileDiagnostics(fileURI)
 	}
 
 	resp := types.FileDiagnostics{


### PR DESCRIPTION
Unsure when this was lost, but this is an important behavior to have back!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->