### PR TITLE
FindConfigRoots: return error, not panic

### DIFF
--- a/internal/lsp/config/find.go
+++ b/internal/lsp/config/find.go
@@ -14,7 +14,11 @@ import (
 func FindConfigRoots(path string) ([]string, error) {
 	var foundRoots []string
 
-	err := filepath.WalkDir(path, func(path string, info os.DirEntry, _ error) error {
+	err := filepath.WalkDir(path, func(path string, info os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if info.IsDir() || !strings.HasSuffix(path, ".yaml") {
 			return nil
 		}


### PR DESCRIPTION
Stumbled upon this when playing with the LSP and sending bad init parameters -- that caused `err` to be non-nil, and ran into a nil deref on `info.IsDir()` 💥 

Happy to add a test if you can point out a good spot 😄 