### PR TITLE
refactor: continued work to improve config handling and tests

### DIFF
--- a/build/do.rq
+++ b/build/do.rq
@@ -362,4 +362,4 @@ is_github if rq.env().GITHUB_ACTION
 error_nonzero(run_result, message) if {
 	run_result.exitcode != 0
 	rq.error(sprintf("%s\nstdout:%s\nstderr:\n%s\n", [message, run_result.stdout, run_result.stderr]))
-} else = true
+} else := true

--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -38,7 +38,15 @@ capabilities := object.union(merged_config.capabilities, {"special": _special})
 
 _special contains "no_filename" if input.regal.file.name == "stdin"
 
-default _params := {}
+default _params := {
+	"ignore_files": [],
+	"disable_all": false,
+	"enable_all": false,
+	"disable_category": [],
+	"enable_category": [],
+	"disable": [],
+	"enable": [],
+}
 
 _params := data.eval.params
 
@@ -77,7 +85,7 @@ level_for_rule(category, title) := "ignore" if {
 _force_disabled(params, _, title) if title in params.disable
 
 _force_disabled(params, category, title) if {
-	params.disable_all
+	params.disable_all == true
 	not category in params.enable_category
 	not title in params.enable
 }
@@ -90,7 +98,7 @@ _force_disabled(params, category, title) if {
 _force_enabled(params, _, title) if title in params.enable
 
 _force_enabled(params, category, title) if {
-	params.enable_all
+	params.enable_all == true
 	not category in params.disable_category
 	not title in params.disable
 }

--- a/bundle/regal/config/config_test.rego
+++ b/bundle/regal/config/config_test.rego
@@ -10,6 +10,7 @@ params(override) := object.union(
 		"enable_all": false,
 		"enable_category": [],
 		"enable": [],
+		"ignore_files": [],
 	},
 	override,
 )
@@ -49,13 +50,6 @@ test_config[name] if {
 	l := config.level_for_rule("test", "test-case") with data.eval.params as params(override)
 
 	l == want_level
-
-	c := config.for_rule("test", "test-case") with config.merged_config as {"rules": {"test": {"test-case": {
-		"level": "ignore",
-		"important_setting": 42,
-	}}}}
-
-	c == {"level": "ignore", "important_setting": 42}
 }
 
 test_all_rules_are_in_provided_configuration if {

--- a/bundle/regal/config/exclusion_test.rego
+++ b/bundle/regal/config/exclusion_test.rego
@@ -46,13 +46,18 @@ test_all_cases_are_as_expected if {
 		some pattern, subcases in cases
 		res := {file |
 			some file, exp in subcases
-			act := config._exclude(pattern, file)
+			act := exclude(pattern, file)
 			exp != act
 		}
 		count(res) > 0
 	}
 
 	count(not_exp) == 0
+}
+
+exclude(pattern, file) if {
+	some p in config._patterns_compiler([pattern])
+	glob.match(p, ["/"], file)
 }
 
 rules_config_error := {"rules": {"test": {"test-case": {"level": "error"}}}}
@@ -71,12 +76,12 @@ test_excluded_file_with_ignore if {
 		with config.merged_config as object.union(rules_config_error, rules_config_ignore_delta)
 }
 
-test_excluded_file_config if {
-	config.excluded_file("test", "test-case", "p.rego") with config.merged_config as config_ignore
+test_ignored_globally if {
+	config.ignored_globally("p.rego") with config.merged_config as config_ignore
 }
 
 test_excluded_file_cli_flag if {
-	config.excluded_file("test", "test-case", "p.rego") with data.eval.params as params({"ignore_files": ["p.rego"]})
+	config.ignored_globally("p.rego") with data.eval.params as params({"ignore_files": ["p.rego"]})
 }
 
 test_excluded_file_cli_overrides_config if {

--- a/bundle/regal/lsp/completion/location/location_test.rego
+++ b/bundle/regal/lsp/completion/location/location_test.rego
@@ -2,6 +2,7 @@ package regal.lsp.completion.location_test
 
 import data.regal.ast
 import data.regal.capabilities
+import data.regal.config
 
 import data.regal.lsp.completion.location
 
@@ -71,7 +72,7 @@ another if {
 
 	r := location.find_locals(module.rules, loc) with input as module
 		with input.regal.file.lines as lines
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == want
 }

--- a/bundle/regal/lsp/completion/ref_names_test.rego
+++ b/bundle/regal/lsp/completion/ref_names_test.rego
@@ -2,6 +2,7 @@ package regal.lsp.completion_test
 
 import data.regal.ast
 import data.regal.capabilities
+import data.regal.config
 
 import data.regal.lsp.completion
 
@@ -20,9 +21,7 @@ test_ref_names if {
 		imp.foo == data.x
 	}
 	`)
-
-	ref_names := completion.ref_names with input as module
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	ref_names := completion.ref_names with input as module with config.capabilities as capabilities.provided
 
 	ref_names == {
 		"imp",

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -47,6 +47,7 @@ _file_name_relative_to_root(filename, root) := trim_prefix(filename, concat("", 
 
 _rules_to_run[category] contains title if {
 	relative_filename := _file_name_relative_to_root(input.regal.file.name, config.path_prefix)
+	not config.ignored_globally(relative_filename)
 
 	some category, title
 	config.rules[category][title]
@@ -104,6 +105,7 @@ report contains violation if {
 # Check custom rules
 report contains violation if {
 	file_name_relative_to_root := trim_prefix(input.regal.file.name, concat("", [config.path_prefix, "/"]))
+	not config.ignored_globally(file_name_relative_to_root)
 
 	some category, title
 
@@ -130,6 +132,8 @@ aggregate[category_title] contains entry if {
 # description: collects aggregates in custom rules
 # scope: rule
 aggregate[category_title] contains entry if {
+	not config.ignored_globally(input.regal.file.name)
+
 	some category, title
 
 	not config.ignored_rule(category, title)
@@ -182,6 +186,8 @@ aggregate_report contains violation if {
 # schemas:
 #   - input: schema.regal.aggregate
 aggregate_report contains violation if {
+	not config.ignored_globally(input.regal.file.name)
+
 	some key in object.keys(input.aggregates_internal)
 	[category, title] := split(key, "/")
 

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard.rego
@@ -19,7 +19,7 @@ report contains violation if {
 		ast.is_wildcard(function.head.args[pos])
 	}
 
-	not _function_name_excepted(config.for_rule("bugs", "argument-always-wildcard"), name)
+	not _function_name_excepted(name)
 
 	violation := result.fail(rego.metadata.chain(), result.location(fn.head.args[pos]))
 }
@@ -30,4 +30,6 @@ _function_groups[name] contains fn if {
 	name := ast.ref_to_string(fn.head.ref)
 }
 
-_function_name_excepted(cfg, name) if regex.match(cfg["except-function-name-pattern"], name)
+_function_name_excepted(name) if {
+	regex.match(config.rules.bugs["argument-always-wildcard"]["except-function-name-pattern"], name)
+}

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard_test.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard_test.rego
@@ -46,7 +46,8 @@ cases["multiple argument always a wildcard"] := {
 test_success_single_function_single_argument_always_a_wildcard_except_function_name if {
 	module := ast.policy(`mock_f(_) := 1`)
 
-	r := rule.report with input as module with config.for_rule as {"except-function-name-pattern": "^mock_"}
+	r := rule.report with input as module
+		with config.rules as {"bugs": {"argument-always-wildcard": {"except-function-name-pattern": "^mock_"}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference.rego
@@ -37,4 +37,4 @@ _valid_test_file_name("test.rego") # Styra DAS convention considered OK
 
 default _enable_for_test_files := false
 
-_enable_for_test_files := config.for_rule("bugs", "leaked-internal-reference")["include-test-files"]
+_enable_for_test_files := config.rules.bugs["leaked-internal-reference"]["include-test-files"]

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
@@ -76,7 +76,7 @@ test_ignore_test_file_by_default if {
 test_ignore_test_file_can_be_disabled if {
 	r := rule.report with input as ast.with_rego_v1(`foo := data.bar._wow`)
 		with input.regal.file.name as "p_test.rego"
-		with config.for_rule as {"include-test-files": true}
+		with config.rules as {"bugs": {"leaked-internal-reference": {"include-test-files": true}}}
 
 	r == expected_with_location({
 		"file": "p_test.rego",

--- a/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin_test.rego
@@ -2,11 +2,11 @@ package regal.rules.bugs["rule-shadows-builtin_test"]
 
 import data.regal.ast
 import data.regal.config
+
 import data.regal.rules.bugs["rule-shadows-builtin"] as rule
 
 test_fail_rule_name_shadows_builtin if {
-	cfg := {"capabilities": {"builtins": {"or": {}}}}
-	r := rule.report with input as ast.policy(`or := 1`) with data.internal.combined_config as cfg
+	r := rule.report with input as ast.policy(`or := 1`) with config.capabilities as {"builtins": {"or": {}}}
 
 	r == {{
 		"category": "bugs",
@@ -31,8 +31,8 @@ test_fail_rule_name_shadows_builtin if {
 }
 
 test_fail_rule_name_shadows_builtin_namespace if {
-	cfg := {"capabilities": {"builtins": {"http.send": {}}}}
-	r := rule.report with input as ast.policy(`http := "yes"`) with data.internal.combined_config as cfg
+	r := rule.report with input as ast.policy(`http := "yes"`)
+		with config.capabilities as {"builtins": {"http.send": {}}}
 
 	r == {{
 		"category": "bugs",

--- a/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
+++ b/bundle/regal/rules/bugs/unassigned-return-value/unassigned_return_value_test.rego
@@ -9,7 +9,7 @@ test_fail_unused_return_value if {
 	r := rule.report with input as ast.with_rego_v1(`allow if {
 		indexof("s", "s")
 	}`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "bugs",
@@ -34,29 +34,29 @@ test_fail_unused_return_value if {
 }
 
 test_success_unused_boolean_return_value if {
-	r := rule.report with input as ast.with_rego_v1(`allow if { startswith("s", "s") }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with input as ast.policy(`allow if { startswith("s", "s") }`)
+		with config.capabilities as capabilities.provided
+
 	r == set()
 }
 
 test_success_return_value_assigned if {
-	r := rule.report with input as ast.with_rego_v1(`allow if { x := indexof("s", "s") }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with input as ast.policy(`allow if { x := indexof("s", "s") }`)
+		with config.capabilities as capabilities.provided
+
 	r == set()
 }
 
 test_success_function_arg_return_ignored if {
-	r := rule.report with data.internal.combined_config as {"capabilities": capabilities.provided}
-		with input as ast.with_rego_v1(`allow if {
-		indexof("s", "s", i)
-	}`)
+	r := rule.report with config.capabilities as capabilities.provided
+		with input as ast.policy(`allow if indexof("s", "s", i)`)
+
 	r == set()
 }
 
 test_success_not_triggered_by_print if {
-	r := rule.report with data.internal.combined_config as {"capabilities": capabilities.provided}
-		with input as ast.with_rego_v1(`allow if {
-		print(lower("A"))
-	}`)
+	r := rule.report with config.capabilities as capabilities.provided
+		with input as ast.policy(`allow if print(lower("A"))`)
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
+++ b/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin_test.rego
@@ -8,7 +8,7 @@ import data.regal.rules.bugs["var-shadows-builtin"] as rule
 
 test_fail_var_shadows_builtin if {
 	module := ast.with_rego_v1(`allow if http := "yes"`)
-	r := rule.report with input as module with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with input as module with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "bugs",
@@ -33,16 +33,14 @@ test_fail_var_shadows_builtin if {
 }
 
 test_success_var_does_not_shadow_builtin if {
-	module := ast.with_rego_v1(`allow if answer := "yes"`)
+	r := rule.report with input as ast.policy(`allow if a := "yes"`) with config.capabilities as capabilities.provided
 
-	r := rule.report with input as module with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }
 
 # https://github.com/StyraInc/regal/issues/1163
 test_success_print_excluded if {
-	module := ast.with_rego_v1(`x if print([y - 1])`)
+	r := rule.report with input as ast.policy(`x if print([y - 1])`) with config.capabilities as capabilities.provided
 
-	r := rule.report with input as module with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == set()
 }

--- a/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call.rego
+++ b/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call.rego
@@ -8,14 +8,14 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	cfg := config.for_rule("custom", "forbidden-function-call")
+	forbidden := util.to_set(config.rules.custom["forbidden-function-call"]["forbidden-functions"])
 
 	# avoid traversal if no forbidden function is called
-	util.intersects(util.to_set(cfg["forbidden-functions"]), ast.builtin_functions_called)
+	util.intersects(forbidden, ast.builtin_functions_called)
 
 	ref := ast.found.refs[_][_]
 	name := ast.ref_to_string(ref[0].value)
-	name in cfg["forbidden-functions"]
+	name in forbidden
 
 	violation := result.fail(rego.metadata.chain(), result.location(ref))
 }

--- a/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call_test.rego
+++ b/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call_test.rego
@@ -1,6 +1,7 @@
 package regal.rules.custom["forbidden-function-call_test"]
 
 import data.regal.ast
+import data.regal.capabilities
 import data.regal.config
 
 import data.regal.rules.custom["forbidden-function-call"] as rule
@@ -8,11 +9,11 @@ import data.regal.rules.custom["forbidden-function-call"] as rule
 test_fail_forbidden_function if {
 	module := ast.policy(`foo := http.send({"method": "GET", "url": "https://example.com"})`)
 
-	r := rule.report with input as module with config.for_rule as {
+	r := rule.report with input as module with config.rules as {"custom": {"forbidden-function-call": {
 		"level": "error",
 		"forbidden-functions": ["http.send"],
-	}
-		with data.internal.combined_config as {"capabilities": data.regal.capabilities.provided}
+	}}}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "custom",

--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
@@ -54,12 +54,14 @@ _rule_locations[rule_path] := location if {
 # schemas:
 #   - input: schema.regal.aggregate
 aggregate_report contains violation if {
+	cfg := config.rules.custom["missing-metadata"]
+
 	some pkg_path, aggs in _package_path_aggs
 	every item in aggs {
 		item.aggregate_data.package_annotated == false
 	}
 
-	not _excepted_package_pattern(config.for_rule("custom", "missing-metadata"), pkg_path)
+	not _excepted_package_pattern(cfg, pkg_path)
 
 	first_item := [item | some item in aggs][0]
 
@@ -77,13 +79,15 @@ aggregate_report contains violation if {
 # schemas:
 #   - input: schema.regal.aggregate
 aggregate_report contains violation if {
+	cfg := config.rules.custom["missing-metadata"]
+
 	some rule_path, aggregates in _rule_path_aggs
 
 	every aggregate in aggregates {
 		aggregate.annotated == false
 	}
 
-	not _excepted_rule_pattern(config.for_rule("custom", "missing-metadata"), rule_path)
+	not _excepted_rule_pattern(cfg, rule_path)
 
 	any_item := util.any_set_item(aggregates)
 

--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata_test.rego
@@ -59,16 +59,15 @@ test_success_not_missing_package_metadata_report if {
 # title: pkg
 package foo.bar
 `)
-	aggregated := rule.aggregate with input as module
-	r := rule.aggregate_report with input.aggregate as aggregated
+	a := rule.aggregate with input as module
+	r := rule.aggregate_report with input.aggregate as a with config.rules as {"custom": {"missing-metadata": {}}}
 
 	r == set()
 }
 
 test_fail_missing_package_metadata_report if {
-	module := regal.parse_module("p.rego", "package foo.bar")
-	aggregated := rule.aggregate with input as module
-	r := rule.aggregate_report with input.aggregate as aggregated
+	a := rule.aggregate with input as regal.parse_module("p.rego", "package foo.bar")
+	r := rule.aggregate_report with input.aggregate as a with config.rules as {"custom": {"missing-metadata": {}}}
 
 	r == {{
 		"category": "custom",
@@ -102,6 +101,7 @@ package foo.bar
 	agg2 := rule.aggregate with input as module2
 
 	r := rule.aggregate_report with input.aggregate as {agg1, agg2}
+		with config.rules as {"custom": {"missing-metadata": {}}}
 
 	r == set()
 }
@@ -117,7 +117,7 @@ baz := true
 `)
 
 	a := rule.aggregate with input as module
-	r := rule.aggregate_report with input.aggregate as a
+	r := rule.aggregate_report with input.aggregate as a with config.rules as {"custom": {"missing-metadata": {}}}
 
 	r == set()
 }
@@ -130,7 +130,7 @@ package foo.bar
 baz := true
 `)
 	a := rule.aggregate with input as module
-	r := rule.aggregate_report with input.aggregate as a with config.for_rule as {"level": "error"}
+	r := rule.aggregate_report with input.aggregate as a with config.rules as {"custom": {"missing-metadata": {}}}
 
 	r == {{
 		"category": "custom",
@@ -172,6 +172,7 @@ rule := false
 	agg2 := rule.aggregate with input as module2
 
 	r := rule.aggregate_report with input.aggregate as {agg1, agg2}
+		with config.rules as {"custom": {"missing-metadata": {}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/custom/naming-convention/naming_convention.rego
+++ b/bundle/regal/rules/custom/naming-convention/naming_convention.rego
@@ -64,8 +64,7 @@ report contains violation if {
 
 # target: var
 report contains violation if {
-	cfg := config.for_rule("custom", "naming-convention")
-	some convention in cfg.conventions
+	some convention in config.rules.custom["naming-convention"].conventions
 	some target in convention.targets
 
 	target in {"var", "variable"}

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
@@ -85,7 +85,7 @@ _args_indices[name] contains rule_index if {
 }
 
 _functions[name] contains func if {
-	cfg := config.for_rule("custom", "narrow-argument")
+	cfg := config.rules.custom["narrow-argument"]
 
 	some i
 	args := input.rules[i].head.args

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
@@ -10,6 +10,7 @@ test_fail_can_be_narrowed_single_ref if {
 		fun(obj) if obj.number == 1
 		fun(obj) if obj.number == 2
 	`)
+		with config.rules as {"custom": {"narrow-argument": {"level": "error"}}}
 
 	r == {{
 		"category": "custom",
@@ -38,6 +39,7 @@ test_fail_can_be_narrowed_prefixed_ref if {
 		fun(obj) if obj.x.y.number == 1
 		fun(obj) if obj.x.y.string == "1"
 	`)
+		with config.rules as {"custom": {"narrow-argument": {"level": "error"}}}
 
 	r == {{
 		"category": "custom",

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule.rego
@@ -14,7 +14,7 @@ import data.regal.util
 notices contains result.notice(rego.metadata.chain()) if not capabilities.has_if
 
 report contains violation if {
-	max_line_length := object.get(config.for_rule("custom", "one-liner-rule"), "max-line-length", 120)
+	max_line_length := object.get(config.rules, ["custom", "one-liner-rule", "max-line-length"], 120)
 
 	some rule in input.rules
 

--- a/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
+++ b/bundle/regal/rules/custom/one-liner-rule/one_liner_rule_test.rego
@@ -12,7 +12,7 @@ test_fail_could_be_one_liner if {
 		input.yes
 	}
 	`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 
 	r == expected_with_location({
 		"col": 2,
@@ -32,7 +32,7 @@ test_fail_could_be_one_liner_all_keywords if {
 		input.yes
 	}
 	`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 
 	r == expected_with_location({
 		"col": 2,
@@ -55,7 +55,7 @@ test_fail_could_be_one_liner_allman_style if {
 	}
 	`)
 
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 	r == expected_with_location({
 		"col": 2,
 		"row": 5,
@@ -74,7 +74,7 @@ test_success_too_long_for_a_one_liner if {
 	}
 	`)
 
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 	r == set()
 }
 
@@ -84,7 +84,8 @@ test_success_too_long_for_a_one_liner_configured_line_length if {
 		some_really_long_rule_name_in_fact_53_characters_long
 	}
 	`)
-	r := rule.report with input as module with config.for_rule as {"level": "error", "max-line-length": 50}
+	r := rule.report with input as module
+		with config.rules as {"custom": {"one-liner-rule": {"level": "error", "max-line-length": 50}}}
 
 	r == set()
 }
@@ -96,8 +97,8 @@ test_success_no_one_liner_comment_in_rule_body if {
 		1 == 1
 	}
 	`)
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 	r == set()
 }
 
@@ -107,7 +108,7 @@ test_success_no_one_liner_comment_in_rule_body_same_line if {
 		1 == 1 # Surely one equals one
 	}
 	`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 
 	r == set()
 }
@@ -119,7 +120,7 @@ test_success_no_one_liner_comment_in_rule_body_line_below if {
 		# Surely one equals one
 	}
 	`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 
 	r == set()
 }
@@ -130,13 +131,14 @@ test_success_does_not_use_if_v0 if {
 		1 == 1
 	}
 	`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
+	r := rule.report with input as module with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 
 	r == set()
 }
 
 test_success_already_a_one_liner if {
-	r := rule.report with input as ast.with_rego_v1(`allow if 1 == 1`) with config.for_rule as {"level": "error"}
+	r := rule.report with input as ast.with_rego_v1(`allow if 1 == 1`)
+		with config.rules as {"custom": {"one-liner-rule": {"level": "error"}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
@@ -7,8 +7,6 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule("custom", "prefer-value-in-head")
-
 	some rule in input.rules
 
 	var := _var_in_head(rule.head)
@@ -19,7 +17,7 @@ report contains violation if {
 	terms[1].type == "var"
 	terms[1].value == var
 
-	not _scalar_fail(cfg, terms[2].type, ast.scalar_types)
+	not _scalar_fail(terms[2].type, ast.scalar_types)
 
 	violation := result.fail(rego.metadata.chain(), result.location(terms[2]))
 }
@@ -31,7 +29,7 @@ _var_in_head(head) := head.key.value if {
 	head.key.type == "var"
 }
 
-_scalar_fail(cfg, term_type, scalar_types) if {
-	cfg["only-scalars"] == true
+_scalar_fail(term_type, scalar_types) if {
+	config.rules.custom["prefer-value-in-head"]["only-scalars"] == true
 	not term_type in scalar_types
 }

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
@@ -6,11 +6,10 @@ import data.regal.config
 import data.regal.rules.custom["prefer-value-in-head"] as rule
 
 test_fail_value_could_be_in_head_assign if {
-	module := ast.policy(`value := x if {
+	r := rule.report with input as ast.policy(`value := x if {
 		input.x
 		x := 10
 	}`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 
 	r == expected_with_location({
 		"col": 8,
@@ -24,11 +23,10 @@ test_fail_value_could_be_in_head_assign if {
 }
 
 test_fail_value_could_be_in_head_assign_composite if {
-	module := ast.policy(`value := x if {
+	r := rule.report with input as ast.policy(`value := x if {
 		input.x
 		x := {"foo": 10}
 	}`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 
 	r == expected_with_location({
 		"col": 8,
@@ -42,17 +40,16 @@ test_fail_value_could_be_in_head_assign_composite if {
 }
 
 test_fail_value_is_in_head_assign if {
-	r := rule.report with input as ast.policy(`value := 10 if { input.x }`) with config.for_rule as {"level": "error"}
+	r := rule.report with input as ast.policy(`value := 10 if { input.x }`)
 
 	r == set()
 }
 
 test_fail_value_could_be_in_head_eq if {
-	module := ast.policy(`value := x if {
+	r := rule.report with input as ast.policy(`value := x if {
 		input.x
 		x = 10
 	}`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 
 	r == expected_with_location({
 		"col": 7,
@@ -67,7 +64,7 @@ test_fail_value_could_be_in_head_eq if {
 }
 
 test_success_value_is_in_head_eq if {
-	r := rule.report with input as ast.policy(`value = x if { input.x }`) with config.for_rule as {"level": "error"}
+	r := rule.report with input as ast.policy(`value = x if { input.x }`)
 
 	r == set()
 }
@@ -77,7 +74,8 @@ test_fail_value_could_be_in_head_but_not_a_scalar if {
 		input.x
 		x := [i | i := input[_]]
 	}`)
-	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
+	r := rule.report with input as module
+		with config.rules as {"custom": {"prefer-value-in-head": {"only-scalars": true}}}
 
 	r == set()
 }
@@ -87,7 +85,8 @@ test_fail_value_could_be_in_head_and_is_a_scalar if {
 		input.x
 		x := 5
 	}`)
-	r := rule.report with input as module with config.for_rule as {"level": "error", "only-scalars": true}
+	r := rule.report with input as module
+		with config.rules as {"custom": {"prefer-value-in-head": {"only-scalars": true}}}
 
 	r == expected_with_location({
 		"col": 8,
@@ -101,11 +100,10 @@ test_fail_value_could_be_in_head_and_is_a_scalar if {
 }
 
 test_fail_value_could_be_in_head_multivalue_rule if {
-	module := ast.with_rego_v1(`violations contains violation if {
+	r := rule.report with input as ast.with_rego_v1(`violations contains violation if {
 		input.bad
 		violation := "not good!"
 	}`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 
 	r == expected_with_location({
 		"col": 16,
@@ -119,11 +117,10 @@ test_fail_value_could_be_in_head_multivalue_rule if {
 }
 
 test_fail_value_could_be_in_head_object_rule if {
-	module := ast.policy(`foo["bar"] := x if {
+	r := rule.report with input as ast.policy(`foo["bar"] := x if {
 		input.foo
 		x := "bar"
 	}`)
-	r := rule.report with input as module with config.for_rule as {"level": "error"}
 
 	r == expected_with_location({
 		"col": 8,

--- a/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment_test.rego
+++ b/bundle/regal/rules/idiomatic/boolean-assignment/boolean_assignment_test.rego
@@ -8,7 +8,7 @@ import data.regal.rules.idiomatic["boolean-assignment"] as rule
 
 test_boolean_assignment_in_rule_head if {
 	r := rule.report with input as ast.policy("more_than_one := input.count > 1")
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "idiomatic",
@@ -33,15 +33,15 @@ test_boolean_assignment_in_rule_head if {
 }
 
 test_success_uses_if_instead_of_boolean_assignment_in_rule_head if {
-	r := rule.report with input as ast.with_rego_v1("more_than_one if input.count > 1")
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with input as ast.policy("more_than_one if input.count > 1")
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_non_boolean_assignment_in_rule_head if {
-	r := rule.report with input as ast.with_rego_v1(`foo := lower("FOO")`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with input as ast.policy(`foo := lower("FOO")`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego
@@ -30,12 +30,10 @@ report contains violation if {
 	)
 }
 
-_pkg_path_values := ast.package_path if {
-	not config.for_rule("idiomatic", "directory-package-mismatch")["exclude-test-suffix"]
-}
+_pkg_path_values := ast.package_path if not config.rules.idiomatic["directory-package-mismatch"]["exclude-test-suffix"]
 
 _pkg_path_values := without_test_suffix if {
-	config.for_rule("idiomatic", "directory-package-mismatch")["exclude-test-suffix"]
+	config.rules.idiomatic["directory-package-mismatch"]["exclude-test-suffix"] == true
 
 	without_test_suffix := array.concat(
 		array.slice(ast.package_path, 0, count(ast.package_path) - 1),

--- a/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
+++ b/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch_test.rego
@@ -6,14 +6,14 @@ import data.regal.rules.idiomatic["directory-package-mismatch"] as rule
 
 test_success_directory_structure_package_path_match if {
 	module := regal.parse_module("foo/bar/baz/p.rego", "package foo.bar.baz")
-	r := rule.report with input as module with config.for_rule as _default_config
+	r := rule.report with input as module with config.rules as _default_config
 
 	r == set()
 }
 
 test_fail_directory_structure_package_path_mismatch if {
 	module := regal.parse_module("foo/bar/baz/p.rego", "package foo.baz.bar")
-	r := rule.report with input as module with config.for_rule as _default_config
+	r := rule.report with input as module with config.rules as _default_config
 
 	r == with_location({
 		"col": 9,
@@ -29,7 +29,7 @@ test_fail_directory_structure_package_path_mismatch if {
 
 test_success_directory_structure_package_path_match_longer_directory_path if {
 	module := regal.parse_module("system/directories/foo/bar/baz/p.rego", "package foo.bar.baz")
-	r := rule.report with input as module with config.for_rule as _default_config
+	r := rule.report with input as module with config.rules as _default_config
 
 	r == set()
 }
@@ -46,7 +46,7 @@ with_location(location) := {{
 	"title": "directory-package-mismatch",
 }}
 
-_default_config := {
+_default_config := {"idiomatic": {"directory-package-mismatch": {
 	"level": "error",
 	"exclude-test-suffix": true,
-}
+}}}

--- a/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern_test.rego
+++ b/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern_test.rego
@@ -8,7 +8,7 @@ import data.regal.rules.idiomatic["non-raw-regex-pattern"] as rule
 
 test_fail_non_raw_rule_head if {
 	r := rule.report with input as ast.policy(`x := regex.match("[0-9]+", "1")`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 	r == {{
 		"category": "idiomatic",
 		"description": "Use raw strings for regex patterns",
@@ -32,7 +32,7 @@ test_fail_non_raw_rule_body if {
 	r := rule.report with input as ast.policy(`allow if {
 		regex.is_valid("[0-9]+")
 	}`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 	r == {{
 		"category": "idiomatic",
 		"description": "Use raw strings for regex patterns",
@@ -54,7 +54,7 @@ test_fail_non_raw_rule_body if {
 
 test_fail_pattern_in_second_arg if {
 	r := rule.report with input as ast.policy(`r := regex.replace("a", "[a]", "b")`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 	r == {{
 		"category": "idiomatic",
 		"description": "Use raw strings for regex patterns",
@@ -76,6 +76,6 @@ test_fail_pattern_in_second_arg if {
 
 test_success_when_using_raw_string if {
 	r := rule.report with input as ast.policy("v := regex.is_valid(`[0-9]+`)")
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 	r == set()
 }

--- a/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin_test.rego
+++ b/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin_test.rego
@@ -8,7 +8,7 @@ import data.regal.rules.imports["import-shadows-builtin"] as rule
 
 test_fail_import_shadows_builtin_name if {
 	r := rule.report with input as ast.policy(`import data.print`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "imports",
@@ -34,7 +34,7 @@ test_fail_import_shadows_builtin_name if {
 
 test_fail_import_shadows_builtin_namespace if {
 	r := rule.report with input as ast.policy(`import input.foo.http`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "imports",
@@ -59,15 +59,14 @@ test_fail_import_shadows_builtin_namespace if {
 }
 
 test_success_import_does_not_shadows_builtin_name if {
-	r := rule.report with input as ast.policy(`import data.users`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with input as ast.policy(`import data.users`) with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_import_shadows_but_alias_does_not if {
 	r := rule.report with input as ast.policy(`import data.http as http_attributes`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
@@ -62,9 +62,7 @@ _resolves(path, pkg_paths) if count([path |
 ]) > 0
 
 _ignored_import_paths contains path if {
-	cfg := config.for_rule("imports", "prefer-package-imports")
-
-	some item in cfg["ignore-import-paths"]
+	some item in config.rules.imports["prefer-package-imports"]["ignore-import-paths"]
 	path := [part |
 		some i, p in split(item, ".")
 		part := _normalize_part(i, p)

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
@@ -134,10 +134,11 @@ test_success_aggregate_report_ignored_import_path if {
 		}},
 	}
 
-	r := rule.aggregate_report with input.aggregate as aggregate with config.for_rule as {
-		"level": "error",
-		"ignore-import-paths": ["data.b.c"],
-	}
+	r := rule.aggregate_report with input.aggregate as aggregate
+		with config.rules as {"imports": {"prefer-package-imports": {
+			"level": "error",
+			"ignore-import-paths": ["data.b.c"],
+		}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
@@ -101,9 +101,7 @@ _to_string(i, part) := "**" if {
 }
 
 _except_imports contains exception if {
-	cfg := config.for_rule("imports", "unresolved-import")
-
-	some str in cfg["except-imports"]
+	some str in config.rules.imports["unresolved-import"]["except-imports"]
 	exception := _trim_data(split(str, "."))
 }
 

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -73,7 +73,7 @@ test_success_unresolved_imports_are_excepted if {
 	x := 1
 	`)
 	r := rule.aggregate_report with input as {"aggregate": (agg1 | agg2)}
-		with config.for_rule as {"level": "error", "except-imports": ["data.bar.excepted"]}
+		with config.rules as {"imports": {"unresolved-import": {"except-imports": ["data.bar.excepted"]}}}
 
 	r == set()
 }
@@ -86,7 +86,7 @@ test_success_unresolved_imports_with_wildcards_are_excepted if {
 	x := 1
 	`)
 	r := rule.aggregate_report with input as {"aggregate": agg1}
-		with config.for_rule as {"level": "error", "except-imports": ["data.bar.*"]}
+		with config.rules as {"imports": {"unresolved-import": {"except-imports": ["data.bar.*"]}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/imports/use-rego-v1/use_rego_v1_test.rego
+++ b/bundle/regal/rules/imports/use-rego-v1/use_rego_v1_test.rego
@@ -10,7 +10,7 @@ test_fail_missing_rego_v1_import if {
 
 	foo if not bar
 	`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "imports",
@@ -40,6 +40,6 @@ test_success_rego_v1_import if {
 
 	foo if not bar
 	`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 	r == set()
 }

--- a/bundle/regal/rules/style/default-over-else/default_over_else.rego
+++ b/bundle/regal/rules/style/default-over-else/default_over_else.rego
@@ -23,7 +23,6 @@ report contains violation if {
 	violation := result.fail(rego.metadata.chain(), result.location(else_head))
 }
 
-_cfg := config.for_rule("style", "default-over-else")
-
-_considered_rules := input.rules if _cfg["prefer-default-functions"] == true
-_considered_rules := ast.rules if not _cfg["prefer-default-functions"]
+_considered_rules := input.rules if {
+	config.rules.style["default-over-else"]["prefer-default-functions"] == true
+} else := ast.rules

--- a/bundle/regal/rules/style/default-over-else/default_over_else_test.rego
+++ b/bundle/regal/rules/style/default-over-else/default_over_else_test.rego
@@ -88,10 +88,8 @@ test_fail_conditionless_else_custom_function_prefer_default_functions if {
 		input.foo
 	} else := 1
 	`)
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
-		"prefer-default-functions": true,
-	}
+	r := rule.report with input as module
+		with config.rules as {"style": {"default-over-else": {"prefer-default-functions": true}}}
 
 	r == with_location({
 		"col": 4,
@@ -111,10 +109,8 @@ test_success_conditionless_else_custom_function_not_constant if {
 		input.foo
 	} else := y
 	`)
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
-		"prefer-default-functions": true,
-	}
+	r := rule.report with input as module
+		with config.rules as {"style": {"default-over-else": {"prefer-default-functions": true}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/style/external-reference/external_reference_test.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference_test.rego
@@ -7,10 +7,8 @@ import data.regal.rules.style["external-reference"] as rule
 
 test_fail_function_references_input if {
 	r := rule.report with input as ast.policy(`f(_) if { input.foo }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == expected_with_location({
 		"col": 11,
@@ -26,10 +24,8 @@ test_fail_function_references_input if {
 
 test_fail_function_references_data if {
 	r := rule.report with input as ast.policy(`f(_) if { data.foo }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == expected_with_location({
 		"col": 11,
@@ -47,10 +43,8 @@ test_fail_function_references_data_in_expr if {
 	r := rule.report with input as ast.policy(`f(x) if {
 		x == data.foo
 	}`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == expected_with_location({
 		"col": 8,
@@ -73,10 +67,8 @@ f(x, y) if {
 	y == foo
 }
 	`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == expected_with_location({
 		"col": 7,
@@ -92,10 +84,8 @@ f(x, y) if {
 
 test_fail_external_reference_in_head_assignment if {
 	r := rule.report with input as ast.policy(`f(_) := r`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == expected_with_location({
 		"col": 9,
@@ -111,10 +101,8 @@ test_fail_external_reference_in_head_assignment if {
 
 test_fail_external_reference_in_head_terms if {
 	r := rule.report with input as ast.policy(`f(_) := {"r": r}`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == expected_with_location({
 		"col": 15,
@@ -130,90 +118,72 @@ test_fail_external_reference_in_head_terms if {
 
 test_success_function_references_no_input_or_data if {
 	r := rule.report with input as ast.policy(`f(x) if { x == true }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_no_input_or_data_reverse if {
 	r := rule.report with input as ast.policy(`f(x) if { true == x }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_only_own_vars if {
 	r := rule.report with input as ast.policy(`f(x) if { y := x; y == 10 }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_only_own_vars_nested if {
 	r := rule.report with input as ast.policy(`f(x, z) if { y := x; y == [1, 2, z]}`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_only_own_vars_and_wildcard if {
 	r := rule.report with input as ast.policy(`f(x, y) if { _ = x + y }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_return_var if {
 	r := rule.report with input as ast.policy(`f(x) := y if { y = true }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_return_vars if {
 	r := rule.report with input as ast.policy(`f(x) := [x, y] if { x = false; y = true }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_external_function if {
 	r := rule.report with input as ast.policy(`f(x) if { data.foo.bar(x) }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
 
 test_success_function_references_external_function_in_expr if {
 	r := rule.report with input as ast.policy(`f(x) := y if { y := data.foo.bar(x) }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }
@@ -226,17 +196,15 @@ test_external_references_max_allowed_configuration if {
 		data.a 
 	}`)
 
-	r1 := rule.report with input as module with data.internal.combined_config as {
-		"capabilities": capabilities.provided,
-		"rules": {"style": {"external-reference": {"max-allowed": 4}}},
-	}
+	r1 := rule.report with input as module
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 4}}}
 
 	r1 == set()
 
-	r2 := rule.report with input as module with data.internal.combined_config as {
-		"capabilities": capabilities.provided,
-		"rules": {"style": {"external-reference": {"max-allowed": 2}}},
-	}
+	r2 := rule.report with input as module
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 2}}}
 
 	# note that we could, flag only the external references above the threshold, but that's potentially
 	# confusing I think, as there's nothing more "illegal" about the last one than the first?
@@ -246,10 +214,8 @@ test_external_references_max_allowed_configuration if {
 # verify fix for https://github.com/StyraInc/regal/issues/1283
 test_success_variable_from_nested_arg_term if {
 	r := rule.report with input as ast.policy(`f([x]) := to_number(x)`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"external-reference": {"max-allowed": 0}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"external-reference": {"max-allowed": 0}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/style/file-length/file_length.rego
+++ b/bundle/regal/rules/style/file-length/file_length.rego
@@ -6,9 +6,7 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule("style", "file-length")
-
-	count(input.regal.file.lines) > cfg["max-file-length"]
+	count(input.regal.file.lines) > config.rules.style["file-length"]["max-file-length"]
 
 	violation := result.fail(rego.metadata.chain(), result.location(input["package"]))
 }

--- a/bundle/regal/rules/style/file-length/file_length_test.rego
+++ b/bundle/regal/rules/style/file-length/file_length_test.rego
@@ -11,10 +11,7 @@ test_fail_configured_file_length_exceeded if {
 	rule2 := "bar"
 	`)
 
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
-		"max-file-length": 2,
-	}
+	r := rule.report with input as module with config.rules as {"style": {"file-length": {"max-file-length": 2}}}
 
 	r == {{
 		"category": "style",
@@ -45,9 +42,6 @@ test_success_configured_file_length_within_limit if {
 	rule2 := "bar"
 	`)
 
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
-		"max-file-length": 10,
-	}
+	r := rule.report with input as module with config.rules as {"style": {"file-length": {"max-file-length": 10}}}
 	r == set()
 }

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
@@ -7,7 +7,7 @@ import data.regal.rules.style["function-arg-return"] as rule
 
 test_fail_function_arg_return_value if {
 	r := rule.report with input as ast.policy(`foo := i if { indexof("foo", "o", i) }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "style",
@@ -33,7 +33,7 @@ test_fail_function_arg_return_value if {
 
 test_fail_function_arg_return_value_multi_part_ref if {
 	r := rule.report with input as ast.policy(`foo := r if { regex.match("foo", "foo", r) }`)
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == {{
 		"category": "style",
@@ -59,10 +59,8 @@ test_fail_function_arg_return_value_multi_part_ref if {
 
 test_success_function_arg_return_value_except_function if {
 	r := rule.report with input as ast.with_rego_v1(`foo := i if { indexof("foo", "o", i) }`)
-		with data.internal.combined_config as {
-			"capabilities": capabilities.provided,
-			"rules": {"style": {"function-arg-return": {"except-functions": ["indexof"]}}},
-		}
+		with config.capabilities as capabilities.provided
+		with config.rules as {"style": {"function-arg-return": {"except-functions": ["indexof"]}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/style/line-length/line_length.rego
+++ b/bundle/regal/rules/style/line-length/line_length.rego
@@ -6,8 +6,7 @@ import data.regal.config
 import data.regal.result
 
 report contains violation if {
-	cfg := config.for_rule("style", "line-length")
-	max_line_length := object.get(cfg, "max-line-length", 120)
+	max_line_length := object.get(config.rules, ["style", "line-length", "max-line-length"], 120)
 
 	some i, line in input.regal.file.lines
 
@@ -16,7 +15,7 @@ report contains violation if {
 	line_length := count(line)
 	line_length > max_line_length
 
-	not _has_word_above_threshold(line, cfg)
+	not _has_word_above_threshold(line)
 
 	violation := result.fail(
 		rego.metadata.chain(),
@@ -33,8 +32,8 @@ report contains violation if {
 	)
 }
 
-_has_word_above_threshold(line, cfg) if {
-	threshold := cfg["non-breakable-word-threshold"]
+_has_word_above_threshold(line) if {
+	threshold := config.rules.style["line-length"]["non-breakable-word-threshold"]
 
 	some word in split(line, " ")
 	count(word) > threshold

--- a/bundle/regal/rules/style/line-length/line_length_test.rego
+++ b/bundle/regal/rules/style/line-length/line_length_test.rego
@@ -8,7 +8,8 @@ test_fail_line_too_long if {
 	r := rule.report with input as ast.with_rego_v1(`allow if {
 foo == bar; bar == baz; [a, b, c, d, e, f] := [1, 2, 3, 4, 5, 6]; qux := [q | some q in input.nonsense]
 	}`)
-		with config.for_rule as {"level": "error", "max-line-length": 80}
+		with config.rules as {"style": {"line-length": {"max-line-length": 80}}}
+
 	r == {{
 		"category": "style",
 		"description": "Line too long",
@@ -34,7 +35,7 @@ test_success_line_too_long_but_non_breakable_word if {
 	# Long url: https://www.example.com/this/is/a/very/long/url/that/cannot/be/shortened
 	allow := true
 	`)
-		with config.for_rule as {"level": "error", "max-line-length": 40, "non-breakable-word-threshold": 50}
+		with config.rules as {"style": {"line-length": {"max-line-length": 40, "non-breakable-word-threshold": 50}}}
 
 	r == set()
 }
@@ -45,7 +46,8 @@ test_fail_line_too_long_but_below_breakable_word_threshold if {
 	# Long url: https://www.example.com/this/is/a/very/long
 	allow := true
 	`)
-		with config.for_rule as {"level": "error", "max-line-length": 40, "non-breakable-word-threshold": 60}
+		with config.rules as {"style": {"line-length": {"max-line-length": 40, "non-breakable-word-threshold": 60}}}
+
 	r == {{
 		"category": "style",
 		"description": "Line too long",
@@ -70,7 +72,8 @@ test_fail_line_exceeds_120_characters_even_if_not_in_config if {
 	r := rule.report with input as ast.with_rego_v1(`# Long url: https://www.example.com/this/is/a/very/long/url/that/cannot/be/shortened/and/should/trigger/an/error/anyway/so/that/it/can/be/shortened
 	allow := true
 	`)
-		with config.for_rule as {"level": "error"}
+		with config.rules as {"style": {"line-length": {"level": "error"}}}
+
 	r == {{
 		"category": "style",
 		"description": "Line too long",
@@ -93,6 +96,7 @@ test_fail_line_exceeds_120_characters_even_if_not_in_config if {
 
 test_success_line_not_too_long if {
 	r := rule.report with input as ast.policy(`allow if { "foo" == "bar" }`)
-		with config.for_rule as {"level": "error", "max-line-length": 80}
+		with config.rules as {"style": {"line-length": {"max-line-length": 80}}}
+
 	r == set()
 }

--- a/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment.rego
+++ b/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment.rego
@@ -15,8 +15,4 @@ report contains violation if {
 }
 
 _whitespace_comment(text) if regex.match(`^(#*)(\s+.*|$)`, text)
-
-_whitespace_comment(text) if {
-	except_pattern := config.for_rule("style", "no-whitespace-comment")["except-pattern"]
-	regex.match(except_pattern, text)
-}
+_whitespace_comment(text) if regex.match(config.rules.style["no-whitespace-comment"]["except-pattern"], text)

--- a/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment_test.rego
+++ b/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment_test.rego
@@ -55,7 +55,8 @@ test_fail_no_leading_whitespace_multiple_hashes if {
 }
 
 test_success_excepted_pattern if {
-	r := rule.report with input as ast.policy(`#-- foo`) with config.for_rule as {"except-pattern": "^--"}
+	r := rule.report with input as ast.policy(`#-- foo`)
+		with config.rules as {"style": {"no-whitespace-comment": {"except-pattern": "^--"}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -8,7 +8,7 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	cfg := config.for_rule("style", "prefer-some-in-iteration")
+	cfg := config.rules.style["prefer-some-in-iteration"]
 
 	some i, rule in input.rules
 

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration_test.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration_test.rego
@@ -10,9 +10,9 @@ test_fail_simple_iteration if {
 		var := input.foo[_]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2)
+	r := rule.report with config.rules as allow_nesting(2)
 		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == with_location({
 		"col": 10,
@@ -31,8 +31,9 @@ test_fail_simple_iteration_comprehension if {
 		p := input.foo[_]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == with_location({
 		"col": 8,
@@ -51,8 +52,9 @@ test_fail_simple_iteration_output_var if {
 		input.foo[x]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == with_location({
 		"col": 3,
@@ -72,8 +74,9 @@ test_fail_simple_iteration_output_var_some_decl if {
 		input.foo[x]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == with_location({
 		"col": 3,
@@ -93,8 +96,9 @@ test_success_some_in_var_input if {
 		input.foo[x] == 1
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
@@ -105,8 +109,9 @@ test_success_allow_nesting_zero if {
 		input.foo[_].bar[_]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(0) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(0)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
@@ -116,8 +121,9 @@ test_success_allow_nesting_one if {
 		input.foo[_]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(1) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(1)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
@@ -127,8 +133,9 @@ test_success_allow_nesting_two if {
 		input.foo[_].bar[_]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
@@ -138,8 +145,9 @@ test_fail_allow_nesting_two if {
 		input.foo[_]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == with_location({
 		"col": 3,
@@ -162,8 +170,9 @@ test_success_not_output_vars if {
 		input.foo[x].bar[y]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
@@ -178,20 +187,19 @@ test_success_output_var_to_input_var if {
 		input.bar[x]
 	}`)
 
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_fail_complex_comprehension_term if {
-	policy := ast.with_rego_v1(`
+	policy := ast.policy(`foo := [{"foo": bar} | input[bar]]`)
 
-	foo := [{"foo": bar} | input[bar]]
-	`)
-
-	r := rule.report with config.for_rule as allow_nesting(2) with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(2)
+		with input as policy
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
@@ -202,13 +210,12 @@ test_success_allow_if_subattribute if {
 		bar == "baz"
 	}`)
 
-	r := rule.report with config.for_rule as {
-		"level": "error",
+	r := rule.report with config.rules as {"style": {"prefer-some-in-iteration": {
 		"ignore-if-sub-attribute": true,
 		"ignore-nesting-level": 5,
-	}
+	}}}
 		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
@@ -219,13 +226,12 @@ test_fail_ignore_if_subattribute_disabled if {
 		bar == "baz"
 	}`)
 
-	r := rule.report with config.for_rule as {
-		"level": "error",
+	r := rule.report with config.rules as {"style": {"prefer-some-in-iteration": {
 		"ignore-if-sub-attribute": false,
 		"ignore-nesting-level": 5,
-	}
+	}}}
 		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == with_location({
 		"col": 10,
@@ -244,134 +250,78 @@ test_success_allow_if_inside_array if {
 		bar := [input.foo[_] == 1]
 	}`)
 
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-if-sub-attribute": true,
-		"ignore-nesting-level": 5,
-	}
+	r := rule.report with config.rules as allow_nesting(5)
 		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_allow_if_inside_set if {
-	policy := ast.with_rego_v1(`s := {input.foo[_] == 1}`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-if-sub-attribute": true,
-		"ignore-nesting-level": 5,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.with_rego_v1(`s := {input.foo[_] == 1}`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_allow_if_inside_object if {
-	policy := ast.with_rego_v1(`s := {foo: input.foo[_] == 1}`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-if-sub-attribute": true,
-		"ignore-nesting-level": 5,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.policy(`s := {foo: input.foo[_] == 1}`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_allow_if_inside_rule_head_key if {
-	policy := ast.with_rego_v1(`s contains input.foo[_]`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-if-sub-attribute": true,
-		"ignore-nesting-level": 5,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.with_rego_v1(`s contains input.foo[_]`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_allow_if_contains_check_eq if {
-	policy := ast.with_rego_v1(`no_violation if {
-		"x" = input.foo[_]
-	}`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-nesting-level": 5,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.policy(`no_violation if "x" = input.foo[_]`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_allow_if_contains_check_equal if {
-	policy := ast.with_rego_v1(`no_violation if {
-		"x" == input.foo[_]
-	}`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-nesting-level": 5,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.with_rego_v1(`no_violation if "x" == input.foo[_]`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_iteration_in_args if {
-	policy := ast.with_rego_v1(`no_violation if {
-		startswith(input.foo[_], "f")
-	}`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-nesting-level": 5,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.policy(`no_violation if startswith(input.foo[_], "f")`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_iteration_in_args_call_in_comprehension_head if {
-	policy := ast.with_rego_v1(`r := [f(obj[k], v) | some k, v in p]`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-nesting-level": 5,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.policy(`r := [f(obj[k], v) | some k, v in p]`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
 test_success_top_level_iteration if {
-	policy := ast.with_rego_v1(`r := input.foo[_]`)
-
-	r := rule.report with config.for_rule as {
-		"level": "error",
-		"ignore-nesting-level": 2,
-	}
-		with input as policy
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
+	r := rule.report with config.rules as allow_nesting(5)
+		with input as ast.policy(`r := input.foo[_]`)
+		with config.capabilities as capabilities.provided
 
 	r == set()
 }
 
-allow_nesting(i) := {
-	"level": "error",
-	"ignore-nesting-level": i,
-}
+allow_nesting(i) := {"style": {"prefer-some-in-iteration": {"ignore-nesting-level": i}}}
 
 with_location(location) := {{
 	"category": "style",

--- a/bundle/regal/rules/style/rule-length/rule_length.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length.rego
@@ -7,7 +7,7 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	cfg := config.for_rule("style", "rule-length")
+	cfg := config.rules.style["rule-length"]
 
 	some rule in input.rules
 

--- a/bundle/regal/rules/style/rule-length/rule_length_test.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length_test.rego
@@ -1,5 +1,6 @@
 package regal.rules.style["rule-length_test"]
 
+import data.regal.ast
 import data.regal.config
 
 import data.regal.rules.style["rule-length"] as rule
@@ -14,11 +15,10 @@ test_fail_rule_longer_than_configured_max_length if {
 		input.x
 	}
 	`)
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
+	r := rule.report with input as module with config.rules as {"style": {"rule-length": {
 		"max-rule-length": 3,
 		"count-comments": true,
-	}
+	}}}
 
 	r == {{
 		"category": "style",
@@ -53,11 +53,11 @@ test_success_rule_not_longer_than_configured_max_length if {
 	}
 	`)
 
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
+	r := rule.report with input as module with config.rules as {"style": {"rule-length": {
 		"max-rule-length": 30,
 		"count-comments": true,
-	}
+	}}}
+
 	r == set()
 }
 
@@ -72,11 +72,10 @@ test_success_rule_longer_than_configured_max_length_but_comments if {
 	}
 	`)
 
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
+	r := rule.report with input as module with config.rules as {"style": {"rule-length": {
 		"max-rule-length": 2,
 		"count-comments": false,
-	}
+	}}}
 	r == set()
 }
 
@@ -91,24 +90,21 @@ test_success_rule_longer_than_configured_max_length_but_no_body_and_exception_co
 	}
 	`)
 
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
+	r := rule.report with input as module with config.rules as {"style": {"rule-length": {
 		"max-rule-length": 2,
 		"except-empty-body": true,
-	}
+	}}}
+
 	r == set()
 }
 
 test_success_rule_length_equals_max_length if {
-	module := regal.parse_module("policy.rego", `package p
+	module := ast.policy("my_tiny_rule := true")
 
-	my_tiny_rule := true
-	`)
-
-	r := rule.report with input as module with config.for_rule as {
-		"level": "error",
+	r := rule.report with input as module with config.rules as {"style": {"rule-length": {
 		"max-rule-length": 1,
 		"count-comments": false,
-	}
+	}}}
+
 	r == set()
 }

--- a/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf_test.rego
+++ b/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf_test.rego
@@ -10,9 +10,8 @@ test_fail_print_sprintf if {
 	module := ast.policy(`y if {
 		print(sprintf("name is: %s domain is: %s", [input.name, input.domain]))
 	}`)
+	r := rule.report with input as module with config.capabilities as capabilities.provided
 
-	r := rule.report with input as module
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == {{
 		"category": "testing",
 		"description": "Dubious use of print and sprintf",
@@ -42,9 +41,8 @@ test_fail_bodies_print_sprintf if {
 			print(sprintf("x is: %s", [x]))
 		]
 	}`)
+	r := rule.report with input as module with config.capabilities as capabilities.provided
 
-	r := rule.report with input as module
-		with data.internal.combined_config as {"capabilities": capabilities.provided}
 	r == {{
 		"category": "testing",
 		"description": "Dubious use of print and sprintf",

--- a/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call_test.rego
+++ b/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call_test.rego
@@ -1,7 +1,9 @@
 package regal.rules.testing["print-or-trace-call_test"]
 
 import data.regal.ast
+import data.regal.capabilities
 import data.regal.config
+
 import data.regal.rules.testing["print-or-trace-call"] as rule
 
 test_fail_call_to_print_and_trace if {
@@ -10,7 +12,8 @@ test_fail_call_to_print_and_trace if {
 
 		x := [i | i = 0; trace("bar")]
 	}`)
-		with data.internal.combined_config as {"capabilities": data.regal.capabilities.provided}
+		with config.capabilities as capabilities.provided
+
 	r == {
 		expected_with_location({
 			"col": 3,

--- a/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
+++ b/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package_test.rego
@@ -5,9 +5,8 @@ import data.regal.config
 import data.regal.rules.testing["test-outside-test-package"] as rule
 
 test_fail_test_outside_test_package if {
-	r := rule.report with input as ast.with_rego_v1(`test_foo if { false }`)
-		with config.for_rule as {"level": "error"}
-		with input.regal.file.name as "p_test.rego"
+	r := rule.report with input as ast.with_rego_v1(`test_foo if { false }`) with input.regal.file.name as "p_test.rego"
+
 	r == {{
 		"category": "testing",
 		"description": "Test outside of test package",

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -729,6 +729,7 @@ import data.unresolved`,
 }
 
 // 1070530708 ns/op	3041023912 B/op	58063258 allocs/op
+// 1048394166 ns/op	2953960968 B/op	56616841 allocs/op
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	linter := NewLinter().


### PR DESCRIPTION
- Check if files are ignored globally only once, and before proceeding to check if they are ignored by some specific rule's configuration
- Stop using config.for_rule("category", "title") now that we can refer directly to config.rules.category.title
- Stop using data.internal in tests

Obviously, there's gotta be some performance improvements in there somewhere too :P Luckily having the global ignore check done only once per file gave us that!

```
1070530708 ns/op	3041023912 B/op	58063258 allocs/op
1048394166 ns/op	2953960968 B/op	56616841 allocs/op
```
Now getting awfully close to sub-second times :)

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->