### PR TITLE
test: fix deadline exceeded test issue in GitHub runners

### DIFF
--- a/bundle/regal/config/config_test.rego
+++ b/bundle/regal/config/config_test.rego
@@ -157,7 +157,7 @@ test_enable_single_rule_with_config if {
 test_all_rules_are_in_provided_configuration if {
 	missing_config := {title |
 		some category, title
-		data.regal.rules[category][title]
+		data.regal.rules[category][title].report
 		not endswith(title, "_test")
 		not config.provided.rules[category][title]
 	}


### PR DESCRIPTION
This was caused by a single test that by the way it evaluated rules would have all the tests from the bundle evaluated inside of its body!

This simple fix takes evaluation time of that test down frm 800 ms on my machine down to 4 ms.