### PR TITLE
Make external-reference rule less annoying

### DIFF
--- a/bundle/regal/ast/imports.rego
+++ b/bundle/regal/ast/imports.rego
@@ -62,7 +62,7 @@ imports_has_path(imports, path) if {
 #   returns whether a keyword is imported in the policy, either explicitly
 #   like "future.keywords.if" or implicitly like "future.keywords" or "rego.v1"
 imports_keyword(imports, keyword) if {
-	capabilities.is_opa_v1 # regal ignore:external-reference
+	capabilities.is_opa_v1
 	input.regal.file.rego_version != "v0"
 } else if {
 	pv := imports[_].path.value

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -105,7 +105,7 @@ _find_vars(value, last) := {"term": find_term_vars(function_ret_args(fn_name, va
 	fn_name := ref_to_string(value[0].value)
 
 	not contains(fn_name, "$")
-	fn_name in all_function_names # regal ignore:external-reference
+	fn_name in all_function_names
 	function_ret_in_args(fn_name, value)
 }
 
@@ -146,7 +146,7 @@ _find_vars(value, last) := {"args": arg_vars} if {
 	count(arg_vars) > 0
 }
 
-_rule_index(rule) := rule_index_strings[i] if { # regal ignore:external-reference
+_rule_index(rule) := rule_index_strings[i] if {
 	some i, r in _rules
 	r == rule
 }
@@ -278,9 +278,9 @@ found.comprehensions[rule_index] contains value if {
 #   assignments / unification, but it's likely good enough since other rules
 #   recommend against those
 find_vars_in_local_scope(rule, location) := [var |
-	var := found.vars[_rule_index(rule)][_][_] # regal ignore:external-reference
+	var := found.vars[_rule_index(rule)][_][_]
 
-	not is_wildcard(var)
+	not startswith(var.value, "$")
 	_before_location(rule.head, var, util.to_location_object(location))
 ]
 
@@ -351,7 +351,7 @@ find_names_in_scope(rule, location) := names if {
 #   find all variables declared via `some` declarations (and *not* `some .. in`)
 #   in the scope of the given location
 find_some_decl_names_in_scope(rule, location) := {some_var.value |
-	some some_var in found.vars[_rule_index(rule)]["some"] # regal ignore:external-reference
+	some some_var in found.vars[_rule_index(rule)]["some"]
 	_before_location(rule.head, some_var, location)
 }
 

--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -29,6 +29,10 @@ docs["resolve_url"](url, category) := replace(
 merged_config := data.internal.combined_config
 
 # METADATA
+# description: the merged (default and user) configuration for rules
+rules := merged_config.rules
+
+# METADATA
 # description: the resolved capabilities sourced from Regal and user configuration
 capabilities := object.union(merged_config.capabilities, {"special": _special})
 
@@ -49,14 +53,14 @@ default for_rule(_, _) := {"level": "error"}
 #   potentially also overrides. Use `level_for_rule` to determine the
 #   exact level as determined during evaluation.
 # scope: document
-for_rule(category, title) := merged_config.rules[category][title] # regal ignore:external-reference
+for_rule(category, title) := rules[category][title]
 
 # METADATA
 # description: answers whether a rule is ignored in the most efficient way
 ignored_rule(category, title) if {
 	_force_disabled(_params, category, title)
 } else if {
-	merged_config.rules[category][title].level == "ignore"
+	rules[category][title].level == "ignore"
 	not _force_enabled(_params, category, title)
 }
 
@@ -67,10 +71,10 @@ level_for_rule(category, title) := "ignore" if {
 } else := "error" if {
 	_force_enabled(_params, category, title)
 } else := level if {
-	level := merged_config.rules[category][title].level # regal ignore:external-reference
+	level := rules[category][title].level
 } else := "error"
 
-_force_disabled(params, _, title) if title in params.disable # regal ignore:external-reference
+_force_disabled(params, _, title) if title in params.disable
 
 _force_disabled(params, category, title) if {
 	params.disable_all

--- a/bundle/regal/config/exclusion.rego
+++ b/bundle/regal/config/exclusion.rego
@@ -5,7 +5,6 @@ package regal.config
 #   determines if file should be excluded, either because it's globally
 #   ignored, or because the specific rule configuration excludes it
 excluded_file(category, title, file) if {
-	# regal ignore:external-reference
 	some pattern in _global_ignore_patterns
 	_exclude(pattern, file)
 } else if {

--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -159,6 +159,7 @@ rules:
       level: error
     external-reference:
       level: error
+      max-allowed: 2
     file-length:
       level: error
       max-file-length: 500

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -55,7 +55,7 @@ _rules_to_run[category] contains title if {
 	relative_filename := _file_name_relative_to_root(input.regal.file.name, config.path_prefix)
 
 	some category, title
-	config.merged_config.rules[category][title]
+	config.rules[category][title]
 
 	not config.ignored_rule(category, title)
 	not config.excluded_file(category, title, relative_filename)

--- a/bundle/regal/main/main_test.rego
+++ b/bundle/regal/main/main_test.rego
@@ -193,9 +193,7 @@ test_exclude_files_rule_config if {
 }
 
 test_exclude_files_rule_config_with_path_prefix_relative_name if {
-	cfg := {"rules": {"testing": {"test": {"level": "error"}}}}
-
-	rules_to_run := main._rules_to_run with config.merged_config as cfg
+	rules_to_run := main._rules_to_run with config.rules as {"testing": {"test": {"level": "error"}}}
 		with config.for_rule as {"level": "error", "ignore": {"files": ["bar/*"]}}
 		with input.regal.file.name as "bar/p.rego"
 		with config.path_prefix as "/foo" # ignored as not prefix of input file

--- a/bundle/regal/result/result.rego
+++ b/bundle/regal/result/result.rego
@@ -45,10 +45,8 @@ aggregate(chain, aggregate_data) := entry if {
 			"title": title,
 		},
 		"aggregate_source": {
-			# regal ignore:external-reference
 			"file": input.regal.file.name,
 			"package_path": [part.value |
-				# regal ignore:external-reference
 				some i, part in input["package"].path
 				i > 0
 			],
@@ -137,7 +135,6 @@ _related_resources(annotations, category, title) := rr if {
 	not annotations.related_resources
 	rr := [{
 		"description": "documentation",
-		# regal ignore:external-reference
 		"ref": sprintf("%s/%s/%s", [config.docs.base_url, category, title]),
 	}]
 }
@@ -183,8 +180,8 @@ _resource_urls(related_resources, category) := [r |
 # the range and will highlight based on that rather than `text`.
 _with_text(loc_obj) := loc if {
 	loc := {"location": object.union(loc_obj, {
-		"file": input.regal.file.name, # regal ignore:external-reference
-		"text": input.regal.file.lines[loc_obj.row - 1], # regal ignore:external-reference
+		"file": input.regal.file.name,
+		"text": input.regal.file.lines[loc_obj.row - 1],
 	})}
 
 	loc_obj.row

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not_test.rego
@@ -214,5 +214,4 @@ expected := {
 	"title": "impossible-not",
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
@@ -106,5 +106,4 @@ expected := {
 	"location": {"file": "policy.rego"},
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
@@ -102,5 +102,4 @@ expected := {
 	"location": {"file": "policy.rego"},
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -8,11 +8,8 @@ import data.regal.result
 
 # target: package
 report contains violation if {
-	cfg := config.for_rule("custom", "naming-convention")
-	some convention in cfg.conventions
-	some target in convention.targets
-
-	target == "package"
+	some convention in config.rules.custom["naming-convention"].conventions
+	"package" in convention.targets
 
 	not regex.match(convention.pattern, ast.package_name)
 
@@ -27,11 +24,8 @@ report contains violation if {
 
 # target: rule
 report contains violation if {
-	cfg := config.for_rule("custom", "naming-convention")
-	some convention in cfg.conventions
-	some target in convention.targets
-
-	target == "rule"
+	some convention in config.rules.custom["naming-convention"].conventions
+	"rule" in convention.targets
 
 	some rule in ast.rules
 
@@ -50,11 +44,8 @@ report contains violation if {
 
 # target: function
 report contains violation if {
-	cfg := config.for_rule("custom", "naming-convention")
-	some convention in cfg.conventions
-	some target in convention.targets
-
-	target == "function"
+	some convention in config.rules.custom["naming-convention"].conventions
+	"function" in convention.targets
 
 	some rule in ast.functions
 

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
@@ -66,7 +66,7 @@ _first_named_arg_location(indices, name) := [arg.location |
 
 _arg_used_in_call(indices, name) if {
 	some i in indices
-	some call in ast.function_calls[ast.rule_index_strings[i]] # regal ignore:external-reference
+	some call in ast.function_calls[ast.rule_index_strings[i]]
 	some arg in call.args
 
 	# only check for vars here, as refs are already dealt with

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
@@ -165,5 +165,4 @@ expected := {
 	"location": {"file": "policy.rego"},
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})}

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
@@ -148,5 +148,4 @@ expected := {
 	"location": {"file": "policy.rego"},
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})}

--- a/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
+++ b/bundle/regal/rules/idiomatic/equals-pattern-matching/equals_pattern_matching_test.rego
@@ -121,5 +121,4 @@ expected := {
 	"location": {"file": "policy.rego"},
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)

--- a/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
+++ b/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator_test.rego
@@ -251,5 +251,4 @@ expected := {
 	"location": {"file": "policy.rego"},
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)

--- a/bundle/regal/rules/style/external-reference/external_reference.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference.rego
@@ -3,30 +3,32 @@
 package regal.rules.style["external-reference"]
 
 import data.regal.ast
+import data.regal.config
 import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	fn_namespaces := {split(name, ".")[0] | some name in object.keys(ast.all_functions)}
+	fn_namespaces := {split(name, ".")[0] | some name in ast.all_function_names}
 
-	some fn in ast.functions
-
-	args_vars := _args_vars(fn.head.args)
-
-	head_vars := {v.value | some v in ast.find_vars(fn.head.value)}
-	body_vars := {v.value | some v in ast.find_vars(fn.body)}
-	else_vars := {v.value | some v in ast.find_vars(fn["else"])}
-	own_vars := (body_vars | head_vars) | else_vars
+	some i
+	arg_vars := _args_vars(input.rules[i].head.args)
+	own_vars := {value | value := ast.found.vars[ast.rule_index_strings[i]][_][_].value}
 
 	# note: parens added by opa fmt 🤦
-	allowed_refs := (args_vars | own_vars) | fn_namespaces
+	allowed_refs := (arg_vars | own_vars) | fn_namespaces
 
-	walk(fn, [path, value])
+	external := [value |
+		walk(input.rules[i], [path, value])
 
-	value.type == "var"
-	not value.value in allowed_refs
-	not ast.is_wildcard(value)
-	not _function_call_ctx(fn, path)
+		value.type == "var"
+		not value.value in allowed_refs
+		not startswith(value.value, "$")
+		not _function_call_ctx(input.rules[i], path)
+	]
+
+	count(external) > object.get(config.rules, ["style", "external-reference", "max-allowed"], 2)
+
+	some value in external
 
 	violation := result.fail(rego.metadata.chain(), result.location(value))
 }
@@ -48,6 +50,8 @@ _named_vars(arg) := {var.value | some var in ast.find_term_vars(arg)} if arg.typ
 #   defined in the same package, as those are already covered by
 #   "fn_namespaces" in the report rule
 _function_call_ctx(fn, path) if {
+	object.get(fn, array.slice(path, 0, count(path) - 4), {}).type == "call"
+} else if {
 	terms_path := array.slice(path, 0, util.last_indexof(path, "terms") + 2)
 	next_term_path := array.concat(
 		array.slice(terms_path, 0, count(terms_path) - 1), # ["body", 0, "terms", 0] -> ["body", 0, "terms"]
@@ -58,5 +62,3 @@ _function_call_ctx(fn, path) if {
 
 	object.get(fn, next_term_path, null) != null
 }
-
-_function_call_ctx(fn, path) if object.get(fn, array.slice(path, 0, count(path) - 4), {}).type == "call"

--- a/bundle/regal/rules/style/external-reference/external_reference_test.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference_test.rego
@@ -7,7 +7,11 @@ import data.regal.rules.style["external-reference"] as rule
 
 test_fail_function_references_input if {
 	r := rule.report with input as ast.policy(`f(_) if { input.foo }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == expected_with_location({
 		"col": 11,
 		"file": "policy.rego",
@@ -22,7 +26,11 @@ test_fail_function_references_input if {
 
 test_fail_function_references_data if {
 	r := rule.report with input as ast.policy(`f(_) if { data.foo }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == expected_with_location({
 		"col": 11,
 		"file": "policy.rego",
@@ -39,7 +47,11 @@ test_fail_function_references_data_in_expr if {
 	r := rule.report with input as ast.policy(`f(x) if {
 		x == data.foo
 	}`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == expected_with_location({
 		"col": 8,
 		"file": "policy.rego",
@@ -61,7 +73,11 @@ f(x, y) if {
 	y == foo
 }
 	`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == expected_with_location({
 		"col": 7,
 		"file": "policy.rego",
@@ -76,7 +92,11 @@ f(x, y) if {
 
 test_fail_external_reference_in_head_assignment if {
 	r := rule.report with input as ast.policy(`f(_) := r`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == expected_with_location({
 		"col": 9,
 		"file": "policy.rego",
@@ -91,7 +111,11 @@ test_fail_external_reference_in_head_assignment if {
 
 test_fail_external_reference_in_head_terms if {
 	r := rule.report with input as ast.policy(`f(_) := {"r": r}`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == expected_with_location({
 		"col": 15,
 		"file": "policy.rego",
@@ -106,62 +130,127 @@ test_fail_external_reference_in_head_terms if {
 
 test_success_function_references_no_input_or_data if {
 	r := rule.report with input as ast.policy(`f(x) if { x == true }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_no_input_or_data_reverse if {
 	r := rule.report with input as ast.policy(`f(x) if { true == x }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_only_own_vars if {
 	r := rule.report with input as ast.policy(`f(x) if { y := x; y == 10 }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_only_own_vars_nested if {
 	r := rule.report with input as ast.policy(`f(x, z) if { y := x; y == [1, 2, z]}`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_only_own_vars_and_wildcard if {
 	r := rule.report with input as ast.policy(`f(x, y) if { _ = x + y }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_return_var if {
 	r := rule.report with input as ast.policy(`f(x) := y if { y = true }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_return_vars if {
 	r := rule.report with input as ast.policy(`f(x) := [x, y] if { x = false; y = true }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_external_function if {
 	r := rule.report with input as ast.policy(`f(x) if { data.foo.bar(x) }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 
 test_success_function_references_external_function_in_expr if {
 	r := rule.report with input as ast.policy(`f(x) := y if { y := data.foo.bar(x) }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
+}
+
+test_external_references_max_allowed_configuration if {
+	module := ast.policy(`f(x) if {
+		data.x
+		data.y
+		data.z
+		data.a 
+	}`)
+
+	r1 := rule.report with input as module with data.internal.combined_config as {
+		"capabilities": capabilities.provided,
+		"rules": {"style": {"external-reference": {"max-allowed": 4}}},
+	}
+
+	r1 == set()
+
+	r2 := rule.report with input as module with data.internal.combined_config as {
+		"capabilities": capabilities.provided,
+		"rules": {"style": {"external-reference": {"max-allowed": 2}}},
+	}
+
+	# note that we could, flag only the external references above the threshold, but that's potentially
+	# confusing I think, as there's nothing more "illegal" about the last one than the first?
+	count(r2) == 4
 }
 
 # verify fix for https://github.com/StyraInc/regal/issues/1283
 test_success_variable_from_nested_arg_term if {
 	r := rule.report with input as ast.policy(`f([x]) := to_number(x)`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
+		}
+
 	r == set()
 }
 

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return.rego
@@ -7,10 +7,8 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule("style", "function-arg-return")
-
-	excluded_functions := {name | some name in cfg["except-functions"]} | {"print"}
-	included_functions := ast.all_function_names - excluded_functions
+	excluded_functions := {name | some name in config.rules.style["function-arg-return"]["except-functions"]}
+	included_functions := (ast.all_function_names - excluded_functions) - {"print"}
 
 	some fn
 	ast.function_calls[_][fn].name in included_functions

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
@@ -7,7 +7,6 @@ import data.regal.rules.style["function-arg-return"] as rule
 
 test_fail_function_arg_return_value if {
 	r := rule.report with input as ast.policy(`foo := i if { indexof("foo", "o", i) }`)
-		with config.for_rule as {"level": "error"}
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
 
 	r == {{
@@ -34,8 +33,8 @@ test_fail_function_arg_return_value if {
 
 test_fail_function_arg_return_value_multi_part_ref if {
 	r := rule.report with input as ast.policy(`foo := r if { regex.match("foo", "foo", r) }`)
-		with config.for_rule as {"level": "error"}
 		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == {{
 		"category": "style",
 		"description": "Function argument used for return value",
@@ -60,10 +59,10 @@ test_fail_function_arg_return_value_multi_part_ref if {
 
 test_success_function_arg_return_value_except_function if {
 	r := rule.report with input as ast.with_rego_v1(`foo := i if { indexof("foo", "o", i) }`)
-		with config.for_rule as {
-			"level": "error",
-			"except-functions": ["indexof"],
+		with data.internal.combined_config as {
+			"capabilities": capabilities.provided,
+			"rules": {"style": {"function-arg-return": {"except-functions": ["indexof"]}}},
 		}
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+
 	r == set()
 }

--- a/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
+++ b/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
@@ -153,5 +153,4 @@ expected := {
 	"location": {"file": "policy.rego"},
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)

--- a/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
+++ b/bundle/regal/rules/style/pointless-reassignment/pointless_reassignment.rego
@@ -19,8 +19,7 @@ report contains violation if {
 
 # pointless reassignment in rule body
 report contains violation if {
-	some rule in input.rules
-	some expr in rule.body
+	expr := input.rules[_].body[_]
 
 	not expr["with"]
 

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -80,8 +80,8 @@ _invalid_some_context(rule, path) if {
 
 	node.terms[0].type == "ref"
 	node.terms[0].value[0].type == "var"
-	node.terms[0].value[0].value in ast.all_function_names # regal ignore:external-reference
-	not node.terms[0].value[0].value in ast.operators # regal ignore:external-reference
+	node.terms[0].value[0].value in ast.all_function_names
+	not node.terms[0].value[0].value in ast.operators
 }
 
 # if previous node is of type call, also don't recommend `some .. in`
@@ -98,5 +98,5 @@ _impossible_some(node) if {
 	node.terms[0].value[0].value in {"eq", "equal"}
 
 	some term in node.terms
-	term.type in ast.scalar_types # regal ignore:external-reference
+	term.type in ast.scalar_types
 }

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
@@ -90,10 +90,8 @@ expected := {
 	"title": "yoda-condition",
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": location})} if is_object(location)
 
-# regal ignore:external-reference
 expected_with_location(location) := {object.union(expected, {"location": loc}) |
 	some loc in location
 } if {

--- a/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
+++ b/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
@@ -92,5 +92,4 @@ expected := {
 	"title": "metasyntactic-variable",
 }
 
-# regal ignore:external-reference
 expected_with_location(location) := object.union(expected, {"location": location})

--- a/docs/rules/style/external-reference.md
+++ b/docs/rules/style/external-reference.md
@@ -34,7 +34,7 @@ is_preferred_login_method(method, user, all_login_methods) if {
 
 ## Rationale
 
-What separates functions from rules is that they accept arguments. While a function too may reference anything from
+What separates functions from rules is that they accept arguments. While a function also may reference anything from
 `input`, `data` or other rules declared in a policy, these references create dependencies that aren't obvious simply by
 checking the function signature, and it makes it harder to reuse that function in other contexts. Additionally,
 functions that only depend on their arguments are easier to test standalone.
@@ -58,6 +58,18 @@ first_name(full_name) := capitalized {
 }
 ```
 
+### Changed default behavior since Regal v0.33.0
+
+While we still consider it a best practice to pass any dependencies of a function in its arguments, the previous
+(non-configurable) default of not allowing **any** external references was often considered too distracting. This led
+to many disabling this rule entirely, or used inline ignore directives where this would be reported. Even in Regal's own
+policies, there were quite a few locations where the latter option was used.
+
+From v0.33.0 and onwards, this rule's default has been relaxed to allow 2 external references in any given function
+definition, and the new `max-allowed` configuration option allows changing this value to whatever feels like a
+reasonable default. If you previously disabled this rule in your projects, consider enabling it again configured to
+match your preference.
+
 ## Configuration Options
 
 This linter rule provides the following configuration options:
@@ -68,6 +80,11 @@ rules:
     external-reference:
       # one of "error", "warning", "ignore"
       level: error
+      # the number of external references to allow for any given function
+      #
+      # introduced in v0.33.0 and defaults to 2. set to 0 to revert to
+      # original behavior to not allow any external references
+      max-allowed: 2
 ```
 
 ## Related Resources

--- a/e2e/e2e_conf.yaml
+++ b/e2e/e2e_conf.yaml
@@ -3,3 +3,8 @@ project:
   roots:
     - path: v0
       rego-version: 0
+
+rules:
+  style:
+    external-reference:
+      max-allowed: 0

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -729,6 +729,7 @@ import data.unresolved`,
 }
 
 // 1145727583 ns/op	3184970896 B/op	61571557 allocs/op
+// 1083952583 ns/op	3105174424 B/op	59992494 allocs/op
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	linter := NewLinter().


### PR DESCRIPTION
And configurable! Instead of flagging all external references in a function, we now allow setting a max number of allowed external references, and have changed the default tolerance from 0 to 2. I hope this will make the rule less distracting, while still help flag excessive undeclared dependencies.

As per usual, a few performance improvements related to code I was working on here also got included, and in particular the improvements to the rule itself made the biggest difference.

```
1145727583 ns/op	3184970896 B/op	61571557 allocs/op
1083952583 ns/op	3105174424 B/op	59992494 allocs/op
```

Fixes #1002

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->