### PR TITLE
perf: various improvements

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -109,7 +109,7 @@ rules := [rule |
 tests := [rule |
 	some rule in rules
 
-	startswith(ref_to_string(rule.head.ref), "test_")
+	startswith(rule.head.ref[0].value, "test_")
 ]
 
 # METADATA
@@ -218,7 +218,7 @@ function_calls[rule_index] contains call if {
 	]
 
 	call := {
-		"name": ref_to_string(ref[0].value),
+		"name": name,
 		"location": ref[0].location,
 		"args": args,
 	}
@@ -230,6 +230,18 @@ _exclude_arg(_, _, arg) if arg.type == "call"
 # first "arg" of assign is the variable to assign to.. special case we simply
 # ignore here, as it's covered elsewhere
 _exclude_arg("assign", 0, _)
+
+# METADATA
+# description: |
+#   true if both ref values (or "paths") are equal in type and value for each path component, ignoring locations
+ref_value_equal(v1, v2) if {
+	count(v1) == count(v2)
+
+	every i, part in v1 {
+		part.type == v2[i].type
+		part.value == v2[i].value
+	}
+}
 
 # METADATA
 # description: returns the "path" string of any given ref value

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
@@ -5,11 +5,12 @@ package regal.rules.bugs["argument-always-wildcard"]
 import data.regal.ast
 import data.regal.config
 import data.regal.result
+import data.regal.util
 
 report contains violation if {
 	some name, functions in _function_groups
 
-	fn := _any_member(functions)
+	fn := util.any_set_item(functions)
 
 	some pos in numbers.range(0, count(fn.head.args) - 1)
 
@@ -30,5 +31,3 @@ _function_groups[name] contains fn if {
 }
 
 _function_name_excepted(cfg, name) if regex.match(cfg["except-function-name-pattern"], name)
-
-_any_member(s) := [x | some x in s][0]

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition.rego
@@ -9,36 +9,31 @@ import data.regal.result
 # Additionally, there are several other conditions that could be considered
 # constant, or if not, redundant... so this rule should be expanded in time
 
-_operators := {"equal", "gt", "gte", "lt", "lte", "neq"}
-
-_rules_with_bodies := [rule |
-	some rule in input.rules
-	rule.body
-]
-
 # METADATA
 # description: single scalar value, like a lone `true` inside a rule body
 # scope: rule
 report contains violation if {
-	expr := _rules_with_bodies[_].body[_]
+	terms := input.rules[_].body[_].terms
 
 	# We could probably include arrays and objects too, as a single compound value
 	# is not very useful, but it's not as clear cut as scalars, as you could have
 	# something like {"a": foo(input.x) == "bar"} which is not a constant condition,
 	# however meaningless it may be. Maybe consider for another rule?
-	expr.terms.type in ast.scalar_types
+	terms.type in ast.scalar_types
 
-	violation := result.fail(rego.metadata.chain(), result.location(expr.terms))
+	violation := result.fail(rego.metadata.chain(), result.location(terms))
 }
 
 # METADATA
 # description: two scalar values with a "boolean operator" between, like 1 == 1, or 2 > 1
 # scope: rule
 report contains violation if {
-	expr := _rules_with_bodies[_].body[_]
+	operators := {"equal", "gt", "gte", "lt", "lte", "neq"}
+
+	expr := input.rules[_].body[_]
 
 	expr.terms[0].value[0].type == "var"
-	expr.terms[0].value[0].value in _operators
+	expr.terms[0].value[0].value in operators
 
 	expr.terms[1].type in ast.scalar_types
 	expr.terms[2].type in ast.scalar_types

--- a/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule.rego
+++ b/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule.rego
@@ -6,11 +6,10 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some i
-	ref := input.rules[i].head.ref
+	head := input.rules[_].head
 
-	count(ref) == 1
-	ast.ref_to_string(ref) in ast.imported_identifiers
+	count(head.ref) == 1
+	head.ref[0].value in ast.imported_identifiers
 
-	violation := result.fail(rego.metadata.chain(), result.location(input.rules[i].head))
+	violation := result.fail(rego.metadata.chain(), result.location(head))
 }

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
@@ -9,21 +9,21 @@ import data.regal.result
 report contains violation if {
 	_enabled(_valid_test_file_name(input.regal.file.name), _enable_for_test_files)
 
-	ref := ast.found.refs[_][_]
+	value := ast.found.refs[_][_].value
 
-	contains(ast.ref_to_string(ref.value), "._")
+	contains(ast.ref_to_string(value), "._")
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(ref.value))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(value))
 }
 
 report contains violation if {
 	_enabled(_valid_test_file_name(input.regal.file.name), _enable_for_test_files)
 
-	some imported in input.imports
+	value := input.imports[_].path.value
 
-	contains(ast.ref_to_string(imported.path.value), "._")
+	contains(ast.ref_to_string(value), "._")
 
-	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(imported.path.value))
+	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(value))
 }
 
 default _enabled(_, _) := true
