### PR TITLE
Some perf fixes

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -100,14 +100,14 @@ _is_name(term, pos) if {
 # description: all the rules (excluding functions) in the input AST
 rules := [rule |
 	some rule in input.rules
+
 	not rule.head.args
 ]
 
 # METADATA
 # description: all the test rules in the input AST
 tests := [rule |
-	some rule in input.rules
-	not rule.head.args
+	some rule in rules
 
 	startswith(ref_to_string(rule.head.ref), "test_")
 ]

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -33,9 +33,7 @@ report contains violation if {
 
 	target == "rule"
 
-	some rule in input.rules
-
-	not rule.head.args
+	some rule in ast.rules
 
 	name := ast.ref_to_string(rule.head.ref)
 

--- a/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
+++ b/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego
@@ -15,8 +15,6 @@ notices contains result.notice(rego.metadata.chain()) if not capabilities.has_st
 # METADATA
 # description: flag calls to `count` where the first argument is a call to `indexof_n`
 report contains violation if {
-	some rule in input.rules
-
 	ref := ast.found.refs[_][_]
 
 	ref[0].value[0].type == "var"


### PR DESCRIPTION
This saves almost a million allocations. The redundant loop in use-strings-count was particularly embarrassing, and should certainly be made a linter rule, if not a strict mode unused violation.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->