### PR TITLE
lsp: Correct path when fixing dir package mismatch

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -749,17 +749,10 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { //nolint:main
 					args,
 				)
 			case "regal.fix.directory-package-mismatch":
-				fileURL, ok := params.Arguments[0].(string)
-				if !ok {
-					l.logf(log.LevelMessage, "expected first argument to be a string, got %T", params.Arguments[0])
-
-					break
-				}
-
 				params, err := l.fixRenameParams(
 					"Rename file to match package path",
 					&fixes.DirectoryPackageMismatch{},
-					fileURL,
+					args.Target,
 				)
 				if err != nil {
 					l.logf(log.LevelMessage, "failed to fix directory package mismatch: %s", err)
@@ -2398,8 +2391,12 @@ func (l *LanguageServer) handleInitialize(ctx context.Context, params types.Init
 			l.configWatcher.Watch(configFile.Name())
 		case globalConfigDir != "":
 			globalConfigFile := filepath.Join(globalConfigDir, "config.yaml")
-			l.logf(log.LevelMessage, "using global config file: %s", globalConfigFile)
-			l.configWatcher.Watch(globalConfigFile)
+			// the file might not exist and we only want to log we're using the
+			// global file if it does.
+			if _, err = os.Stat(globalConfigFile); err == nil {
+				l.logf(log.LevelMessage, "using global config file: %s", globalConfigFile)
+				l.configWatcher.Watch(globalConfigFile)
+			}
 		default:
 			l.logf(log.LevelMessage, "no config file found for workspace: %s", err)
 		}


### PR DESCRIPTION
This had not been updated to the new arg format causing it to look up the wrong file path.

Also only log the use of the global file if a file is found.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://communityinviter.com/apps/styracommunity/signup).
-->