### PR TITLE
perf: improve aggregate rules

### DIFF
--- a/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
+++ b/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego
@@ -22,9 +22,6 @@ _package_annotated if input["package"].annotations
 
 _rule_annotations[rule_path] contains annotated if {
 	some rule in ast.public_rules_and_functions
-	every part in rule.head.ref {
-		not startswith(part.value, "_")
-	}
 
 	rule_path := concat(".", [ast.package_name, ast.ref_static_to_string(rule.head.ref)])
 	annotated := count(object.get(rule, "annotations", [])) > 0
@@ -91,13 +88,10 @@ aggregate_report contains violation if {
 
 	any_item := util.any_set_item(aggregates)
 
-	violation := result.fail(rego.metadata.chain(), {"location": object.union(
-		any_item.location,
-		{
-			"file": any_item.file,
-			"text": split(any_item.location.text, "\n")[0],
-		},
-	)})
+	violation := result.fail(rego.metadata.chain(), {"location": object.union(any_item.location, {
+		"file": any_item.file,
+		"text": split(any_item.location.text, "\n")[0],
+	})})
 }
 
 # METADATA

--- a/bundle/regal/rules/imports/circular-import/circular_import_test.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import_test.rego
@@ -37,17 +37,7 @@ test_aggregate_rule_contains_single_self_ref if {
 	aggregate := rule.aggregate with input as module
 
 	aggregate == {{
-		"aggregate_data": {"refs": {{
-			"location": {
-				"col": 12,
-				"row": 4,
-				"end": {
-					"col": 24,
-					"row": 4,
-				},
-			},
-			"package_path": "data.example",
-		}}},
+		"aggregate_data": {"refs": {["data.example", "4:12:4:24"]}},
 		"aggregate_source": {"file": "example.rego", "package_path": ["example"]},
 		"rule": {"category": "imports", "title": "circular-import"},
 	}}
@@ -73,18 +63,9 @@ test_aggregate_rule_surfaces_refs if {
 
 	aggregate == {{
 		"aggregate_data": {"refs": {
-			{
-				"location": {"col": 7, "end": {"col": 31, "row": 11}, "row": 11},
-				"package_path": "data.config.deny.enabled",
-			},
-			{
-				"location": {"col": 12, "end": {"col": 24, "row": 6}, "row": 6},
-				"package_path": "data.foo.bar",
-			},
-			{
-				"location": {"col": 14, "end": {"col": 26, "row": 8}, "row": 8},
-				"package_path": "data.baz.qux",
-			},
+			["data.config.deny.enabled", "11:7:11:31"],
+			["data.foo.bar", "6:12:6:24"],
+			["data.baz.qux", "8:14:8:26"],
 		}},
 		"aggregate_source": {
 			"file": "example.rego",
@@ -97,7 +78,7 @@ test_aggregate_rule_surfaces_refs if {
 test_import_graph if {
 	r := rule._import_graph with input as {"aggregate": {
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.b"}}},
+			"aggregate_data": {"refs": {["data.policy.b", "3:12:3:12"]}},
 			"aggregate_source": {
 				"file": "a.rego",
 				"package_path": ["policy", "a"],
@@ -105,7 +86,7 @@ test_import_graph if {
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.c"}}},
+			"aggregate_data": {"refs": {["data.policy.c", "3:12:3:12"]}},
 			"aggregate_source": {
 				"file": "b.rego",
 				"package_path": ["policy", "b"],
@@ -113,7 +94,7 @@ test_import_graph if {
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.a"}}},
+			"aggregate_data": {"refs": {["data.policy.a", "3:12:3:12"]}},
 			"aggregate_source": {
 				"file": "c.rego",
 				"package_path": ["policy", "c"],
@@ -127,7 +108,7 @@ test_import_graph if {
 
 test_import_graph_self_import if {
 	r := rule._import_graph with input as {"aggregate": {{
-		"aggregate_data": {"refs": {{"location": {"col": 12, "row": 4}, "package_path": "data.example"}}},
+		"aggregate_data": {"refs": {["data.example", "4:12:4:12"]}},
 		"aggregate_source": {"file": "example.rego", "package_path": ["example"]},
 		"rule": {"category": "imports", "title": "circular-import"},
 	}}}
@@ -171,17 +152,17 @@ test_groups_empty_graph if {
 test_package_locations if {
 	r := rule._package_locations with input as {"aggregate": {
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.b"}}},
+			"aggregate_data": {"refs": {["data.policy.b", "3:12:3:12"]}},
 			"aggregate_source": {"file": "a.rego", "package_path": ["policy.a"]},
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.c"}}},
+			"aggregate_data": {"refs": {["data.policy.c", "3:12:3:12"]}},
 			"aggregate_source": {"file": "b.rego", "package_path": ["policy.b"]},
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.a"}}},
+			"aggregate_data": {"refs": {["data.policy.a", "3:12:3:12"]}},
 			"aggregate_source": {"file": "c.rego", "package_path": ["policy.c"]},
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
@@ -197,7 +178,7 @@ test_package_locations if {
 test_aggregate_report_fails_when_cycle_present if {
 	r := rule.aggregate_report with input as {"aggregate": {
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.b"}}},
+			"aggregate_data": {"refs": {["data.policy.b", "3:12:3:12"]}},
 			"aggregate_source": {
 				"file": "a.rego",
 				"package_path": ["policy", "a"],
@@ -205,7 +186,7 @@ test_aggregate_report_fails_when_cycle_present if {
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 0, "row": 2}, "package_path": "data.policy.a"}}},
+			"aggregate_data": {"refs": {["data.policy.a", "2:0:2:0"]}},
 			"aggregate_source": {
 				"file": "b.rego",
 				"package_path": ["policy", "b"],
@@ -229,7 +210,7 @@ test_aggregate_report_fails_when_cycle_present if {
 
 test_aggregate_report_fails_when_cycle_present_in_1_package if {
 	r := rule.aggregate_report with input as {"aggregate": {{
-		"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.a"}}},
+		"aggregate_data": {"refs": {["data.policy.a", "3:12:3:12"]}},
 		"aggregate_source": {
 			"file": "a.rego",
 			"package_path": ["policy", "a"],
@@ -253,17 +234,17 @@ test_aggregate_report_fails_when_cycle_present_in_1_package if {
 test_aggregate_report_fails_when_cycle_present_in_n_packages if {
 	r := rule.aggregate_report with input as {"aggregate": {
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.b"}}},
+			"aggregate_data": {"refs": {["data.policy.b", "3:12:3:12"]}},
 			"aggregate_source": {"file": "a.rego", "package_path": ["policy", "a"]},
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.c"}}},
+			"aggregate_data": {"refs": {["data.policy.c", "3:12:3:12"]}},
 			"aggregate_source": {"file": "b.rego", "package_path": ["policy", "b"]},
 			"rule": {"category": "imports", "title": "circular-import"},
 		},
 		{
-			"aggregate_data": {"refs": {{"location": {"col": 12, "row": 3}, "package_path": "data.policy.a"}}},
+			"aggregate_data": {"refs": {["data.policy.a", "3:12:3:12"]}},
 			"aggregate_source": {"file": "c.rego", "package_path": ["policy", "c"]},
 			"rule": {"category": "imports", "title": "circular-import"},
 		},

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports_test.rego
@@ -15,32 +15,8 @@ test_aggregate_collects_imports_with_location if {
 	r == {{
 		"aggregate_data": {
 			"imports": [
-				{
-					"location": {
-						"col": 2,
-						"file": "p.rego",
-						"row": 4,
-						"end": {
-							"col": 8,
-							"row": 4,
-						},
-						"text": "\timport data.b",
-					},
-					"path": ["b"],
-				},
-				{
-					"location": {
-						"col": 2,
-						"file": "p.rego",
-						"row": 5,
-						"end": {
-							"col": 8,
-							"row": 5,
-						},
-						"text": "\timport data.c.d",
-					},
-					"path": ["c", "d"],
-				},
+				[["b"], "4:2:4:8"],
+				[["c", "d"], "5:2:5:8"],
 			],
 			"package_path": ["a"],
 		},
@@ -51,28 +27,37 @@ test_aggregate_collects_imports_with_location if {
 
 test_fail_aggregate_report_on_imported_rule if {
 	r := rule.aggregate_report with input.aggregate as {
-		{"aggregate_data": {
-			"package_path": ["a"],
-			"imports": [
-				{
-					# likely import of rule — should fail
-					"path": ["b", "c"],
-					"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import data.b.c"},
-				},
-				# import of package, should not fail
-				{"path": ["b"], "location": {"col": 1, "file": "policy.rego", "row": 4, "text": "import data.b"}},
-				# unresolved import, should not fail
-				{"path": ["c"], "location": {"col": 1, "file": "policy.rego", "row": 5, "text": "import data.c"}},
-			],
-		}},
-		{"aggregate_data": {"package_path": ["b"], "imports": []}},
+		{
+			"aggregate_data": {
+				"package_path": ["a"],
+				"imports": [
+					[["b", "c"], "3:1:3:8"], # likely import of rule — should fail
+					[["b"], "4:1:4:8"], # import of package, should not fail
+					[["c"], "5:1:5:8"], # unresolved import, should not fail
+				],
+			},
+			"aggregate_source": {"file": "policy.rego", "package_path": ["a"]},
+		},
+		{
+			"aggregate_data": {"package_path": ["b"], "imports": []},
+			"aggregate_source": {"file": "policy2.rego", "package_path": ["b"]},
+		},
 	}
 
 	r == {{
 		"category": "imports",
 		"description": "Prefer importing packages over rules",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import data.b.c"},
+		"location": {
+			"file": "policy.rego",
+			"col": 1,
+			"row": 3,
+			"end": {
+				"col": 8,
+				"row": 3,
+			},
+			"text": "import data.b.c",
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/prefer-package-imports", "imports"),
@@ -85,10 +70,7 @@ test_success_aggregate_report_on_import_with_matching_package if {
 	r := rule.aggregate_report with input.aggregate as {
 		{"aggregate_data": {
 			"package_path": ["a"],
-			"imports": [{
-				"path": ["b"],
-				"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import data.b"},
-			}],
+			"imports": [[["b"], "3:1:3:8"]],
 		}},
 		{"aggregate_data": {
 			"package_path": ["b"],
@@ -105,10 +87,7 @@ test_success_aggregate_report_on_import_with_unresolved_path if {
 	r := rule.aggregate_report with input.aggregate as {
 		{"aggregate_data": {
 			"package_path": ["a"],
-			"imports": [{
-				"path": ["foo"],
-				"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import data.b"},
-			}],
+			"imports": [[["b"], "3:1:3:8"]],
 		}},
 		{"aggregate_data": {
 			"package_path": ["bar"],
@@ -123,10 +102,7 @@ test_success_aggregate_report_ignored_import_path if {
 	aggregate := {
 		{"aggregate_data": {
 			"package_path": ["a"],
-			"imports": [{
-				"path": ["b", "c"],
-				"location": {"col": 1, "file": "policy.rego", "row": 3, "text": "import data.b.c"},
-			}],
+			"imports": [[["b", "c"], "3:1:3:8"]],
 		}},
 		{"aggregate_data": {
 			"package_path": ["b"],
@@ -154,19 +130,7 @@ test_aggregate_ignores_imports_of_regal_in_custom_rule if {
 
 	r == {{
 		"aggregate_data": {
-			"imports": [{
-				"location": {
-					"col": 2,
-					"file": "p.rego",
-					"row": 6,
-					"end": {
-						"col": 8,
-						"row": 6,
-					},
-					"text": "\timport data.a.b.c",
-				},
-				"path": ["a", "b", "c"],
-			}],
+			"imports": [[["a", "b", "c"], "6:2:6:8"]],
 			"package_path": ["custom", "regal", "rules", "foo", "bar"],
 		},
 		"aggregate_source": {"file": "p.rego", "package_path": ["custom", "regal", "rules", "foo", "bar"]},

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import_test.rego
@@ -30,7 +30,7 @@ test_fail_identifies_unresolved_imports if {
 				"col": 8,
 				"row": 5,
 			},
-			"text": "\timport data.nope",
+			"text": "import data.nope",
 		}),
 		with_location({
 			"file": "p1.rego",
@@ -40,7 +40,7 @@ test_fail_identifies_unresolved_imports if {
 				"col": 8,
 				"row": 4,
 			},
-			"text": "\timport data.bar.nope",
+			"text": "import data.bar.nope",
 		}),
 	}
 }

--- a/bundle/regal/util/util.rego
+++ b/bundle/regal/util/util.rego
@@ -68,6 +68,22 @@ to_location_object(loc) := {
 to_location_object(loc) := loc if is_object(loc)
 
 # METADATA
+# description: convert location string to location object, without the 'text' attribute
+# scope: document
+to_location_no_text(loc) := {
+	"row": to_number(r),
+	"col": to_number(c),
+	"end": {
+		"row": to_number(er),
+		"col": to_number(ec),
+	},
+} if {
+	is_string(loc)
+
+	[r, c, er, ec] := split(loc, ":")
+}
+
+# METADATA
 # description: efficiently extracts row number from location string
 to_location_row(loc) := to_number(regex.replace(loc, `^(\d+):.*`, "$1"))
 

--- a/internal/lsp/server_aggregates_test.go
+++ b/internal/lsp/server_aggregates_test.go
@@ -259,8 +259,8 @@ import data.quz
 			if aggregateData, ok := entry["aggregate_data"].(map[string]any); ok {
 				if importsList, ok := aggregateData["imports"].([]any); ok {
 					for _, imp := range importsList {
-						if impMap, ok := imp.(map[string]any); ok {
-							if pathList, ok := impMap["path"].([]any); ok {
+						if item, ok := imp.([]any); ok {
+							if pathList, ok := item[0].([]any); ok {
 								pathParts := []string{}
 
 								for _, p := range pathList {

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -538,7 +538,7 @@ func TestLintWithAggregateRule(t *testing.T) {
 		t.Errorf("expected violation to be on column 3, got %d", violation.Location.Column)
 	}
 
-	if *violation.Location.Text != "\t\timport data.foo.allow" {
+	if *violation.Location.Text != "import data.foo.allow" {
 		t.Errorf("expected violation to be on 'import data.foo.allow', got %q", *violation.Location.Text)
 	}
 }
@@ -728,7 +728,7 @@ import data.unresolved`,
 	}
 }
 
-// 1130275167 ns/op	3204268280 B/op	62150928 allocs/op - a few small tweaks
+// 1095128583 ns/op	3171781928 B/op	61097537 allocs/op
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	linter := NewLinter().


### PR DESCRIPTION
Make aggregate rules more efficient by only aggregating data that's absolutely needed, and try to use more compact representations for the aggregated data, the same way just done for unresolved-reference.

```
1130275167 ns/op	3204268280 B/op	62150928 allocs/op
1166222041 ns/op	3189028336 B/op	61860532 allocs/op - circular-import: defer to_location to report
1107372792 ns/op	3191798600 B/op	61459275 allocs/op - circular-import: use compact array format for aggregates
1122124750 ns/op	3183487808 B/op	61315825 allocs/op - prefer-package-imports: same as above
1095128583 ns/op	3171781928 B/op	61097537 allocs/op - unresolved-import: same as above
```

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->