### PR TITLE
perf: walk less, save allocations

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -352,7 +352,9 @@ negated_expressions[rule_index] contains value if {
 	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
 	rule_index := rule_index_strings[i]
 
-	walk(rule, [_, value])
+	some node in ["head", "body", "else"]
+
+	walk(rule[node], [_, value])
 
 	value.negated == true
 }

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -208,12 +208,10 @@ _rules := data.workspace.parsed[input.regal.file.uri].rules if not input.rules
 #   - somein
 #   - ref
 found.vars[rule_index][context] contains var if {
-	some i, rule in _rules
+	some i, rule_index in rule_index_strings
+	some node in ["head", "body", "else"]
 
-	# converting to string until https://github.com/open-policy-agent/opa/issues/6736 is fixed
-	rule_index := rule_index_strings[i]
-
-	walk(rule, [path, value])
+	walk(_rules[i][node], [path, value])
 
 	last := regal.last(path)
 	last in {"terms", "symbols", "args"}

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -10,11 +10,13 @@ import data.regal.util
 report contains violation if {
 	cfg := config.rules.style["prefer-some-in-iteration"]
 
-	some i, rule in input.rules
+	some rule in input.rules
 
 	not _possible_top_level_iteration(rule)
 
-	walk(rule, [path, value])
+	some node in ["head", "body", "else"]
+
+	walk(rule[node], [path, value])
 
 	value.type == "ref"
 
@@ -34,7 +36,7 @@ report contains violation if {
 	num_output_vars < cfg["ignore-nesting-level"]
 
 	not _except_sub_attribute(cfg, value.value)
-	not _invalid_some_context(input.rules[i], path)
+	not _invalid_some_context(rule, array.concat([node], path))
 
 	violation := result.fail(rego.metadata.chain(), result.location(value))
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -728,8 +728,7 @@ import data.unresolved`,
 	}
 }
 
-// 1070530708 ns/op	3041023912 B/op	58063258 allocs/op
-// 1048394166 ns/op	2953960968 B/op	56616841 allocs/op
+// 1034816959 ns/op	2910685336 B/op	55738401 allocs/op
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	linter := NewLinter().


### PR DESCRIPTION
Avoids walking `.annotations` in rules, which is particularly expensive in the few places where we need the path from each iteration. We could probably use this everywhere we walk, but it would be more noisy and for less gain, so stopping here for now.

```
1048394166 ns/op	2953960968 B/op	56616841 allocs/op
1034816959 ns/op	2910685336 B/op	55738401 allocs/op
```

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->