### PR TITLE
Enable prefer-values-in-head

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -21,6 +21,9 @@ rules:
         - rule
     one-liner-rule:
       level: error
+    prefer-value-in-head:
+      level: error
+      only-scalars: true
   style:
     line-length:
       level: error

--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -62,10 +62,7 @@ builtin_names := object.keys(config.capabilities.builtins)
 # description: |
 #   set containing the namespaces of all built-in functions (given the active capabilities),
 #   like "http" in `http.send` or "sum" in `sum``
-builtin_namespaces contains namespace if {
-	some name in builtin_names
-	namespace := split(name, ".")[0]
-}
+builtin_namespaces contains split(name, ".")[0] if some name in builtin_names
 
 # METADATA
 # description: |

--- a/bundle/regal/ast/imports.rego
+++ b/bundle/regal/ast/imports.rego
@@ -25,7 +25,7 @@ imported_identifiers contains _imported_identifier(imp) if {
 # METADATA
 # description: |
 #   map of all imported paths in the input module, keyed by their identifier or "namespace"
-resolved_imports[identifier] := path if {
+resolved_imports[identifier] := paths[0] if {
 	some identifier in imported_identifiers
 
 	# this should really be just a 1:1 mapping, but until OPA 1.0 we cannot
@@ -39,8 +39,6 @@ resolved_imports[identifier] := path if {
 
 		path := [part.value | some part in imp.path.value]
 	]
-
-	path := paths[0]
 }
 
 # METADATA

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -51,7 +51,7 @@ find_ref_vars(value) := [var | # regal ignore:narrow-argument
 
 # one or two vars declared via `every`, i.e. `every x in y {}`
 # or `every`, i.e. `every x, y in y {}`
-_find_every_vars(value) := vars if {
+_find_every_vars(value) := array.concat(key_var, val_var) if {
 	key_var := [value.key |
 		value.key.type == "var"
 		indexof(value.key.value, "$") == -1
@@ -60,8 +60,6 @@ _find_every_vars(value) := vars if {
 		value.value.type == "var"
 		indexof(value.value.value, "$") == -1
 	]
-
-	vars := array.concat(key_var, val_var)
 }
 
 # METADATA

--- a/bundle/regal/lsp/completion/location/location.rego
+++ b/bundle/regal/lsp/completion/location/location.rego
@@ -65,10 +65,7 @@ find_rule(rules, row) := [rule |
 #   find local variables (declared via function arguments, some/every
 #   declarations or assignment) at the given location. note that this expects
 #   `location` as a map, not a string
-find_locals(rules, location) := tmp if {
-	rul := find_rule(rules, location.row)
-	tmp := ast.find_names_in_local_scope(rul, location)
-}
+find_locals(rules, location) := ast.find_names_in_local_scope(find_rule(rules, location.row), location)
 
 # METADATA
 # description: |

--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs.rego
@@ -76,11 +76,7 @@ _rule_ref_suggestions contains ref if some ref in _other_package_refs
 
 # also suggest the unimported packages themselves
 # e.g. data.foo.rule will also generate data.foo as a suggestion
-_rule_ref_suggestions contains pkg if {
-	some ref in _other_package_refs
-
-	pkg := regex.replace(ref, `\.[^\.]+$`, "")
-}
+_rule_ref_suggestions contains regex.replace(ref, `\.[^\.]+$`, "") if some ref in _other_package_refs
 
 _matching_rule_ref_suggestions contains ref if {
 	_line != ""

--- a/bundle/regal/lsp/completion/providers/rulerefs/rulerefs_test.rego
+++ b/bundle/regal/lsp/completion/providers/rulerefs/rulerefs_test.rego
@@ -34,21 +34,14 @@ _internal_rule := true
 `,
 }
 
-parsed_modules[file_uri] := parsed_module if {
-	some file_uri, contents in workspace
-	parsed_module := regal.parse_module(file_uri, contents)
-}
+parsed_modules[file_uri] := regal.parse_module(file_uri, contents) if some file_uri, contents in workspace
 
-defined_refs[file_uri] contains ref if {
+defined_refs[file_uri] contains concat(".", [package_name, ast.ref_to_string(rule.head.ref)]) if {
 	some file_uri, parsed_module in parsed_modules
 
 	package_name := ast.ref_to_string(parsed_module["package"].path)
 
 	some rule in parsed_module.rules
-
-	rule_ref := ast.ref_to_string(rule.head.ref)
-
-	ref := concat(".", [package_name, rule_ref])
 }
 
 test_rule_refs_no_word if {

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
@@ -35,26 +35,22 @@ _message(n, arg, narrowed) := sprintf(
 	n > 1
 }
 
-_narrow(refs) := narrowed if {
+_narrow(refs) := ast.ref_to_string(_to_terms(arr)) if {
 	count(refs) == 1
 
 	arr := util.any_set_item(refs)
 
 	count(arr) > 1
 	not _nested(arr)
-
-	narrowed := ast.ref_to_string(_to_terms(arr))
 }
 
-_narrow(refs) := narrowed if {
+_narrow(refs) := ast.ref_to_string(_to_terms(prefix)) if {
 	count(refs) > 1
 
 	prefix := util.longest_prefix(refs)
 
 	count(prefix) > 1
 	not _nested(prefix)
-
-	narrowed := ast.ref_to_string(_to_terms(prefix))
 }
 
 _first_named_arg_location(indices, name) := [arg.location |
@@ -85,7 +81,7 @@ _args_indices[name] contains rule_index if {
 	rule_index := _functions[name][_].rule_index
 }
 
-_functions[name] contains func if {
+_functions[name] contains {"rule_index": i, "args_refs": args_refs} if {
 	cfg := config.rules.custom["narrow-argument"]
 
 	some i
@@ -116,7 +112,6 @@ _functions[name] contains func if {
 	}
 
 	name := ast.ref_to_string(input.rules[i].head.ref)
-	func := {"rule_index": i, "args_refs": args_refs}
 }
 
 _first_var_pos(ref) := pos if {

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head.rego
@@ -18,6 +18,7 @@ report contains violation if {
 	terms[1].value == var
 
 	not _scalar_fail(terms[2].type, ast.scalar_types)
+	not _excepted_var_name(var)
 
 	violation := result.fail(rego.metadata.chain(), result.location(terms[2]))
 }
@@ -33,3 +34,5 @@ _scalar_fail(term_type, scalar_types) if {
 	config.rules.custom["prefer-value-in-head"]["only-scalars"] == true
 	not term_type in scalar_types
 }
+
+_excepted_var_name(name) if name in config.rules.custom["prefer-value-in-head"]["except-var-names"]

--- a/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
+++ b/bundle/regal/rules/custom/prefer-value-in-head/prefer_value_in_head_test.rego
@@ -133,6 +133,16 @@ test_fail_value_could_be_in_head_object_rule if {
 	})
 }
 
+test_success_var_name_is_in_excepted_set if {
+	r := rule.report with input as ast.policy(`value := x if {
+		input.x
+		x := 10
+	}`)
+		with config.rules as {"custom": {"prefer-value-in-head": {"except-var-names": ["x"]}}}
+
+	r == set()
+}
+
 expected := {
 	"category": "custom",
 	"description": "Prefer value in rule head",

--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -112,11 +112,7 @@ _import_graph[pkg] contains edge if {
 	edge := ag_pkg.aggregate_data.refs[_][0]
 }
 
-_reachable_index[pkg] := reachable if {
-	some pkg, _ in _import_graph
-
-	reachable := graph.reachable(_import_graph, {pkg})
-}
+_reachable_index[pkg] := graph.reachable(_import_graph, {pkg}) if some pkg, _ in _import_graph
 
 _self_reachable contains pkg if {
 	some pkg, _ in _import_graph

--- a/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
+++ b/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego
@@ -88,9 +88,8 @@ _to_string(i, part) := "**" if {
 	part.type == "var"
 }
 
-_except_imports contains exception if {
+_except_imports contains _trim_data(split(str, ".")) if {
 	some str in config.rules.imports["unresolved-import"]["except-imports"]
-	exception := _trim_data(split(str, "."))
 }
 
 _trim_data(path) := array.slice(path, 1, count(path)) if path[0] == "data"

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
@@ -21,14 +21,9 @@ report contains violation if {
 
 _titleize(str) := upper(str) if count(str) == 1
 
-_titleize(str) := result if {
+_titleize(str) := concat("", array.concat([upper(chrs[0])], array.slice(chrs, 1, count(chrs)))) if {
 	chrs := regex.split(``, str)
 	count(chrs) > 1
-
-	result := concat(
-		"",
-		array.concat([upper(chrs[0])], array.slice(chrs, 1, count(chrs))),
-	)
 }
 
 _num_package_path_components := count(ast.package_path)
@@ -43,13 +38,11 @@ _possible_path_component_combinations contains combination if {
 	)
 }
 
-_possible_offending_prefixes contains prefix if {
+_possible_offending_prefixes contains concat("_", combination) if {
 	some combination in _possible_path_component_combinations
-
-	prefix := concat("_", combination)
 }
 
-_possible_offending_prefixes contains prefix if {
+_possible_offending_prefixes contains concat("", formatted_combination) if {
 	some combination in _possible_path_component_combinations
 
 	count(combination) > 1
@@ -58,6 +51,4 @@ _possible_offending_prefixes contains prefix if {
 		some word in util.rest(combination)
 		w := _titleize(word)
 	])
-
-	prefix := concat("", formatted_combination)
 }

--- a/docs/rules/custom/prefer-value-in-head.md
+++ b/docs/rules/custom/prefer-value-in-head.md
@@ -74,6 +74,10 @@ rules:
       # whether to only suggest moving scalar values (strings, numbers, booleans, null)
       # to the head, and not expressions or functions
       only-scalars: false
+      # variable names to exempt from the rule (by default, none)
+      except-var-names:
+        - report
+        - violation
 ```
 
 ## Related Resources


### PR DESCRIPTION
Although with `only-scalars` set to `true`. I did review the violations reported without that, and while most didn't warrant "fixing", a a few did, and so I did.

Also added an option to the rule to be able to list variable names that should be excluded.

It's fun to play around, but the high-level goal here is mostly to have `regal lint bundle` run all rules, even if with some exceptions defined in the config.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->