@@ -35,8 +35,6 @@ default _valid_test_file_name(_) := false
 _valid_test_file_name(filename) if endswith(filename, "_test.rego")
 _valid_test_file_name("test.rego") # Styra DAS convention considered OK
 
-_cfg := config.for_rule("bugs", "leaked-internal-reference")
-
 default _enable_for_test_files := false
 
-_enable_for_test_files := object.get(_cfg, "include-test-files", false)
+_enable_for_test_files := config.for_rule("bugs", "leaked-internal-reference")["include-test-files"]

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
@@ -6,17 +6,17 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some expr in ast.exprs[_]
+	terms := ast.exprs[_][_].terms
 
-	expr.terms[0].type == "ref"
-	expr.terms[0].value[0].type == "var"
-	expr.terms[0].value[0].value == "neq"
+	terms[0].type == "ref"
+	terms[0].value[0].type == "var"
+	terms[0].value[0].value == "neq"
 
-	some neq_term in array.slice(expr.terms, 1, count(expr.terms))
+	some neq_term in array.slice(terms, 1, count(terms))
 	neq_term.type == "ref"
 
 	some value in neq_term.value
 	ast.is_wildcard(value)
 
-	violation := result.fail(rego.metadata.chain(), result.location(expr.terms[0]))
+	violation := result.fail(rego.metadata.chain(), result.location(terms[0]))
 }

--- a/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
+++ b/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check.rego
@@ -17,12 +17,9 @@ report contains violation if {
 
 	ast.static_ref(expr.terms)
 
-	ref_str := ast.ref_to_string(expr.terms.value)
-	next_expr := rule.body[expr_index + 1]
+	some term in rule.body[expr_index + 1].terms
 
-	some term in next_expr.terms
-
-	ast.ref_to_string(term.value) == ref_str
+	ast.ref_value_equal(expr.terms.value, term.value)
 
 	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(expr.terms.value))
 }
@@ -55,12 +52,10 @@ report contains violation if {
 
 	rule.head.value.type == "ref"
 
-	ref_str := ast.ref_to_string(rule.head.value.value)
-
 	some expr in ast.exprs[rule_index]
 
 	expr.terms.type == "ref"
-	ast.ref_to_string(expr.terms.value) == ref_str
+	ast.ref_value_equal(expr.terms.value, rule.head.value.value)
 
 	violation := result.fail(rego.metadata.chain(), result.ranged_from_ref(expr.terms.value))
 }

--- a/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default.rego
+++ b/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default.rego
@@ -7,6 +7,8 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
+	count(_default_rule_values) > 0
+
 	some rule in input.rules
 
 	not rule["default"]

--- a/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin.rego
+++ b/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin.rego
@@ -6,9 +6,9 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some rule in input.rules
+	head := input.rules[_].head
 
-	ast.ref_to_string(rule.head.ref) in ast.builtin_namespaces
+	ast.ref_to_string(head.ref) in ast.builtin_namespaces
 
-	violation := result.fail(rego.metadata.chain(), result.location(rule.head))
+	violation := result.fail(rego.metadata.chain(), result.location(head))
 }

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value.rego
@@ -7,12 +7,12 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	some expr in ast.exprs[_]
+	terms := ast.exprs[_][_].terms
 
-	expr.terms[0].type == "ref"
-	expr.terms[0].value[0].type == "var"
+	terms[0].type == "ref"
+	terms[0].value[0].type == "var"
 
-	ref_name := expr.terms[0].value[0].value
+	ref_name := terms[0].value[0].value
 	ref_name in ast.builtin_names
 
 	# special case as the "result" of print is ""
