### PR TITLE
docs: Use strings for non-loop expression role

### DIFF
--- a/docs/rules/performance/non-loop-expression.md
+++ b/docs/rules/performance/non-loop-expression.md
@@ -11,7 +11,7 @@ package policy
 
 allow if {
     some email in input.emails
-    admin in input.roles # <- this is not required in the loop
+    "admin" in input.roles # <- this is not required in the loop
     endswith(email, "@example.com")
 }
 ```
@@ -22,7 +22,7 @@ allow if {
 package policy
 
 allow if {
-    admin in input.roles # <- moved out of the loop
+    "admin" in input.roles # <- moved out of the loop
     some email in input.emails
     endswith(email, "@example.com")
 }


### PR DESCRIPTION
This example role is clearer as a string rather than some random var.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->