### PR TITLE
cmd/lint: Fix windows Abs path handling

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -221,18 +221,13 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 
 	var configSearchPath string
 
-	cwd, _ := os.Getwd()
-
 	m := metrics.New()
 	if params.metrics {
 		m.Timer(regalmetrics.RegalConfigSearch).Start()
 	}
 
 	if len(args) == 1 {
-		configSearchPath = args[0]
-		if !strings.HasPrefix(args[0], "/") {
-			configSearchPath = filepath.Join(cwd, args[0])
-		}
+		configSearchPath, _ = filepath.Abs(args[0])
 	} else {
 		configSearchPath, _ = os.Getwd()
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -105,8 +105,7 @@ func NewLanguageServer(ctx context.Context, opts *LanguageServerOptions) *Langua
 	c := cache.NewCache()
 	store := NewRegalStore()
 
-	var ls *LanguageServer
-	ls = &LanguageServer{
+	ls := &LanguageServer{
 		cache:                       c,
 		regoStore:                   store,
 		logWriter:                   opts.LogWriter,
@@ -116,13 +115,14 @@ func NewLanguageServer(ctx context.Context, opts *LanguageServerOptions) *Langua
 		builtinsPositionJobs:        make(chan lintFileJob, 10),
 		commandRequest:              make(chan types.ExecuteCommandParams, 10),
 		templateFileJobs:            make(chan lintFileJob, 10),
-		configWatcher:               lsconfig.NewWatcher(&lsconfig.WatcherOpts{LogFunc: ls.logf}),
 		completionsManager:          completions.NewDefaultManager(ctx, c, store),
 		webServer:                   web.NewServer(c, opts.LogWriter, opts.LogLevel),
 		loadedBuiltins:              concurrent.MapOf(make(map[string]map[string]*ast.Builtin)),
 		workspaceDiagnosticsPoll:    opts.WorkspaceDiagnosticsPoll,
 		loadedConfigAllRegoVersions: concurrent.MapOf(make(map[string]ast.RegoVersion)),
 	}
+
+	ls.configWatcher = lsconfig.NewWatcher(&lsconfig.WatcherOpts{LogFunc: ls.logf})
 
 	return ls
 }


### PR DESCRIPTION
Previously, there was an incorrect assumption that abs paths started with /.

This commit also fixes a test bug where the server's logger was used before it was defined.

Fixes https://github.com/StyraInc/regal/issues/1414

