### PR TITLE
lint: Handle root filesystem root prefix

### DIFF
--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -42,8 +42,20 @@ lint.aggregate.violations := aggregate_report if {
 	"aggregate" in input.regal.operations
 }
 
+_file_name_relative_to_root(filename, "/") := trim_prefix(filename, "/")
+
+_file_name_relative_to_root(filename, root) := trim_prefix(
+	filename,
+	concat("", [root, "/"]),
+) if {
+	root != "/"
+}
+
 _rules_to_run[category] contains title if {
-	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
+	relative_filename := _file_name_relative_to_root(
+		input.regal.file.name,
+		config.path_prefix,
+	)
 
 	some category, title
 	config.merged_config.rules[category][title]
@@ -53,7 +65,7 @@ _rules_to_run[category] contains title if {
 	not config.excluded_file(
 		category,
 		title,
-		file_name_relative_to_root,
+		relative_filename,
 	)
 }
 

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -225,6 +225,17 @@ test_exclude_files_rule_config_with_path_prefix if {
 	rules_to_run == {}
 }
 
+test_exclude_files_rule_config_with_root_path_prefix if {
+	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
+
+	rules_to_run := main._rules_to_run with config.merged_config as cfg
+		with config.for_rule as {"level": "error", "ignore": {"files": ["foo/*"]}}
+		with input.regal.file.name as "/foo/bar/p.rego"
+		with config.path_prefix as "/"
+
+	rules_to_run == {}
+}
+
 test_not_exclude_files_rule_config_with_path_prefix if {
 	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
 


### PR DESCRIPTION
When the root is also the root of the filesystem, the linter will  now handle ignore patterns correctly.

Fixes https://github.com/StyraInc/regal/issues/1415
<img width="681" alt="Screenshot 2025-02-24 at 14 44 36" src="https://github.com/user-attachments/assets/f292d13a-0fad-4253-8620-52fb67c8eea8" />
