### PR TITLE
golangci-lint v2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,10 +60,10 @@ jobs:
           path: ~/go/bin/rq
           key: ${{ runner.os }}-${{ runner.arch }}-go-rq-${{ env.RQ_VERSION }}
       - run: build/do.rq pull_request
-      - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         if: matrix.os.name == 'linux'
         with:
-          version: v1.64.5
+          version: v2.0.0
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: regal-${{ matrix.os.name }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,76 +1,111 @@
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
-    # annoying
-    - gocyclo
-    - tagliatelle
-    - nestif
-    - gocognit
-    - varnamelen
-    - nonamedreturns
-    - testpackage
-    - goconst
-    - gochecknoinits
-    - mnd
-    - inamedparam
-    - err113
-    - godox
-    - exhaustruct
+    # these linters are disabled either because they
+    # are annoying or because they are deprecated
     - cyclop
-    - ireturn
+    - err113
+    - exhaustive
+    - exhaustruct
     - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocyclo
+    - godox
     - gomoddirectives # need replacements for wasip1
-    - tenv # deprecated
-linters-settings:
-  tagliatelle:
-    case:
+    - inamedparam
+    - ireturn
+    - mnd
+    - nestif
+    - nonamedreturns
+    - tagliatelle
+    - testpackage
+    - varnamelen
+  settings:
+    depguard:
       rules:
-        json: snake
-  revive:
-    rules:
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
-      - name: unused-parameter
-        severity: warning
-        disabled: false
-        arguments:
-          - allowRegex: "^_"
-      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
-      - name: unused-receiver
-        severity: warning
-        disabled: false
-        arguments:
-          - allowRegex: "^_"
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/open-policy-agent/opa)
-      - prefix(github.com/styrainc/roast)
-      - prefix(github.com/styrainc/regal)
-      - blank
-      - dot
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "gopkg.in/yaml.v2"
-            desc: use yaml.v3 only
-  govet:
-    enable-all: true
-    disable:
-      - shadow
-      # this is nice, but it doesn't seem possible to disable
-      # this for tests? definitely don't want this in tests
-      - fieldalignment
-
-issues:
-  exclude-dirs:
-    - internal/lsp/opa
-  exclude-files:
-    # For whatever reason, the exclude-dirs setting isn't honored when
-    # golangci-lint is targeting one of these files *specifically* rather
-    # than whole whole workspace / directory. This happens when opening up
-    # one of these files in VS Code, which will have the linter complain
-    # loudly. Hopefully this workaround can be removed in the future.
-    - scanner.go
-    - tokens.go
+        main:
+          deny:
+            - pkg: gopkg.in/yaml.v2
+              desc: use yaml.v3 only
+    gocritic:
+      disabled-checks:
+        - hugeParam
+      enabled-checks:
+        - filepathJoin
+        - dupImport
+        - redundantSprint
+        - stringConcatSimplify
+      enabled-tags:
+        - performance
+    govet:
+      disable:
+        - shadow
+        # this is nice, but it doesn't seem possible to disable
+        # this for tests? definitely don't want this in tests
+        - fieldalignment
+      enable-all: true
+    perfsprint:
+      err-error: true
+    revive:
+      rules:
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter
+        - name: unused-parameter
+          arguments:
+            - allowRegex: ^_
+          severity: warning
+          disabled: false
+        # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-receiver
+        - name: unused-receiver
+          arguments:
+            - allowRegex: ^_
+          severity: warning
+          disabled: false
+    staticcheck:
+      checks:
+        - all
+    tagliatelle:
+      case:
+        rules:
+          json: snake
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - scanner.go
+      - tokens.go
+      - internal/lsp/opa
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/open-policy-agent/opa)
+        - prefix(github.com/styrainc/roast)
+        - prefix(github.com/styrainc/regal)
+        - blank
+        - dot
+  exclusions:
+    generated: lax
+    paths:
+      - internal/lsp/opa
+      # For whatever reason, the exclude-dirs setting isn't honored when
+      # golangci-lint is targeting one of these files *specifically* rather
+      # than whole whole workspace / directory. This happens when opening up
+      # one of these files in VS Code, which will have the linter complain
+      # loudly. Hopefully this workaround can be removed in the future.
+      - scanner.go
+      - tokens.go

