### PR TITLE
Add Prepare method for reusing state across linter runs

### DIFF
--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -12,9 +12,8 @@ import data.regal.result
 import data.regal.util
 
 _refs contains ref if {
-	r := ast.found.refs[_][_]
-
-	r.value[0].value == "data"
+	some r
+	ast.found.refs[_][r].value[0].value == "data"
 
 	ast.static_ref(r)
 

--- a/cmd/fix.go
+++ b/cmd/fix.go
@@ -411,8 +411,7 @@ please run fix from a clean state to support the use of git to undo, or use --fo
 
 	if !params.dryRun {
 		for _, file := range fileProvider.DeletedFiles() {
-			err := os.Remove(file)
-			if err != nil {
+			if err := os.Remove(file); err != nil {
 				return fmt.Errorf("failed to delete file %s: %w", file, err)
 			}
 

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -249,8 +249,7 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 		m.Timer(regalmetrics.RegalConfigSearch).Stop()
 	}
 
-	regal := linter.NewEmptyLinter().
-		WithAddedBundle(&rbundle.LoadedBundle).
+	regal := linter.NewLinter().
 		WithDisableAll(params.disableAll).
 		WithDisabledCategories(params.disableCategory.v...).
 		WithDisabledRules(params.disable.v...).
@@ -329,6 +328,11 @@ func lint(args []string, params *lintCommandParams) (report.Report, error) {
 	}
 
 	go updateCheckAndWarn(params, &rbundle.LoadedBundle, &userConfig)
+
+	regal, err = regal.Prepare(ctx)
+	if err != nil {
+		return report.Report{}, fmt.Errorf("failed to prepare for linting: %w", err)
+	}
 
 	result, err := regal.Lint(ctx)
 	if err != nil {

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/tester"
 
+	"github.com/styrainc/regal/internal/mode"
 	"github.com/styrainc/regal/internal/testutil"
 	"github.com/styrainc/regal/pkg/config"
 	"github.com/styrainc/regal/pkg/report"
@@ -181,10 +182,11 @@ func TestLintNonExistentDir(t *testing.T) {
 	}
 }
 
-// NOTE(ae): this test *will fail* when run via "go test -e2e" and a normal development binary is used for the test.
-// This is because proposing fixes is only enabled when regal is built with the "regal_standalone" build tag. I spent
-// way more time on chasing that down than I would have wanted, so leaving this here for future me and others.
 func TestLintProposeToRunFix(t *testing.T) {
+	if !mode.Standalone {
+		t.Skip("test requires regal to be built with the 'regal_standalone' build tag")
+	}
+
 	t.Parallel()
 	stdout, stderr := bytes.Buffer{}, bytes.Buffer{}
 
@@ -1045,8 +1047,7 @@ allow := true
 func TestFixWithConflicts(t *testing.T) {
 	t.Parallel()
 
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
+	stdout, stderr := bytes.Buffer{}, bytes.Buffer{}
 
 	initialState := map[string]string{
 		".regal/config.yaml": "", // needed to find the root in the right place
@@ -1112,8 +1113,7 @@ Cannot move multiple files to: bar/bar.rego
 func TestFixWithConflictRenaming(t *testing.T) {
 	t.Parallel()
 
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
+	stdout, stderr := bytes.Buffer{}, bytes.Buffer{}
 
 	initialState := map[string]string{
 		".regal/config.yaml": "", // needed to find the root in the right place
@@ -1292,8 +1292,7 @@ rules:
 func TestLintAnnotationCustomAttributeMultipleItems(t *testing.T) {
 	t.Parallel()
 
-	stdout := bytes.Buffer{}
-	stderr := bytes.Buffer{}
+	stdout, stderr := bytes.Buffer{}, bytes.Buffer{}
 	cwd := testutil.Must(os.Getwd())(t)
 
 	err := regal(&stdout, &stderr)(


### PR DESCRIPTION
This paves the way for moving initialization logic to Rego later: https://github.com/StyraInc/regal/issues/359

As well as moving the `DetermineEnabledRules` and
`DetermineEnabledAggregateRules` methods to instead use the same query later on.

Fixes #1394

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->