### PR TITLE
docs: fix docs that still used v0 syntax

### DIFF
--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -78,6 +78,21 @@ _find_every_vars(value) := vars if {
 
 # METADATA
 # description: |
+#   true if a var of 'name' can be found in the provided AST node
+has_named_var(node, name) if {
+	node.type == "var"
+	node.value == name
+} else if {
+	node.type in {"array", "object", "set", "ref"}
+
+	walk(node.value, [_, nested])
+
+	nested.type == "var"
+	nested.value == name
+}
+
+# METADATA
+# description: |
 #   traverses all nodes in provided terms (using `walk`), and returns an array with
 #   all variables declared in terms, i,e [x, y] or {x: y}, etc.
 find_term_vars(terms) := [term |
@@ -208,16 +223,12 @@ found.vars[rule_index][context] contains var if {
 }
 
 found.vars[rule_index].ref contains var if {
-	some i, rule in _rules
-
 	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
-	rule_index := rule_index_strings[i]
+	some rule_index in rule_index_strings
+	some ref
+	found.refs[rule_index][ref].type == "ref"
 
-	walk(rule, [_, value])
-
-	value.type == "ref"
-
-	some x, var in value.value
+	some x, var in ref.value
 	x > 0
 	var.type == "var"
 }

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -43,13 +43,7 @@ lint.aggregate.violations := aggregate_report if {
 }
 
 _file_name_relative_to_root(filename, "/") := trim_prefix(filename, "/")
-
-_file_name_relative_to_root(filename, root) := trim_prefix(
-	filename,
-	concat("", [root, "/"]),
-) if {
-	root != "/"
-}
+_file_name_relative_to_root(filename, root) := trim_prefix(filename, concat("", [root, "/"])) if root != "/"
 
 _rules_to_run[category] contains title if {
 	relative_filename := _file_name_relative_to_root(input.regal.file.name, config.path_prefix)

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego
@@ -50,8 +50,6 @@ _ref_vars[rule_index][var.value] contains var if {
 _ref_base_vars[rule_index][term.value] contains term if {
 	some rule_index
 	term := ast.found.refs[rule_index][_].value[0]
-
-	not ast.is_wildcard(term)
 }
 
 _comprehension_term_vars[rule_index] contains var.value if {

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego
@@ -6,14 +6,16 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
+	# NOTE: All these cases already covered by opa fmt
 	# foo = "bar"
 	# default foo = "bar"
 	# foo(bar) = "baz"
 	# default foo(_) = "bar"
 	some rule in input.rules
+
+	rule.head.value.location
 	not rule.head.assign
 	not rule.head.key
-	not ast.implicit_boolean_assignment(rule)
 	not ast.is_chained_rule_body(rule, input.regal.file.lines)
 
 	loc := result.location(rule.head)

--- a/docs/rules/idiomatic/use-some-for-output-vars.md
+++ b/docs/rules/idiomatic/use-some-for-output-vars.md
@@ -8,7 +8,7 @@
 ```rego
 package policy
 
-allow {
+allow if {
     userinfo := data.users[id]
     # ...
 }
@@ -16,14 +16,16 @@ allow {
 
 **Prefer**
 ```rego
-allow {
+package policy
+
+allow if {
     some id
     userinfo := data.users[id]
     # ...
 }
 
 # alternatively, and arguably more idiomatic:
-allow {
+allow if {
     some id, userinfo in data.users
     # ...
 }

--- a/docs/rules/style/use-assignment-operator.md
+++ b/docs/rules/style/use-assignment-operator.md
@@ -28,7 +28,7 @@ default allow := false
 
 first_name(full_name) := split(full_name, " ")[0]
 
-allow {
+allow if {
     username := input.user.name
     # .. more conditions ..
 }
@@ -46,7 +46,7 @@ While it often is "harmless" to use the unification operator (`=`) for assignmen
 removes any ambiguities around intent, and prevents some hard to debug issues. Consider:
 
 ```rego
-allow {
+allow if {
     username = input.user.name
     # .. more conditions ..
 }

--- a/docs/rules/testing/dubious-print-sprintf.md
+++ b/docs/rules/testing/dubious-print-sprintf.md
@@ -8,7 +8,7 @@
 ```rego
 package policy
 
-allow {
+allow if {
     # if any of input.name or input.domain are undefined, this will just print <undefined>
     print(sprintf("name is: %s domain is: %s", [input.name, input.domain]))
 
@@ -20,7 +20,7 @@ allow {
 ```rego
 package policy
 
-allow {
+allow if {
     # if any of input.name or input.domain are undefined, this will still print the whole
     # sentence, with the value undefined printed as such, e.g.
     # name is: admin domain is: <undefined>

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -728,8 +728,7 @@ import data.unresolved`,
 	}
 }
 
-// 1145727583 ns/op	3184970896 B/op	61571557 allocs/op
-// 1083952583 ns/op	3105174424 B/op	59992494 allocs/op
+// 1070530708 ns/op	3041023912 B/op	58063258 allocs/op
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	linter := NewLinter().
@@ -759,6 +758,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 // 268203979 ns/op	501748262 B/op	 9724107 allocs/op
 // 258819136 ns/op	497016108 B/op	 9632445 allocs/op
 // 170215493 ns/op	497115590 B/op	 9228106 allocs/op
+// 155879726 ns/op	444934614 B/op	 8362362 allocs/op
 // ...
 func BenchmarkRegalNoEnabledRules(b *testing.B) {
 	linter := NewLinter().


### PR DESCRIPTION
Also a small few perf fixes I hadn't committed before. Small but
with quite an impact. ~2 million allocs!

```
1088929208 ns/op        3104908016 B/op 59995728 allocs/op
1070530708 ns/op        3041023912 B/op 58063258 allocs/op
```

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->