### PR TITLE
build: Make novelty package opt-in

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,6 +18,7 @@ builds:
         goarch: arm64
     tags:
       - regal_standalone
+      - regal_enable_novelty
     ldflags:
       - -s -w
       - -X github.com/styrainc/regal/pkg/version.Version={{ .Version }}
@@ -32,6 +33,7 @@ builds:
       - arm64
     tags:
       - regal_standalone
+      - regal_enable_novelty
     ldflags:
       - -s -w
       - -X github.com/styrainc/regal/pkg/version.Version={{ .Version }}

--- a/internal/novelty/holidays.go
+++ b/internal/novelty/holidays.go
@@ -1,3 +1,5 @@
+//go:build regal_enable_novelty
+
 package novelty
 
 import (

--- a/internal/novelty/novelty.go
+++ b/internal/novelty/novelty.go
@@ -1,0 +1,5 @@
+//go:build !regal_enable_novelty
+
+package novelty
+
+func HappyHolidays() error { return nil }


### PR DESCRIPTION
This allows Regal to be built without the go-asciisprite dependency.