### PR TITLE
Ignore test 'rules' as they take up a lot of memory and cpu

### DIFF
--- a/bundle/regal/config/provided/data.yaml
+++ b/bundle/regal/config/provided/data.yaml
@@ -136,6 +136,8 @@ rules:
       level: error
     unresolved-reference:
       level: error
+      excepted_export_patterns:
+        - "**.test_*"
     use-rego-v1:
       level: error
   performance:


### PR DESCRIPTION
Test references are more than half the `refs` in the aaggregate. Tests should not be referenced, an as such there is a big overhead in performance. We also expected that it had a big overhead in storage, but that was not the case.

Benchmark on main
```BenchmarkRegalLintingItself-10    	       1	15386247125 ns/op	3171539784 B/op	61023512 allocs/op```
Benchmark on this branch
```BenchmarkRegalLintingItself-10    	       1	11105144576 ns/op	3176159616 B/op	61074987 allocs/op```

