### PR TITLE
Add max-test-rule-length setting to rule-length rule

### DIFF
--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -3,7 +3,6 @@ package regal.ast_test
 import data.regal.ast
 import data.regal.capabilities
 
-# regal ignore:rule-length
 test_find_vars if {
 	policy := `
 	package p
@@ -107,7 +106,6 @@ test_function_decls_multiple_same_name if {
 	is_object(custom)
 }
 
-# regal ignore:rule-length
 test_comment_blocks if {
 	policy := `package p
 
@@ -138,7 +136,6 @@ allow := true
 	]
 }
 
-# regal ignore:rule-length
 test_find_vars_in_local_scope if {
 	policy := `
 	package p

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -188,6 +188,7 @@ rules:
       except-empty-body: true
       level: error
       max-rule-length: 30
+      max-test-rule-length: 60
     rule-name-repeats-package:
       level: error
     todo-comment:

--- a/bundle/regal/lsp/completion/location/location_test.rego
+++ b/bundle/regal/lsp/completion/location/location_test.rego
@@ -5,7 +5,6 @@ import data.regal.capabilities
 
 import data.regal.lsp.completion.location
 
-# regal ignore:rule-length
 test_find_rule_from_location if {
 	policy := `package p
 
@@ -40,7 +39,6 @@ rule3 if {
 	ast.ref_to_string(r3.head.ref) == "rule3"
 }
 
-# regal ignore:rule-length
 test_find_locals_at_location[loc] if {
 	policy := `package p
 

--- a/bundle/regal/lsp/completion/providers/default/default_test.rego
+++ b/bundle/regal/lsp/completion/providers/default/default_test.rego
@@ -28,7 +28,6 @@ import rego.v1
 	}}
 }
 
-# regal ignore:rule-length
 test_default_completion_on_typing_with_rule_suggestions if {
 	policy := `package policy
 

--- a/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
+++ b/bundle/regal/lsp/completion/providers/inputdotjson/inputdotjson_test.rego
@@ -2,7 +2,6 @@ package regal.lsp.completion.providers.inputdotjson_test
 
 import data.regal.lsp.completion.providers.inputdotjson as provider
 
-# regal ignore:rule-length
 test_matching_input_suggestions if {
 	items := provider.items with input as input_obj
 	items == {

--- a/bundle/regal/lsp/completion/providers/packagename/packagename_test.rego
+++ b/bundle/regal/lsp/completion/providers/packagename/packagename_test.rego
@@ -33,7 +33,6 @@ test_package_name_completion_on_typing if {
 	}}
 }
 
-# regal ignore:rule-length
 test_package_name_completion_on_typing_multiple_suggestions if {
 	policy := `package b`
 	provider_input := {"regal": {
@@ -79,7 +78,6 @@ test_package_name_completion_on_typing_multiple_suggestions if {
 	}
 }
 
-# regal ignore:rule-length
 test_package_name_completion_on_typing_multiple_suggestions_when_invoked if {
 	policy := `package `
 	provider_input := {"regal": {

--- a/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
@@ -3,7 +3,6 @@ package regal.lsp.completion.providers.snippet_test
 import data.regal.lsp.completion.providers.snippet as provider
 import data.regal.lsp.completion.providers.test_utils as util
 
-# regal ignore:rule-length
 test_snippet_completion_on_typing_partial_prefix if {
 	policy := `package policy
 
@@ -43,7 +42,6 @@ allow if {
 	}
 }
 
-# regal ignore:rule-length
 test_snippet_completion_on_typing_full_prefix if {
 	policy := `package policy
 
@@ -96,7 +94,6 @@ allow if {
 	items == set()
 }
 
-# regal ignore:rule-length
 test_snippet_completion_on_invoked if {
 	policy := `package policy
 
@@ -160,7 +157,6 @@ allow if `
 	}
 }
 
-# regal ignore:rule-length
 test_metadata_snippet_completion if {
 	policy := `package policy
 

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -327,7 +327,6 @@ test_camelcase if {
 	{notice.title | some notice in result.lint.notices} == {"file-missing-test-suffix", "directory-package-mismatch"}
 }
 
-# regal ignore:rule-length
 test_main_lint if {
 	policy := `package p
 	x = 1`

--- a/bundle/regal/result/result_test.rego
+++ b/bundle/regal/result/result_test.rego
@@ -81,7 +81,6 @@ test_related_resources_generated_by_result_fail_for_builtin_rule if {
 	}
 }
 
-# regal ignore:rule-length
 test_aggregate_function_builtin_rule if {
 	chain := [
 		{"path": ["regal", "rules", "testing", "aggregation", "report"]},

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
@@ -47,7 +47,6 @@ test_success_similar_but_not_duplicate_rule if {
 	r == set()
 }
 
-# regal ignore:rule-length
 test_fail_multiple_duplicate_rules if {
 	module := ast.with_rego_v1(`
 

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
@@ -64,7 +64,6 @@ test_fail_multivalue_not_reference_different_package_using_direct_reference if {
 	})
 }
 
-# regal ignore:rule-length
 test_fail_multivalue_not_reference_different_package_using_import if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
@@ -4,7 +4,6 @@ import data.regal.ast
 import data.regal.config
 import data.regal.rules.bugs["not-equals-in-loop"] as rule
 
-# regal ignore:rule-length
 test_fail_neq_in_loop if {
 	r := rule.report with input as ast.policy(`deny if {
 		"admin" != input.user.groups[_]

--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
@@ -4,7 +4,6 @@ import data.regal.config
 
 import data.regal.rules.custom["missing-metadata"] as rule
 
-# regal ignore:rule-length
 test_success_aggregate_format_as_expected if {
 	module := regal.parse_module("p.rego", `# METADATA
 # title: pkg
@@ -66,7 +65,6 @@ package foo.bar
 	r == set()
 }
 
-# regal ignore:rule-length
 test_fail_missing_package_metadata_report if {
 	module := regal.parse_module("p.rego", "package foo.bar")
 	aggregated := rule.aggregate with input as module

--- a/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention_test.rego
@@ -146,7 +146,6 @@ test_success_var_name_matches_pattern if {
 	r == set()
 }
 
-# regal ignore:rule-length
 test_fail_multiple_conventions if {
 	policy := regal.parse_module("policy.rego", `package foo.bar
 

--- a/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint_test.rego
+++ b/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint_test.rego
@@ -4,7 +4,6 @@ import data.regal.config
 
 import data.regal.rules.idiomatic["no-defined-entrypoint"] as rule
 
-# regal ignore:rule-length
 test_aggregate_entrypoints if {
 	module := regal.parse_module("policy.rego", `
 # METADATA

--- a/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars_test.rego
+++ b/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars_test.rego
@@ -30,7 +30,6 @@ test_fail_output_var_not_declared if {
 	}}
 }
 
-# regal ignore:rule-length
 test_fail_multiple_output_vars_not_declared if {
 	r := rule.report with input as ast.policy(`allow if {
 		foo := input.foo[i].bar[j]

--- a/bundle/regal/rules/imports/circular-import/circular_import_test.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import_test.rego
@@ -53,7 +53,6 @@ test_aggregate_rule_contains_single_self_ref if {
 	}}
 }
 
-# regal ignore:rule-length
 test_aggregate_rule_surfaces_refs if {
 	module := regal.parse_module("example.rego", `
     package policy.foo

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
@@ -4,7 +4,6 @@ import data.regal.config
 
 import data.regal.rules.imports["prefer-package-imports"] as rule
 
-# regal ignore:rule-length
 test_aggregate_collects_imports_with_location if {
 	r := rule.aggregate with input as regal.parse_module("p.rego", `
 	package a

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -4,7 +4,6 @@ import data.regal.config
 
 import data.regal.rules.imports["unresolved-import"] as rule
 
-# regal ignore:rule-length
 test_fail_identifies_unresolved_imports if {
 	agg1 := rule.aggregate with input as regal.parse_module("p1.rego", `package foo
 	import data.bar

--- a/bundle/regal/rules/style/file-length/file_length_test.rego
+++ b/bundle/regal/rules/style/file-length/file_length_test.rego
@@ -4,7 +4,6 @@ import data.regal.config
 
 import data.regal.rules.style["file-length"] as rule
 
-# regal ignore:rule-length
 test_fail_configured_file_length_exceeded if {
 	module := regal.parse_module("policy.rego", `package policy
 

--- a/bundle/regal/rules/style/rule-length/rule_length.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length.rego
@@ -13,7 +13,7 @@ report contains violation if {
 
 	lines := split(util.to_location_object(rule.location).text, "\n")
 
-	_line_count(cfg, rule, lines) > cfg["max-rule-length"]
+	_line_count(cfg, rule, lines) > cfg[_max_length_property(rule.head)]
 
 	not _generated_body_exception(cfg, rule)
 
@@ -24,6 +24,10 @@ _generated_body_exception(conf, rule) if {
 	conf["except-empty-body"] == true
 	not rule.body
 }
+
+default _max_length_property(_) := "max-rule-length"
+
+_max_length_property(head) := "max-test-rule-length" if startswith(head.ref[0].value, "test_")
 
 _line_count(cfg, _, lines) := count(lines) if cfg["count-comments"] == true
 

--- a/bundle/regal/rules/style/rule-length/rule_length_test.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length_test.rego
@@ -4,8 +4,6 @@ import data.regal.config
 
 import data.regal.rules.style["rule-length"] as rule
 
-# yes, ironic
-# regal ignore:rule-length
 test_fail_rule_longer_than_configured_max_length if {
 	module := regal.parse_module("policy.rego", `package p
 

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
@@ -79,7 +79,6 @@ test_rule_violation_if_repetition_of_more_than_one_path_component if {
 	}
 }
 
-# regal ignore:rule-length
 test_rule_violation_if_repetition_multiple if {
 	module := regal.parse_module("example.rego", `
     package policy.foo.bar

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
@@ -223,7 +223,6 @@ test_success_ref_head_rule_with_var_if if {
 	r == set()
 }
 
-# regal ignore:rule-length
 test_fail_unification_in_else if {
 	r := rule.report with input as ast.with_rego_v1(`
 	allow if {

--- a/docs/rules/style/rule-length.md
+++ b/docs/rules/style/rule-length.md
@@ -32,6 +32,8 @@ rules:
       level: error
       # default limit is 30 lines
       max-rule-length: 30
+      # default limit is 60 lines for test rules (i.e. prefixed with 'test_')
+      max-test-rule-length: 60
       # whether to count comments as lines
       # by default, this is set to false
       count-comments: false


### PR DESCRIPTION
Since tests are often mostly data, there is little to gain by moving relevant data outside of tests. This PR introduces a max-test-rule-length setting, which by default is set to 60 rather than 30, which is the default for other rules.

Finally getting rid of all inline ignore directives related to this in our tests!

Fixes #1125

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->