### PR TITLE
perf: Improve how config is parsed, and when

### DIFF
--- a/bundle/regal/config/config_test.rego
+++ b/bundle/regal/config/config_test.rego
@@ -15,15 +15,15 @@ params(override) := object.union(
 )
 
 test_disable_all_no_config if {
-	c := config.for_rule("test", "test-case") with data.eval.params as params({"disable_all": true})
+	c := config.level_for_rule("test", "test-case") with data.eval.params as params({"disable_all": true})
 
-	c == {"level": "ignore"}
+	c == "ignore"
 }
 
 test_enable_all_no_config if {
-	c := config.for_rule("test", "test-case") with data.eval.params as params({"enable_all": true})
+	c := config.level_for_rule("test", "test-case") with data.eval.params as params({"enable_all": true})
 
-	c == {"level": "error"}
+	c == "error"
 }
 
 test_config[name] if {
@@ -46,13 +46,16 @@ test_config[name] if {
 		"enable_single_rule_with_config": [{"enable": ["test-case"]}, "error"],
 	}
 
-	c := config.for_rule("test", "test-case") with data.eval.params as params(override)
-		with config.merged_config as {"rules": {"test": {"test-case": {
-			"level": "ignore",
-			"important_setting": 42,
-		}}}}
+	l := config.level_for_rule("test", "test-case") with data.eval.params as params(override)
 
-	c == {"level": want_level, "important_setting": 42}
+	l == want_level
+
+	c := config.for_rule("test", "test-case") with config.merged_config as {"rules": {"test": {"test-case": {
+		"level": "ignore",
+		"important_setting": 42,
+	}}}}
+
+	c == {"level": "ignore", "important_setting": 42}
 }
 
 test_all_rules_are_in_provided_configuration if {
@@ -75,8 +78,6 @@ test_all_configured_rules_exist if {
 
 	count(missing_rules) == 0
 }
-
-test_default_level_is_error if config.rule_level("unknown") == "error"
 
 test_path_prefix if {
 	config.path_prefix == ""

--- a/bundle/regal/result/result.rego
+++ b/bundle/regal/result/result.rego
@@ -148,7 +148,7 @@ _fail_annotated(metadata, details) := violation if {
 	category := with_location.custom.category
 	with_category := object.union(with_location, {
 		"category": category,
-		"level": config.rule_level(config.for_rule(category, metadata.title)),
+		"level": config.level_for_rule(category, metadata.title),
 	})
 
 	without_custom_and_scope := object.remove(with_category, ["custom", "scope", "schemas"])
@@ -166,7 +166,7 @@ _fail_annotated_custom(metadata, details) := violation if {
 	category := with_location.custom.category
 	with_category := object.union(with_location, {
 		"category": category,
-		"level": config.rule_level(config.for_rule(category, metadata.title)),
+		"level": config.level_for_rule(category, metadata.title),
 	})
 
 	violation := object.remove(with_category, ["custom", "scope", "schemas"])

--- a/pkg/linter/linter.go
+++ b/pkg/linter/linter.go
@@ -541,7 +541,7 @@ func (l Linter) DetermineEnabledRules(ctx context.Context) ([]string, error) {
 	queryStr := `[rule |
         data.regal.rules[cat][rule]
 		object.get(data.regal.rules[cat][rule], "notices", set()) == set()
-        data.regal.config.for_rule(cat, rule).level != "ignore"
+        not data.regal.config.ignored_rule(cat, rule)
     ]`
 
 	query := ast.MustParseBody(queryStr)
@@ -595,7 +595,7 @@ func (l Linter) DetermineEnabledAggregateRules(ctx context.Context) ([]string, e
 
 	queryStr := `[rule |
         data.regal.rules[cat][rule].aggregate
-        data.regal.config.for_rule(cat, rule).level != "ignore"
+        not data.regal.config.ignored_rule(cat, rule)
     ]`
 
 	query := ast.MustParseBody(queryStr)

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -728,8 +728,8 @@ import data.unresolved`,
 	}
 }
 
-// 1173608750 ns/op	3293593016 B/op	63366367 allocs/op
-// 1157190875 ns/op	3285082192 B/op	63014329 allocs/op
+// 1188808042 ns/op	3332404200 B/op	63908530 allocs/op
+// 1148661583 ns/op	3173734464 B/op	61290539 allocs/op
 //
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {


### PR DESCRIPTION
**main**
```
1188808042 ns/op	3332404200 B/op	63908530 allocs/op
```
**this**
```
1148661583 ns/op	3173734464 B/op	61290539 allocs/op
```

2,7 million allocs!

Mostly guided by `--profile` metrics, which suggested a lot of time being spent in config.rego. That is interesting, as there isn't really anything there that would easily map to the pprof heap dumps. And there weren't any real bottlenecks to be found either. Just custom functions called very frequently, and some objects getting unioned constantly, even though the info added (the calculated level) almost never matters, as the main route won't even consider ignored policies.

This makes it much cheaper to check for the actual level for a rule from the main.rego composition, while also making it much cheaper to get the config for a rule by *not* merging the data (level) we normally don't care for. So a win-win really!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->