### PR TITLE
lsp: Fix Code Lenses jank

### DIFF
--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -45,6 +45,7 @@ func updateParse(
 		// if the parse was ok, clear the parse errors
 		cache.SetParseErrors(fileURI, []types.Diagnostic{})
 		cache.SetModule(fileURI, module)
+		cache.SetSuccessfulParseLineCount(fileURI, len(lines))
 
 		if err := PutFileMod(ctx, store, fileURI, module); err != nil {
 			return false, fmt.Errorf("failed to update rego store with parsed module: %w", err)


### PR DESCRIPTION
Previously, when editing a line, if parse errors come and go as you edit, the Code Lenses will toggle on and off as the parse error list is updated.

Now, only if the line count is different from the last successful parse, will the Code Lenses be disabled.

This means that a line can be typed while it contains errors, and code lenses will now come and go.

https://github.com/user-attachments/assets/861c837a-375a-48da-97d9-1867fe2e5ba7