@@ -22,7 +22,7 @@ report contains violation if {
 
 	# no violation if the return value is declared as the last function argument
 	# see the function-arg-return rule for *that* violation
-	not ast.function_ret_in_args(ref_name, expr.terms)
+	not ast.function_ret_in_args(ref_name, terms)
 
-	violation := result.fail(rego.metadata.chain(), result.location(expr.terms[0]))
+	violation := result.fail(rego.metadata.chain(), result.location(terms[0]))
 }

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
@@ -14,7 +14,8 @@ import data.regal.util
 notices contains result.notice(rego.metadata.chain()) if not capabilities.has_if
 
 report contains violation if {
-	# Note: this covers both rules and functions, which is what we want here
+	max_line_length := object.get(config.for_rule("custom", "one-liner-rule"), "max-line-length", 120)
+
 	some rule in input.rules
 
 	# Bail out of rules with else for now. It is possible that they can be made
@@ -37,9 +38,6 @@ report contains violation if {
 	# Technically, the `if` could be on another line, but who would do that?
 	regex.match(`\s+if`, lines[0])
 	_rule_body_brackets(lines)
-
-	cfg := config.for_rule("custom", "one-liner-rule")
-	max_line_length := object.get(cfg, "max-line-length", 120)
 
 	# ideally we'd take style preference into account but for now assume tab == 4 spaces
 	# then just add the sum of the line counts minus the removed '{' character

--- a/bundle/regal/rules/imports/redundant-data-import/redundant_data_import.rego
+++ b/bundle/regal/rules/imports/redundant-data-import/redundant_data_import.rego
@@ -5,11 +5,10 @@ package regal.rules.imports["redundant-data-import"]
 import data.regal.result
 
 report contains violation if {
-	some imported in input.imports
+	path := input.imports[_].path.value
 
-	count(imported.path.value) == 1
+	count(path) == 1
+	path[0].value == "data"
 
-	imported.path.value[0].value == "data"
-
-	violation := result.fail(rego.metadata.chain(), result.location(imported.path.value[0]))
+	violation := result.fail(rego.metadata.chain(), result.location(path[0]))
 }

--- a/bundle/regal/rules/performance/defer-assignment/defer_assignment.rego
+++ b/bundle/regal/rules/performance/defer-assignment/defer_assignment.rego
@@ -22,8 +22,8 @@ report contains violation if {
 	not ast.is_assignment(next)
 	not ast.var_in_head(rule.head, var.value)
 	not _var_used_in_expression(var, next)
-	not _iteration_expression(next)
-	not _print_call(next)
+	not _iteration_expression(next.terms)
+	not _print_call(next.terms)
 
 	violation := result.fail(rego.metadata.chain(), result.location(expr))
 }
@@ -80,18 +80,18 @@ _var_used_in_expression(var, expr) if {
 # while not technically checking of use here:
 # the next expression having symbols indicate iteration, and
 # we don't want to defer assignment into a loop
-_iteration_expression(expr) if expr.terms.symbols
+_iteration_expression(terms) if terms.symbols
 
 # likewise with every
-_iteration_expression(expr) if expr.terms.domain
+_iteration_expression(terms) if terms.domain
 
 # and walk
-_iteration_expression(expr) if {
-	expr.terms[0].value[0].type == "var"
-	expr.terms[0].value[0].value == "walk"
+_iteration_expression(terms) if {
+	terms[0].value[0].type == "var"
+	terms[0].value[0].value == "walk"
 }
 
-_print_call(expr) if {
-	expr.terms[0].value[0].type == "var"
-	expr.terms[0].value[0].value == "print"
+_print_call(terms) if {
+	terms[0].value[0].type == "var"
+	terms[0].value[0].value == "print"
 }

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
@@ -86,10 +86,9 @@ _loop_start_points[rule_index][loc.row] contains var if {
 }
 
 _loop_start_points[rule_index][row] contains var if {
-	some rule_index
-	call := ast.function_calls[rule_index][_]
+	some rule_index, call
+	ast.function_calls[rule_index][call].name == "walk"
 
-	call.name == "walk"
 	call.args[1].type == "array"
 
 	some var in ast.find_term_vars(call.args[1].value)

--- a/bundle/regal/rules/performance/walk-no-path/walk_no_path.rego
+++ b/bundle/regal/rules/performance/walk-no-path/walk_no_path.rego
@@ -6,10 +6,9 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some rule_index
-	call := ast.function_calls[rule_index][_]
+	some rule_index, call
+	ast.function_calls[rule_index][call].name == "walk"
 
-	call.name == "walk"
 	call.args[1].type == "array"
 	call.args[1].value[0].type == "var"
 
@@ -45,9 +44,7 @@ _var_in_arg(arg, var) if {
 }
 
 _var_in_ref(rule_index, var) if {
-	some ref_var in ast.found.vars[rule_index].ref
-
-	var.value == ref_var.value
+	ast.found.vars[rule_index].ref[_].value == var.value
 }
 
 _var_in_ref(rule_index, var) if {

--- a/bundle/regal/rules/style/default-over-not/default_over_not.rego
+++ b/bundle/regal/rules/style/default-over-not/default_over_not.rego
@@ -14,11 +14,9 @@ report contains violation if {
 	not rule["default"]
 	not rule.body
 
+	ast.static_ref(rule.head.value)
+
 	name := ast.ref_static_to_string(rule.head.ref)
-
-	value := rule.head.value
-
-	ast.static_ref(value)
 
 	# part 2 - find corresponding assignment of constant on negated condition
 	# example: `rule := 1 if not input.foo`
@@ -34,7 +32,8 @@ report contains violation if {
 	ast.is_constant(sibling.head.value)
 	count(sibling.body) == 1
 	sibling.body[0].negated
-	ast.ref_to_string(sibling.body[0].terms.value) == ast.ref_to_string(value.value)
+
+	ast.ref_value_equal(sibling.body[0].terms.value, rule.head.value.value)
 
 	violation := result.fail(rego.metadata.chain(), result.location(sibling.body[0]))
 }

--- a/bundle/regal/rules/style/double-negative/double_negative.rego
+++ b/bundle/regal/rules/style/double-negative/double_negative.rego
@@ -12,9 +12,8 @@ import data.regal.result
 
 report contains violation if {
 	some node
-	ast.negated_expressions[_][node]
+	ast.negated_expressions[_][node].terms.type == "var"
 
-	node.terms.type == "var"
 	strings.any_prefix_match(node.terms.value, {
 		"cannot_",
 		"no_",

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
@@ -12,10 +12,8 @@ report contains violation if {
 	excluded_functions := {name | some name in cfg["except-functions"]} | {"print"}
 	included_functions := ast.all_function_names - excluded_functions
 
-	some rule_index in ast.rule_index_strings
-	some fn in ast.function_calls[rule_index]
-
-	fn.name in included_functions
+	some fn
+	ast.function_calls[_][fn].name in included_functions
 
 	count(fn.args) > count(ast.all_functions[fn.name].decl.args)
 

--- a/bundle/regal/rules/style/line-length/line_length.rego
+++ b/bundle/regal/rules/style/line-length/line_length.rego
@@ -7,7 +7,6 @@ import data.regal.result
 
 report contains violation if {
 	cfg := config.for_rule("style", "line-length")
-
 	max_line_length := object.get(cfg, "max-line-length", 120)
 
 	some i, line in input.regal.file.lines

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -63,7 +63,7 @@ _possible_top_level_iteration(rule) if {
 _invalid_some_context(rule, path) if {
 	some p in util.all_paths(path)
 
-	node := object.get(rule, p, [])
+	node := object.get(rule, p, false)
 
 	_impossible_some(node)
 }

--- a/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call.rego
+++ b/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call.rego
@@ -10,10 +10,10 @@ report contains violation if {
 	# skip iteration of refs if no print or trace calls are registered
 	util.intersects(ast.builtin_functions_called, {"print", "trace"})
 
-	ref := ast.found.refs[_][_]
+	ref := ast.found.refs[_][_][0]
 
-	ref[0].value[0].type == "var"
-	ref[0].value[0].value in {"print", "trace"}
+	ref.value[0].type == "var"
+	ref.value[0].value in {"print", "trace"}
 
-	violation := result.fail(rego.metadata.chain(), result.location(ref[0]))
+	violation := result.fail(rego.metadata.chain(), result.location(ref))
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -727,8 +727,8 @@ import data.unresolved`,
 	}
 }
 
-// 1133583042 ns/op	3185226192 B/op	61392363 allocs/op
-// 1111341875 ns/op	3181965048 B/op	61390130 allocs/op
+// 1173608750 ns/op	3293593016 B/op	63366367 allocs/op
+// 1157190875 ns/op	3285082192 B/op	63014329 allocs/op
 //
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {


### PR DESCRIPTION
This started out as simply improving the performance of ref comparisons, where we should avoid stringifying if possible. But eventually led to a series of smallish optimizations, mostly related to iteration, and to keep the scope of _what_ is iterated down to smaller components. This saves about 300k allocations in `regal lint bundle`.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->