--- a/build/do.rq
+++ b/build/do.rq
@@ -81,8 +81,6 @@ job contains "tasks" if {
 # description: |
 #   Run all recommended tasks before submitting a PR
 # related_resources:
-#   - https://github.com/daixiang0/gci
-#   - https://github.com/mvdan/gofumpt
 #   - https://github.com/golangci/golangci-lint
 #   - https://github.com/open-policy-agent/opa
 job contains "pr" if {

--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -13,6 +13,4 @@ import (
 var Bundle embed.FS
 
 // LoadedBundle contains the loaded contents of the Bundle.
-//
-//nolint:gochecknoglobals
 var LoadedBundle = rio.MustLoadRegalBundleFS(Bundle)

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -118,8 +118,8 @@ func init() {
 			errorsFound := 0
 			warningsFound := 0
 
-			for _, violation := range rep.Violations {
-				switch violation.Level {
+			for i := range rep.Violations {
+				switch rep.Violations[i].Level {
 				case "error":
 					errorsFound++
 				case "warning":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,8 +8,6 @@ import (
 )
 
 // RootCommand is the base CLI command that all subcommands are added to.
-//
-//nolint:gochecknoglobals
 var RootCommand = &cobra.Command{
 	Use:   path.Base(os.Args[0]),
 	Short: "Regal",

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -74,9 +74,9 @@ func (f loaderFilter) Apply(abspath string, info os.FileInfo, depth int) bool {
 	})
 }
 
-var testParams = newTestCommandParams() //nolint: gochecknoglobals
+var testParams = newTestCommandParams()
 
-var testCommand = &cobra.Command{ //nolint: gochecknoglobals
+var testCommand = &cobra.Command{
 	Hidden: true,
 	Use:    "test <path> [path [...]]",
 	Short:  "Execute Rego test cases for Regal",

--- a/internal/explorer/stages.go
+++ b/internal/explorer/stages.go
@@ -25,8 +25,6 @@ type CompileResult struct {
 type stage struct{ name, metricName string }
 
 // NOTE(sr): copied from 0.68.0.
-//
-//nolint:gochecknoglobals
 var stages = []stage{
 	{"ResolveRefs", "compile_stage_resolve_refs"},
 	{"InitLocalVarGen", "compile_stage_init_local_var_gen"},

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -187,7 +187,6 @@ func FindManifestLocations(root string) ([]string, error) {
 // this package. We should probably move these definitions to somewhere where all
 // packages can import them from.
 
-//nolint:gochecknoglobals
 var regalParseModuleMeta = &rego.Function{
 	Name: "regal.parse_module",
 	Decl: types.NewFunction(
@@ -199,7 +198,6 @@ var regalParseModuleMeta = &rego.Function{
 	),
 }
 
-//nolint:gochecknoglobals
 var regalLastMeta = &rego.Function{
 	Name: "regal.last",
 	Decl: types.NewFunction(
@@ -211,10 +209,8 @@ var regalLastMeta = &rego.Function{
 	),
 }
 
-//nolint:gochecknoglobals
 var OPACapabilities = ast.CapabilitiesForThisVersion()
 
-//nolint:gochecknoglobals
 var Capabilities = sync.OnceValue(capabilities)
 
 func capabilities() *ast.Capabilities {

--- a/internal/lsp/completions/providers/rulehead.go
+++ b/internal/lsp/completions/providers/rulehead.go
@@ -82,11 +82,11 @@ func (*RuleHead) Run(
 		symbol := completion.Variable
 		detail := "Rule"
 
-		switch {
-		case ref.Kind == types.ConstantRule:
+		switch ref.Kind {
+		case types.ConstantRule:
 			symbol = completion.Constant
 			detail = "Constant Rule"
-		case ref.Kind == types.Function:
+		case types.Function:
 			symbol = completion.Function
 			detail = "Function"
 		}

--- a/internal/lsp/completions/refs/used.go
+++ b/internal/lsp/completions/refs/used.go
@@ -52,7 +52,6 @@ func prepareQuery() (*rego.PreparedEvalQuery, error) {
 	return &preparedQuery, nil
 }
 
-//nolint:gochecknoglobals
 var pqOnce = sync.OnceValues(prepareQuery)
 
 // UsedInModule returns a list of ref names suitable for completion that are

--- a/internal/lsp/eval.go
+++ b/internal/lsp/eval.go
@@ -46,14 +46,14 @@ func (l *LanguageServer) Eval(
 
 	allBundles := make(map[string]bundle.Bundle)
 
-	for k, v := range dataBundles {
-		if v.Manifest.Roots == nil {
+	for k := range dataBundles {
+		if dataBundles[k].Manifest.Roots == nil {
 			l.logf(log.LevelMessage, "bundle %s has no roots and will be skipped", k)
 
 			continue
 		}
 
-		allBundles[k] = v
+		allBundles[k] = dataBundles[k]
 	}
 
 	allBundles["workspace"] = bundle.Bundle{
@@ -145,6 +145,8 @@ func prepareRegoArgs(
 	cfg *config.Config,
 ) []func(*rego.Rego) {
 	bundleArgs := make([]func(*rego.Rego), 0, len(bundles))
+	// this copy is expensive, but I don't think we can avoid it
+	//nolint:gocritic
 	for key, b := range bundles {
 		bundleArgs = append(bundleArgs, rego.ParsedBundle(key, &b))
 	}

--- a/internal/lsp/examples/examples.go
+++ b/internal/lsp/examples/examples.go
@@ -35,6 +35,7 @@ func createIndex() *indexData {
 // if it has been documented, otherwise it returns false.
 func GetBuiltInLink(builtinName string) (string, bool) {
 	index := indexOnce()
+
 	path, ok := index.BuiltIns[builtinName]
 	if ok {
 		return baseURL + "/" + path, true
@@ -47,6 +48,7 @@ func GetBuiltInLink(builtinName string) (string, bool) {
 // if it has been documented, otherwise it returns false.
 func GetKeywordLink(keyword string) (string, bool) {
 	index := indexOnce()
+
 	path, ok := index.Keywords[keyword]
 	if ok {
 		return baseURL + "/" + path, true

--- a/internal/lsp/hover/hover.go
+++ b/internal/lsp/hover/hover.go
@@ -18,7 +18,7 @@ import (
 	"github.com/styrainc/roast/pkg/util/concurrent"
 )
 
-var builtinCache = concurrent.MapOf(make(map[*ast.Builtin]string)) //nolint:gochecknoglobals
+var builtinCache = concurrent.MapOf(make(map[*ast.Builtin]string))
 
 func writeFunctionSnippet(sb *strings.Builder, builtin *ast.Builtin) {
 	sb.WriteString("```rego\n")
@@ -81,7 +81,7 @@ func CreateHoverContent(builtin *ast.Builtin) string {
 
 	exampleLink, ok := examples.GetBuiltInLink(builtin.Name)
 	if ok {
-		sb.WriteString(fmt.Sprintf("[View Usage Examples](%s)\n", exampleLink))
+		fmt.Fprintf(sb, "[View Usage Examples](%s)\n", exampleLink)
 	}
 
 	writeFunctionSnippet(sb, builtin)

--- a/internal/lsp/lint.go
+++ b/internal/lsp/lint.go
@@ -293,6 +293,8 @@ func convertReportToDiagnostics(
 ) map[string][]types.Diagnostic {
 	fileDiags := make(map[string][]types.Diagnostic)
 
+	// rangeValCopy necessary, as value copied in loop anyway
+	//nolint:gocritic
 	for _, item := range rpt.Violations {
 		// here errors are presented as warnings, and warnings as info
 		// to differentiate from parse errors

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -98,14 +98,12 @@ func AllBuiltinCalls(module *ast.Module, builtins map[string]*ast.Builtin) []Bui
 	return builtinCalls
 }
 
-//nolint:gochecknoglobals
 var (
 	keywordsPreparedQuery          *rego.PreparedEvalQuery
 	ruleHeadLocationsPreparedQuery *rego.PreparedEvalQuery
 	codeLensPreparedQuery          *rego.PreparedEvalQuery
 )
 
-//nolint:gochecknoglobals
 var preparedQueriesInitOnce sync.Once
 
 type policy struct {

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1,4 +1,4 @@
-//nolint:nilerr,nilnil,gochecknoglobals
+//nolint:nilerr,nilnil
 package lsp
 
 import (

--- a/internal/parse/parse.go
+++ b/internal/parse/parse.go
@@ -27,10 +27,7 @@ func ParserOptions() ast.ParserOptions {
 	}
 }
 
-//nolint:gochecknoglobals
-var (
-	attemptVersionOrder = [2]ast.RegoVersion{ast.RegoV1, ast.RegoV0}
-)
+var attemptVersionOrder = [2]ast.RegoVersion{ast.RegoV1, ast.RegoV0}
 
 // ModuleWithOpts parses a module with the given options. If the Rego version is unknown, the function
 // may attempt to run several parser versions to determine the correct version. Setting the Rego version

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -100,7 +100,7 @@ func CheckAndWarn(opts Options, w io.Writer) {
 See %s for the latest release.
 `
 
-	w.Write([]byte(fmt.Sprintf(tmpl, latestVersion, opts.CurrentVersion, ctaURL)))
+	fmt.Fprintf(w, tmpl, latestVersion, opts.CurrentVersion, ctaURL)
 }
 
 func getLatestVersion(ctx context.Context, opts Options) (string, error) {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -164,12 +164,7 @@ func DirCleanUpPaths(target string, preserve []string) ([]string, error) {
 
 	dir := filepath.Dir(target)
 
-	for {
-		// check if we reached the preserved dir
-		if preserveDirs.Contains(dir) {
-			break
-		}
-
+	for !preserveDirs.Contains(dir) {
 		parts := strings.Split(dir, rio.PathSeparator)
 		if len(parts) == 1 {
 			break

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -26,7 +26,6 @@ const mainTemplate = "main.tpl"
 //go:embed assets/*
 var assets embed.FS
 
-//nolint:gochecknoglobals
 var tpl = template.Must(template.New("main.tpl").ParseFS(assets, "assets/main.tpl"))
 
 type Server struct {

--- a/pkg/builtins/builtins.go
+++ b/pkg/builtins/builtins.go
@@ -1,4 +1,4 @@
-//nolint:gochecknoglobals,wrapcheck
+//nolint:wrapcheck
 package builtins
 
 import (

--- a/pkg/fixer/fixer.go
+++ b/pkg/fixer/fixer.go
@@ -110,6 +110,9 @@ func (f *Fixer) FixViolations(
 		return nil, fmt.Errorf("failed to list files: %w", err)
 	}
 
+	// rangeValCopy may be expensive, but this is not critical enough
+	// to motivate cluttering the code
+	//nolint:gocritic
 	for _, violation := range violations {
 		file := violation.Location.File
 
@@ -219,6 +222,7 @@ func (f *Fixer) applyLinterFixes(
 			break
 		}
 
+		//nolint:gocritic
 		for _, violation := range rep.Violations {
 			file := violation.Location.File
 

--- a/pkg/hints/hints.go
+++ b/pkg/hints/hints.go
@@ -35,7 +35,6 @@ func GetForError(e error) ([]string, error) {
 	return hintKeys, nil
 }
 
-//nolint:gochecknoglobals
 var patterns = map[string]*regexp.Regexp{
 	`eval-conflict-error/complete-rules-must-not-produce-multiple-outputs`: regexp.MustCompile(`^eval_conflict_error: complete rules must not produce multiple outputs$`),
 	`eval-conflict-error/object-keys-must-be-unique`:                       regexp.MustCompile(`^object insert conflict$|^eval_conflict_error: object keys must be unique$`),

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -69,7 +69,6 @@ type Linter struct {
 	hasCustomRules       bool
 }
 
-//nolint:gochecknoglobals
 var lintQuery = ast.MustParseBody("lint := data.regal.main.lint")
 
 // NewLinter creates a new Regal linter.

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -162,8 +162,8 @@ func (r *Report) AggregateProfileToSortedProfile(numResults int) {
 // ViolationsFileCount returns the number of files containing violations.
 func (r *Report) ViolationsFileCount() map[string]int {
 	fc := map[string]int{}
-	for _, violation := range r.Violations {
-		fc[violation.Location.File]++
+	for i := range r.Violations {
+		fc[r.Violations[i].Location.File]++
 	}
 
 	return fc

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -14,7 +14,6 @@ func ptr(s string) *string {
 	return &s
 }
 
-//nolint:gochecknoglobals
 var rep = report.Report{
 	Summary: report.Summary{
 		FilesScanned:  3,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,3 @@
-//nolint:gochecknoglobals
 package version
 
 import (


### PR DESCRIPTION
This was made pretty easy with the help of `golangci-lint migrate`.

Also:
- disable gochecknoglobals linter (because annoying)
- disable exhaustive linter (new? annoying either way)

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->