### PR TITLE
perf: improve performance of new unresolved-reference rule

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -145,7 +145,7 @@ function_arg_names(rule) := [arg.value | some arg in rule.head.args]
 
 # METADATA
 # description: all the rule and function names in the input AST
-rule_and_function_names contains ref_to_string(rule.head.ref) if some rule in input.rules
+rule_and_function_names contains ref_static_to_string(rule.head.ref) if some rule in input.rules
 
 # METADATA
 # description: all identifiers in the input AST (rule and function names, plus imported names)
@@ -153,7 +153,7 @@ identifiers := rule_and_function_names | imported_identifiers
 
 # METADATA
 # description: all rule names in the input AST (excluding functions)
-rule_names contains ref_to_string(rule.head.ref) if some rule in rules
+rule_names contains ref_static_to_string(rule.head.ref) if some rule in rules
 
 # METADATA
 # description: |
@@ -273,10 +273,7 @@ _format_part(part) := sprintf(".%s", [part.value]) if {
 #   non-static (i.e. variable) value, if any:
 #   foo.bar -> foo.bar
 #   foo.bar[baz] -> foo.bar
-ref_static_to_string(ref) := str if {
-	rs := ref_to_string(ref)
-	str := _trim_from_var(rs, regex.find_n(`\[[^"]`, rs, 1))
-}
+ref_static_to_string(ref) := _trim_from_var(rs, regex.find_n(`\[[^"]`, rs, 1)) if rs := ref_to_string(ref)
 
 _trim_from_var(ref_str, vars) := ref_str if {
 	count(vars) == 0

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -67,6 +67,10 @@ to_location_object(loc) := {
 
 to_location_object(loc) := loc if is_object(loc)
 
+# METADATA
+# description: efficiently extracts row number from location string
+to_location_row(loc) := to_number(regex.replace(loc, `^(\d+):.*`, "$1"))
+
 _location_to_text(row, col, end_row, end_col) := substring(
 	input.regal.file.lines[row - 1],
 	col - 1,

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -728,7 +728,7 @@ import data.unresolved`,
 	}
 }
 
-// 1111071791 ns/op	3001557280 B/op	58184205 allocs/op
+// 1130275167 ns/op	3204268280 B/op	62150928 allocs/op - a few small tweaks
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	linter := NewLinter().
@@ -755,7 +755,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 	}
 }
 
-// 1011992167 ns/op	2949576920 B/op	57079296 allocs/op
+// 1082386000 ns/op	3147603112 B/op	61016216 allocs/op
 // ...
 func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 	ctx := context.Background()


### PR DESCRIPTION
We've had a few heavy rules in the past, but nothing like this one. That's not really due to the implementation of the rule, but simply the fact that it aggregates every ref found everywhere, which will be a lot no matter what.

Using the standard "regal linting itself" benchmark on main before the rule was merged and after shows a 10%+ increase in memory allocated as well as wall clock time:

```
1111071791 ns/op	3001557280 B/op	58184205 allocs/op
1289814875 ns/op	3363166528 B/op	64788506 allocs/op - unresolved-reference merged
```

There are [some design issues](https://github.com/StyraInc/regal/issues/1265) to address with aggregate rules that likely would mean bigger wins across the board, but the focus of this PR is solely to optimize the code for the rule itself.

While this remains an expensive rule, it's now closer to our other more costly rules. In total, this saves about 2.7 million allocations of the 6.7 million allocs increased with its addition. The steps in which this was done are roughly as follows:

```
1249527041 ns/op	3337275400 B/op	64261924 allocs/op - exclude input refs
1247609750 ns/op	3325728208 B/op	64061112 allocs/op - get rid of _import_aliases
1264200584 ns/op	3324900160 B/op	64037543 allocs/op - simplify _all_full_path_refs
1182358875 ns/op	3322581056 B/op	64013278 allocs/op - inline parts of _is_resolved_ref
1189268416 ns/op	3317109520 B/op	63942894 allocs/op - skip if name in ast.rule_and_function_names
1182895291 ns/op	3305238432 B/op	63739044 allocs/op - only aggregate data used in report
1179427375 ns/op	3273346464 B/op	63188538 allocs/op - custom result.location alternative
1161155834 ns/op	3210160768 B/op	62267845 allocs/op - defer to_location_object to report
1130275167 ns/op	3204268280 B/op	62150928 allocs/op - a few small tweaks
```

I have a few more ideas for improvements, but as they'd touch on more than just this rule, this is probably a good place to stop for now.

This was great for getting to think more about aggregate rules, and what we can do to improve them. Expect more on that soon.