### PR TITLE
refactor: simplify test format

### DIFF
--- a/bundle/regal/ast/keywords_test.rego
+++ b/bundle/regal/ast/keywords_test.rego
@@ -3,9 +3,7 @@ package regal.ast_test
 import data.regal.ast
 
 test_keywords_package if {
-	policy := `package policy`
-
-	kwds := ast.keywords with input as regal.parse_module("p.rego", policy)
+	kwds := ast.keywords with input as ast.policy("")
 
 	count(kwds) == 1 # lines with keywords
 
@@ -20,11 +18,7 @@ test_keywords_package if {
 }
 
 test_keywords_import if {
-	policy := `package policy
-
-import data.foo`
-
-	kwds := ast.keywords with input as regal.parse_module("p.rego", policy)
+	kwds := ast.keywords with input as ast.policy("import data.foo")
 
 	count(kwds) == 2 # lines with keywords
 

--- a/bundle/regal/ast/testing.rego
+++ b/bundle/regal/ast/testing.rego
@@ -1,7 +1,9 @@
 package regal.ast
 
 # METADATA
-# description: parses provided policy with all future keywords imported. Primarily for testing.
+# description: |
+#   parses provided policy with all future keywords imported. Primarily for testing.
+#   deprecated: use ast.policy instead
 with_rego_v1(policy) := regal.parse_module("policy.rego", concat("", [
 	`package policy
 

--- a/bundle/regal/config/config.rego
+++ b/bundle/regal/config/config.rego
@@ -28,8 +28,12 @@ docs["resolve_url"](url, category) := replace(
 # description: the default configuration with user config merged on top (if provided)
 merged_config := data.internal.combined_config
 
+# ensure that config.rules can be referenced in tests even without mocking
+default rules := {}
+
 # METADATA
 # description: the merged (default and user) configuration for rules
+# scope: document
 rules := merged_config.rules
 
 # METADATA

--- a/bundle/regal/lsp/completion/ref_names_test.rego
+++ b/bundle/regal/lsp/completion/ref_names_test.rego
@@ -7,7 +7,7 @@ import data.regal.config
 import data.regal.lsp.completion
 
 test_ref_names if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	import data.imp
 	import data.foo.bar as bb
 

--- a/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata_test.rego
+++ b/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata_test.rego
@@ -6,11 +6,10 @@ import data.regal.config
 import data.regal.rules.bugs["annotation-without-metadata"] as rule
 
 test_fail_annotation_without_metadata if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 # title: allow
 allow := false
 	`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -35,33 +34,28 @@ allow := false
 }
 
 test_success_annotation_with_metadata if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 # METADATA
 # title: allow
 allow := false
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_annotation_but_no_metadata_location if {
-	module := ast.with_rego_v1(`
-allow := false # title: allow
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`allow := false # title: allow`)
 
 	r == set()
 }
 
 test_success_annotation_without_metadata_but_comment_preceding if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 # something that is not an annotation here will cancel this rule
 # as this is less likely to be a mistake... but weird
 # title: allow
 allow := false
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }

--- a/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard_test.rego
+++ b/bundle/regal/rules/bugs/argument-always-wildcard/argument_always_wildcard_test.rego
@@ -44,9 +44,7 @@ cases["multiple argument always a wildcard"] := {
 }
 
 test_success_single_function_single_argument_always_a_wildcard_except_function_name if {
-	module := ast.policy(`mock_f(_) := 1`)
-
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`mock_f(_) := 1`)
 		with config.rules as {"bugs": {"argument-always-wildcard": {"except-function-name-pattern": "^mock_"}}}
 
 	r == set()

--- a/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
+++ b/bundle/regal/rules/bugs/constant-condition/constant_condition_test.rego
@@ -147,6 +147,6 @@ test_success_non_constant_condition if {
 }
 
 test_success_adding_constant_to_set if {
-	r := rule.report with input as ast.with_rego_v1(`rule contains "message"`)
+	r := rule.report with input as ast.policy(`rule contains "message"`)
 	r == set()
 }

--- a/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
+++ b/bundle/regal/rules/bugs/duplicate-rule/duplicate_rule_test.rego
@@ -37,12 +37,11 @@ test_fail_simple_duplicate_rule if {
 }
 
 test_success_similar_but_not_duplicate_rule if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	allow if input.foo == "bar"
 
 	allow if input.foo == "bar "
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }

--- a/bundle/regal/rules/bugs/if-empty-object/if_empty_object_test.rego
+++ b/bundle/regal/rules/bugs/if-empty-object/if_empty_object_test.rego
@@ -6,8 +6,7 @@ import data.regal.config
 import data.regal.rules.bugs["if-empty-object"] as rule
 
 test_fail_if_empty_object if {
-	module := ast.with_rego_v1("rule if {}")
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy("rule if {}")
 
 	r == {{
 		"category": "bugs",
@@ -16,11 +15,11 @@ test_fail_if_empty_object if {
 		"location": {
 			"col": 1,
 			"file": "policy.rego",
-			"row": 5,
+			"row": 3,
 			"text": "rule if {}",
 			"end": {
 				"col": 11,
-				"row": 5,
+				"row": 3,
 			},
 		},
 		"related_resources": [{
@@ -34,7 +33,7 @@ test_fail_if_empty_object if {
 test_success_if_non_empty_object if {
 	# this is arguably just as useless, but we'll defer
 	# to the constant-condition rule for these cases
-	module := ast.with_rego_v1(`rule if {"foo": "bar"}`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`rule if {"foo": "bar"}`)
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/if-object-literal/if_object_literal_test.rego
+++ b/bundle/regal/rules/bugs/if-object-literal/if_object_literal_test.rego
@@ -11,11 +11,11 @@ test_fail[name] if {
 			`rule if {}`,
 			{
 				"col": 9,
-				"row": 5,
+				"row": 3,
 				"text": "rule if {}",
 				"end": {
 					"col": 11,
-					"row": 5,
+					"row": 3,
 				},
 			},
 		],
@@ -23,17 +23,17 @@ test_fail[name] if {
 			`rule if {"x": input.x}`,
 			{
 				"col": 9,
-				"row": 5,
+				"row": 3,
 				"text": `rule if {"x": input.x}`,
 				"end": {
 					"col": 23,
-					"row": 5,
+					"row": 3,
 				},
 			},
 		],
 	}
+	r := rule.report with input as ast.policy(policy)
 
-	r := rule.report with input as ast.with_rego_v1(policy)
 	r == {{
 		"category": "bugs",
 		"description": "Object literal following `if`",
@@ -48,7 +48,7 @@ test_fail[name] if {
 }
 
 test_success_not_an_object if {
-	module := ast.with_rego_v1(`rule if { true }`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.with_rego_v1(`rule if { true }`)
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule_test.rego
+++ b/bundle/regal/rules/bugs/import-shadows-rule/import_shadows_rule_test.rego
@@ -6,12 +6,11 @@ import data.regal.config
 import data.regal.rules.bugs["import-shadows-rule"] as rule
 
 test_fail_import_shadows_rule if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	import data.foo.bar
 
 	bar := 1
 	`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -36,12 +35,11 @@ test_fail_import_shadows_rule if {
 }
 
 test_fail_import_alias_shadows_rule if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	import data.foo as bar
 
 	bar := 1
 	`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -66,23 +64,21 @@ test_fail_import_alias_shadows_rule if {
 }
 
 test_success_import_does_not_shadow_rule if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	import data.foo.bar
 
 	foo := 1
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_import_alias_does_not_shadow_rule if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	import data.foo as bar
 
 	foo := 1
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args_test.rego
@@ -43,7 +43,7 @@ test_fail_nested_inconsistent_args if {
 }
 
 test_success_not_inconsistent_args if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	foo(a, b) if a == b
 	foo(a, b) if a > b
 
@@ -58,7 +58,7 @@ test_success_not_inconsistent_args if {
 }
 
 test_success_using_wildcard if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	foo(a, b) if a == b
 	foo(_, b) if b.foo
 
@@ -70,7 +70,7 @@ test_success_using_wildcard if {
 }
 
 test_success_using_pattern_matching if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	foo(a, b) if a == b
 	foo(a, "foo") if a.foo
 
@@ -84,7 +84,7 @@ test_success_using_pattern_matching if {
 # this is a compiler error, so let's not flag it here
 # see https://github.com/StyraInc/regal/issues/1250
 test_success_incorrect_arity if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	foo(a, b) if a == b
 	foo(a, b, c) if a > b > c
 	foo(b, a) if a == b

--- a/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint_test.rego
+++ b/bundle/regal/rules/bugs/internal-entrypoint/internal_entrypoint_test.rego
@@ -6,8 +6,7 @@ import data.regal.config
 import data.regal.rules.bugs["internal-entrypoint"] as rule
 
 test_fail_internal_entrypoint if {
-	module := ast.with_rego_v1(`
-
+	module := ast.policy(`
 # METADATA
 # entrypoint: true
 _allow := true
@@ -18,7 +17,16 @@ _allow := true
 		"category": "bugs",
 		"description": "Entrypoint can't be marked internal",
 		"level": "error",
-		"location": {"col": 1, "file": "policy.rego", "row": 9, "text": "_allow := true", "end": {"col": 7, "row": 9}},
+		"location": {
+			"col": 1,
+			"file": "policy.rego",
+			"row": 6,
+			"text": "_allow := true",
+			"end": {
+				"col": 7,
+				"row": 6,
+			},
+		},
 		"related_resources": [{
 			"description": "documentation",
 			"ref": config.docs.resolve_url("$baseUrl/$category/internal-entrypoint", "bugs"),
@@ -28,23 +36,25 @@ _allow := true
 }
 
 test_fail_internal_entrypoint_rule_ref if {
-	module := ast.with_rego_v1(`
-
+	module := ast.policy(`
 # METADATA
 # entrypoint: true
 authz._allow := true
 	`)
-
 	r := rule.report with input as module
+
 	r == {{
 		"category": "bugs",
 		"description": "Entrypoint can't be marked internal",
 		"level": "error",
 		"location": {
 			"col": 7,
-			"end": {"col": 13, "row": 9},
+			"end": {
+				"col": 13,
+				"row": 6,
+			},
 			"file": "policy.rego",
-			"row": 9,
+			"row": 6,
 			"text": "authz._allow := true",
 		},
 		"related_resources": [{
@@ -56,13 +66,11 @@ authz._allow := true
 }
 
 test_success_non_internal_entrypoint if {
-	module := ast.with_rego_v1(`
-
+	r := rule.report with input as ast.policy(`
 # METADATA
 # entrypoint: true
 allow := true
 	`)
 
-	r := rule.report with input as module
 	r == set()
 }

--- a/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
+++ b/bundle/regal/rules/bugs/leaked-internal-reference/leaked_internal_reference_test.rego
@@ -6,85 +6,82 @@ import data.regal.config
 import data.regal.rules.bugs["leaked-internal-reference"] as rule
 
 test_fail_leaked_internal_reference_in_import if {
-	r := rule.report with input as ast.with_rego_v1(`import data.foo._bar`)
+	r := rule.report with input as ast.policy(`import data.foo._bar`)
 
 	r == expected_with_location({
 		"col": 8,
-		"row": 5,
+		"row": 3,
 		"end": {
 			"col": 21,
-			"row": 5,
+			"row": 3,
 		},
 		"text": "import data.foo._bar",
 	})
 }
 
 test_fail_leaked_internal_reference_in_rule_head if {
-	r := rule.report with input as ast.with_rego_v1(`var := data.foo._bar`)
+	r := rule.report with input as ast.policy(`var := data.foo._bar`)
 
 	r == expected_with_location({
 		"col": 8,
 		"file": "policy.rego",
-		"row": 5,
+		"row": 3,
 		"end": {
 			"col": 21,
-			"row": 5,
+			"row": 3,
 		},
 		"text": "var := data.foo._bar",
 	})
 }
 
 test_fail_leaked_internal_reference_in_rule_body if {
-	r := rule.report with input as ast.with_rego_v1(`rule if {
+	r := rule.report with input as ast.policy(`rule if {
 		x := data.foo._bar
 	}`)
 
 	r == expected_with_location({
 		"col": 8,
-		"row": 6,
+		"row": 4,
 		"end": {
 			"col": 21,
-			"row": 6,
+			"row": 4,
 		},
 		"text": "\t\tx := data.foo._bar",
 	})
 }
 
 test_fail_leaked_internal_reference_in_nested_comprehension if {
-	r := rule.report with input as ast.with_rego_v1(`rule if {
-		comp := [x | x := data.foo._bar]
-	}`)
+	r := rule.report with input as ast.policy("rule if comp := [x | x := data.foo._bar]")
 
 	r == expected_with_location({
-		"col": 21,
-		"row": 6,
+		"col": 27,
+		"row": 3,
 		"end": {
-			"col": 34,
-			"row": 6,
+			"col": 40,
+			"row": 3,
 		},
-		"text": "\t\tcomp := [x | x := data.foo._bar]",
+		"text": "rule if comp := [x | x := data.foo._bar]",
 	})
 }
 
 test_ignore_test_file_by_default if {
-	r := rule.report with input as ast.with_rego_v1(`foo := data.bar._wow`)
-		with input.regal.file.name as "p_test.rego"
+	r := rule.report with input as ast.policy("foo := data.bar._wow") with input.regal.file.name as "p_test.rego"
 
 	r == set()
 }
 
 test_ignore_test_file_can_be_disabled if {
-	r := rule.report with input as ast.with_rego_v1(`foo := data.bar._wow`)
+	r := rule.report with input as ast.policy(`foo := data.bar._wow`)
 		with input.regal.file.name as "p_test.rego"
 		with config.rules as {"bugs": {"leaked-internal-reference": {"include-test-files": true}}}
 
 	r == expected_with_location({
 		"file": "p_test.rego",
 		"col": 8,
-		"row": 5,
+		"row": 3,
 		"end": {
 			"col": 21,
-			"row": 5,
+			"row": 3,
 		},
 		"text": "foo := data.bar._wow",
 	})

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop_test.rego
@@ -55,7 +55,7 @@ test_fail_neq_in_loop if {
 }
 
 test_fail_neq_in_loop_one_liner if {
-	r := rule.report with input as ast.with_rego_v1(`deny if "admin" != input.user.groups[_]`)
+	r := rule.report with input as ast.policy(`deny if "admin" != input.user.groups[_]`)
 
 	r == {{
 		"category": "bugs",
@@ -64,10 +64,10 @@ test_fail_neq_in_loop_one_liner if {
 		"location": {
 			"col": 17,
 			"file": "policy.rego",
-			"row": 5,
+			"row": 3,
 			"end": {
 				"col": 19,
-				"row": 5,
+				"row": 3,
 			},
 			"text": "deny if \"admin\" != input.user.groups[_]",
 		},

--- a/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check_test.rego
+++ b/bundle/regal/rules/bugs/redundant-existence-check/redundant_existence_check_test.rego
@@ -6,12 +6,11 @@ import data.regal.config
 import data.regal.rules.bugs["redundant-existence-check"] as rule
 
 test_fail_redundant_existence_check if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	redundant if {
 		input.foo
 		startswith(input.foo, "bar")
 	}`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -27,12 +26,11 @@ test_fail_redundant_existence_check if {
 }
 
 test_fail_redundant_existence_check_subset if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	redundant if {
 		input.foo
 		startswith(input.foo.bar, "bar")
 	}`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -48,33 +46,30 @@ test_fail_redundant_existence_check_subset if {
 }
 
 test_success_not_redundant_existence_check if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	redundant if {
 		input.foo
 		something_expensive
 		startswith(input.foo, "bar")
 	}`)
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_redundant_existence_check_with_cancels if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	not_redundant if {
 		rule.foo with input as {}
 		rule.foo == 1
 	}`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_fail_redundant_existence_check_head_assignment_of_ref if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	redundant := input.foo if {
 		input.foo
 	}`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -90,11 +85,10 @@ test_fail_redundant_existence_check_head_assignment_of_ref if {
 }
 
 test_fail_redundant_existence_check_function_arg if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	fun(foo) if {
 		foo
 	}`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",

--- a/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default_test.rego
+++ b/bundle/regal/rules/bugs/rule-assigns-default/rule_assigns_default_test.rego
@@ -6,7 +6,7 @@ import data.regal.config
 import data.regal.rules.bugs["rule-assigns-default"] as rule
 
 test_fail_rule_assigned_default_value if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 
 	default allow := false
 
@@ -14,7 +14,6 @@ test_fail_rule_assigned_default_value if {
 		some conditions in policy
 	}
 	`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",

--- a/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch_test.rego
+++ b/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch_test.rego
@@ -81,7 +81,8 @@ test_fail_too_few_values_in_array if {
 }
 
 test_success_same_number_of_values if {
-	r := rule.report with input as ast.with_rego_v1(`x := sprintf("%s%d", [1, 2])`)
+	r := rule.report with input as ast.policy(`x := sprintf("%s%d", [1, 2])`)
+
 	r == set()
 }
 
@@ -137,19 +138,22 @@ test_fail_first_arg_is_variable_with_nonmatching_pattern if {
 }
 
 test_success_first_arg_is_variable_with_matching_pattern if {
-	r := rule.report with input as ast.with_rego_v1(`rule if {
+	r := rule.report with input as ast.policy(`rule if {
 		s := "%s"
 		sprintf(s, ["foo"]) == "foo"
 	}`)
+
 	r == set()
 }
 
 test_success_same_number_of_values_with_explicit_index if {
-	r := rule.report with input as ast.with_rego_v1(`x := sprintf("%[1]s %[1]s %[2]d", [1, 2])`)
+	r := rule.report with input as ast.policy(`x := sprintf("%[1]s %[1]s %[2]d", [1, 2])`)
+
 	r == set()
 }
 
 test_success_escaped_verbs_are_ignored if {
-	r := rule.report with input as ast.with_rego_v1(`x := sprintf("%d %% %% %s", [1, "f"])`)
+	r := rule.report with input as ast.policy(`x := sprintf("%d %% %% %s", [1, "f"])`)
+
 	r == set()
 }

--- a/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice_test.rego
+++ b/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice_test.rego
@@ -6,13 +6,12 @@ import data.regal.config
 import data.regal.rules.bugs["time-now-ns-twice"] as rule
 
 test_fail_time_now_ns_called_twice if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	took := then if {
 		now := time.now_ns()
 		numbers.range(1, 10)
 		then := time.now_ns() - now
 	}`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -37,12 +36,11 @@ test_fail_time_now_ns_called_twice if {
 }
 
 test_fail_time_now_ns_called_twice_body_and_head if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	took := time.now_ns() - now if {
 		now := time.now_ns()
 		numbers.range(1, 10)
 	}`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "bugs",
@@ -67,17 +65,16 @@ test_fail_time_now_ns_called_twice_body_and_head if {
 }
 
 test_success_time_now_ns_called_once if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	rule if {
 		print(time.now_ns())
 	}`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_time_now_ns_called_twice_but_different_rule_indices if {
-	module := ast.policy(`
+	r := rule.report with input as ast.policy(`
 	rule if {
 		print(time.now_ns())
 	}
@@ -86,7 +83,6 @@ test_success_time_now_ns_called_twice_but_different_rule_indices if {
 		print(time.now_ns())
 	}
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }

--- a/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration_test.rego
+++ b/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration_test.rego
@@ -56,7 +56,7 @@ test_fail_top_level_iteration_named_var if {
 }
 
 test_success_top_level_known_var_ref if {
-	r := rule.report with input as ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	i := "foo"
 	x := input.foo.bar[i]`)
 
@@ -65,38 +65,38 @@ test_success_top_level_known_var_ref if {
 
 # https://github.com/StyraInc/regal/issues/852
 test_success_top_level_ref_head_vars_assignment if {
-	r := rule.report with input as ast.with_rego_v1(`foo[x] := input[x] if some x in [1, 2, 3]`)
+	r := rule.report with input as ast.policy(`foo[x] := input[x] if some x in [1, 2, 3]`)
 
 	r == set()
 }
 
 # https://github.com/StyraInc/regal/issues/401
 test_success_top_level_input_assignment if {
-	r := rule.report with input as ast.with_rego_v1(`x := input`)
+	r := rule.report with input as ast.policy(`x := input`)
 
 	r == set()
 }
 
 test_success_top_level_input_ref if {
-	r := rule.report with input as ast.with_rego_v1(`x := input.foo.bar[input.y]`)
+	r := rule.report with input as ast.policy(`x := input.foo.bar[input.y]`)
 
 	r == set()
 }
 
 test_success_top_level_const if {
-	r := rule.report with input as ast.with_rego_v1(`x := input.foo.bar[4]`)
+	r := rule.report with input as ast.policy(`x := input.foo.bar[4]`)
 
 	r == set()
 }
 
 test_success_top_level_param if {
-	r := rule.report with input as ast.with_rego_v1(`x(y) := input.foo.bar[y]`)
+	r := rule.report with input as ast.policy(`x(y) := input.foo.bar[y]`)
 
 	r == set()
 }
 
 test_success_top_level_import if {
-	r := rule.report with input as ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	import data.x
 
 	y := input[x]`)
@@ -106,7 +106,7 @@ test_success_top_level_import if {
 
 # verify fix for https://github.com/StyraInc/regal/issues/1277
 test_success_vars_in_head_also_in_body if {
-	r := rule.report with input as ast.with_rego_v1(`x := input.x[a][b] if [a, b] := [1, 2]`)
+	r := rule.report with input as ast.policy(`x := input.x[a][b] if [a, b] := [1, 2]`)
 
 	r == set()
 }

--- a/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
+++ b/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable_test.rego
@@ -6,13 +6,12 @@ import data.regal.config
 import data.regal.rules.bugs["unused-output-variable"] as rule
 
 test_fail_unused_output_variable if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	fail if {
 		input[x]
 	}
 	`)
 
-	r := rule.report with input as module
 	r == {{
 		"category": "bugs",
 		"description": "Unused output variable",
@@ -27,14 +26,13 @@ test_fail_unused_output_variable if {
 }
 
 test_fail_unused_output_variable_some if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	fail if {
 		some xx
 		input[xx]
 	}
 	`)
 
-	r := rule.report with input as module
 	r == {{
 		"category": "bugs",
 		"description": "Unused output variable",
@@ -49,62 +47,37 @@ test_fail_unused_output_variable_some if {
 }
 
 test_success_unused_wildcard if {
-	module := ast.with_rego_v1(`
-	success if {
-		input[_]
-	}
-	`)
+	r := rule.report with input as ast.policy("success if input[_]")
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_variable_in_head_value if {
-	module := ast.with_rego_v1(`
-	success := x if {
-		input[x]
-	}
-	`)
+	r := rule.report with input as ast.policy("success := x if input[x]")
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_variable_in_head_term_value if {
-	module := ast.with_rego_v1(`
-	success := {x} if {
-		input[x]
-	}
-	`)
+	r := rule.report with input as ast.policy("success := {x} if input[x]")
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_variable_in_head_term_key if {
-	module := ast.with_rego_v1(`
-	success contains {x} if {
-		input[x]
-	}
-	`)
+	r := rule.report with input as ast.policy("success contains {x} if input[x]")
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_variable_in_head_key if {
-	module := ast.with_rego_v1(`
-	success contains x if {
-		input[x]
-	}
-	`)
+	r := rule.report with input as ast.policy("success contains x if input[x]")
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_output_variable_function_call if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	success if {
 		some x
 		input[x]
@@ -112,12 +85,11 @@ test_success_not_unused_output_variable_function_call if {
 	}
 	`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_output_variable_function_call_arg_term if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	success if {
 		some x
 		input[x]
@@ -125,75 +97,61 @@ test_success_not_unused_output_variable_function_call_arg_term if {
 	}
 	`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_output_variable_other_ref if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	success if {
 		some x
 		input[x] == data.foo[x]
 	}
 	`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_output_variable_head_ref if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	success[x] if {
 		some x
 		input[x]
 	}
 	`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_output_variable_rule if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	x := 1
 
-	success := x if {
-		input[x]
-	}
+	success := x if input[x]
 	`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_output_variable_argument if {
-	module := ast.with_rego_v1(`
-	success(x) if {
-		input[x]
-	}
-	`)
+	r := rule.report with input as ast.policy("success(x) if input[x]")
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_comprehension_term if {
-	module := ast.with_rego_v1(`success if {x | input[x]}`)
+	r := rule.report with input as ast.with_rego_v1(`success if {x | input[x]}`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_comprehension_term_complex if {
-	module := ast.with_rego_v1(`success if {[x, y] | input[x][y]}`)
+	r := rule.report with input as ast.policy(`success if {[x, y] | input[x][y]}`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_unused_comprehension_term_key_value if {
-	module := ast.with_rego_v1(`success if {x: y | input[x][y]}`)
+	r := rule.report with input as ast.policy(`success if {x: y | input[x][y]}`)
 
-	r := rule.report with input as module
 	r == set()
 }

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument.rego
@@ -82,8 +82,6 @@ _args_indices[name] contains rule_index if {
 }
 
 _functions[name] contains {"rule_index": i, "args_refs": args_refs} if {
-	cfg := config.rules.custom["narrow-argument"]
-
 	some i
 	args := input.rules[i].head.args
 
@@ -91,7 +89,7 @@ _functions[name] contains {"rule_index": i, "args_refs": args_refs} if {
 		some arg in args
 		arg.type == "var"
 		not startswith(arg.value, "$")
-		not _exclude_arg(cfg, arg.value)
+		not _exclude_arg(arg.value)
 	}
 
 	# we don't care for functions without named variable arguments
@@ -122,7 +120,7 @@ _first_var_pos(ref) := pos if {
 	][0]
 } else := count(ref) + 1
 
-_exclude_arg(cfg, name) if name in cfg["exclude-args"]
+_exclude_arg(name) if name in config.rules.custom["narrow-argument"]["exclude-args"]
 
 _to_terms(arr) := [_to_term(item) | some item in arr]
 

--- a/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
+++ b/bundle/regal/rules/custom/narrow-argument/narrow_argument_test.rego
@@ -10,7 +10,6 @@ test_fail_can_be_narrowed_single_ref if {
 		fun(obj) if obj.number == 1
 		fun(obj) if obj.number == 2
 	`)
-		with config.rules as {"custom": {"narrow-argument": {"level": "error"}}}
 
 	r == {{
 		"category": "custom",
@@ -39,7 +38,6 @@ test_fail_can_be_narrowed_prefixed_ref if {
 		fun(obj) if obj.x.y.number == 1
 		fun(obj) if obj.x.y.string == "1"
 	`)
-		with config.rules as {"custom": {"narrow-argument": {"level": "error"}}}
 
 	r == {{
 		"category": "custom",
@@ -68,7 +66,6 @@ test_fail_can_be_narrowed_prefixed_array_ref if {
 		fun(arr) if arr[0].y.number == 1
 		fun(arr) if arr[0].y.string == "1"
 	`)
-		with config.rules as {"custom": {"narrow-argument": {"level": "error"}}}
 
 	r == {{
 		"category": "custom",
@@ -97,14 +94,12 @@ test_success_can_not_be_narrowed_arg_is_least_common_denominator if {
 		fun(obj) if obj.typ == "string"
 		fun(obj) if obj.val == "string"
 	`)
-		with config.rules as {"custom": {"narrow-argument": {"level": "error"}}}
 
 	r == set()
 }
 
 test_success_nested_or_variable_path_not_narrowed if {
 	r := rule.report with input as ast.policy(`foo(lines) := lines[bar - 1]`)
-		with config.rules as {"custom": {"narrow-argument": {"level": "error"}}}
 
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule_test.rego
+++ b/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule_test.rego
@@ -64,31 +64,31 @@ test_fail_object_comprehension_could_be_rule if {
 }
 
 test_success_set_comprehension_array_to_set_conversion_ref_iteration if {
-	r := rule.report with input as ast.with_rego_v1(`my_set := {s | s := arr[_]}`)
+	r := rule.report with input as ast.policy(`my_set := {s | s := arr[_]}`)
 
 	r == set()
 }
 
 test_success_set_comprehension_array_to_set_conversion_ref_nested_iteration if {
-	r := rule.report with input as ast.with_rego_v1(`my_set := {s | s := a.b.c[_]}`)
+	r := rule.report with input as ast.policy(`my_set := {s | s := a.b.c[_]}`)
 
 	r == set()
 }
 
 test_success_set_comprehension_array_to_set_conversion_ref_nested_iteration_sub_attribute if {
-	r := rule.report with input as ast.with_rego_v1(`my_set := {s | s := a.b.c[_].d}`)
+	r := rule.report with input as ast.policy(`my_set := {s | s := a.b.c[_].d}`)
 
 	r == set()
 }
 
 test_success_set_comprehension_array_to_set_conversion_some_in if {
-	r := rule.report with input as ast.with_rego_v1(`my_set := {s | some s in arr}`)
+	r := rule.report with input as ast.policy(`my_set := {s | some s in arr}`)
 
 	r == set()
 }
 
 test_success_set_comprehension_but_rule_body if {
-	r := rule.report with input as ast.with_rego_v1(`my_set := {s | some s in arr; s == ""} if { some_condition }`)
+	r := rule.report with input as ast.policy(`my_set := {s | some s in arr; s == ""} if { some_condition }`)
 
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/use-contains/use_contains_test.rego
+++ b/bundle/regal/rules/idiomatic/use-contains/use_contains_test.rego
@@ -6,13 +6,12 @@ import data.regal.config
 import data.regal.rules.idiomatic["use-contains"] as rule
 
 test_fail_should_use_contains if {
-	module := ast.with_rego_v0(`
+	r := rule.report with input as ast.with_rego_v0(`
 	import future.keywords
 
 	rule[item] {
 		some item in input.items
 	}`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "idiomatic",
@@ -37,32 +36,23 @@ test_fail_should_use_contains if {
 }
 
 test_success_uses_contains if {
-	module := ast.with_rego_v1(`rule contains item if {
-		some item in input.items
-	}`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy("rule contains item if some item in input.items")
 
 	r == set()
 }
 
 test_success_object_rule if {
-	module := ast.with_rego_v1(`rule[foo] := bar if {
+	r := rule.report with input as ast.policy(`rule[foo] := bar if {
 		foo := "bar"
 		bar := "baz"
 	}`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 # https://github.com/StyraInc/regal/issues/1212
 test_success_contains_without_rule_body if {
-	module := ast.policy(`
-	import future.keywords.contains
-
-	mask contains "foo"
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`mask contains "foo"`)
 
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
+++ b/bundle/regal/rules/idiomatic/use-if/use_if_test.rego
@@ -36,18 +36,13 @@ test_fail_should_use_if if {
 }
 
 test_success_uses_if if {
-	module := ast.with_rego_v1(`rule := [true |
-		input[_]
-	] if {
-		input.attribute
-	}`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy("rule := [true | input[_]] if input.attribute")
 
 	r == set()
 }
 
 test_success_no_body_no_if if {
-	r := rule.report with input as ast.with_rego_v1(`rule := "without body"`)
+	r := rule.report with input as ast.policy(`rule := "without body"`)
 
 	r == set()
 }

--- a/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars_test.rego
+++ b/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars_test.rego
@@ -115,7 +115,7 @@ test_success_uses_some if {
 }
 
 test_success_var_in_comprehension_body if {
-	r := rule.report with input as ast.with_rego_v1(`build_obj(params) if {
+	r := rule.report with input as ast.policy(`build_obj(params) if {
 		paths := {"foo": ["bar"]}
 		param_objects := [f(paths[key], val) | some key, val in paths]
 	}`)
@@ -123,27 +123,27 @@ test_success_var_in_comprehension_body if {
 }
 
 test_success_some_iteration if {
-	rule.report with input as ast.with_rego_v1(`allow if {
+	rule.report with input as ast.policy(`allow if {
 		some i in input
 		foo[i]
 	}`) == set()
 
-	rule.report with input as ast.with_rego_v1(`allow if {
+	rule.report with input as ast.policy(`allow if {
 		some i, x in input
 		input.user.roles[i]
 	}`) == set()
 
-	rule.report with input as ast.with_rego_v1(`allow if {
+	rule.report with input as ast.policy(`allow if {
 		some x, i in input
 		input.user.roles[i]
 	}`) == set()
 
-	rule.report with input as ast.with_rego_v1(`allow if {
+	rule.report with input as ast.policy(`allow if {
 		some x, i in input
 		input.user.roles[x][i]
 	}`) == set()
 
-	rule.report with input as ast.with_rego_v1(`allow if {
+	rule.report with input as ast.policy(`allow if {
 		some i in input
 		input.user.roles[_]
 	}`) == set()
@@ -157,5 +157,6 @@ test_success_not_an_output_var if {
 			# i now an *input* var
 			"admin" == input.user.roles[i]
 		}`)
+
 	r == set()
 }

--- a/bundle/regal/rules/performance/defer-assignment/defer_assignment_test.rego
+++ b/bundle/regal/rules/performance/defer-assignment/defer_assignment_test.rego
@@ -6,14 +6,14 @@ import data.regal.config
 import data.regal.rules.performance["defer-assignment"] as rule
 
 test_fail_can_defer_assignment_simple if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	allow if {
 		resp := http.send({"method": "get", "url": "http://localhost"})
 		input.foo == "bar"
 		resp.status_code == 200
 	}
 	`)
-	r := rule.report with input as module
+
 	r == {with_location({
 		"col": 3,
 		"end": {
@@ -30,85 +30,84 @@ test_fail_can_defer_assignment_simple if {
 # be deferrable, but we won't e.g. defer assignments into loop bodies, etc
 
 test_success_can_not_defer_assignment_var_used_in_next_expression if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := input.x
 		x == true
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_var_used_in_next_negated_expression if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := input.x
 		not x
 	}
 	`)
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_can_not_defer_loop_assignment if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := input[foo][bar]
 		input.x == 2
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_array_assignment if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		[x, y] := foo("bar")
 		input.x == 2
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_in_group if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := 1
 		y := 2
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_var_in_rule_head if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	rule[x] := 1 if {
 		x := input.x
 		input.bar == "baz"
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_next_expression_some if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := input.x
 		some foo in bar
 		x == 5
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_next_expression_every if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := input.x
 		every foo in bar {
@@ -116,53 +115,53 @@ test_success_can_not_defer_assignment_next_expression_every if {
 		}
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_next_expression_walk if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := input.x
 		walk(input, [p, v])
 		v == x
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_next_expression_has_with if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	test_allow if {
 		x := input.x
 		allow with input as x
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_next_expression_with_in_arg if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	rule if {
 		u := "u"
 		input == "U" with input as upper(u)
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_can_not_defer_assignment_next_expression_print_call if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		x := input.x
 		print("here!")
 		x == "yes"
 	}
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 

--- a/bundle/regal/rules/performance/walk-no-path/walk_no_path_test.rego
+++ b/bundle/regal/rules/performance/walk-no-path/walk_no_path_test.rego
@@ -6,82 +6,76 @@ import data.regal.config
 import data.regal.rules.performance["walk-no-path"] as rule
 
 test_fail_walk_can_have_path_omitted if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		walk(input, [path, value])
 		value == 1
 	}
 	`)
-	r := rule.report with input as module
 
 	r == {with_location({
 		"col": 3,
 		"end": {
 			"col": 7,
-			"row": 7,
+			"row": 5,
 		},
 		"file": "policy.rego",
-		"row": 7,
+		"row": 5,
 		"text": "\t\twalk(input, [path, value])",
 	})}
 }
 
 test_success_path_is_wildcard if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		walk(input, [_, value])
 		value == 1
 	}
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_path_in_head if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	rule[path] := "foo" if {
 		walk(input, [path, value])
 		value == 1
 	}
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_path_in_call if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		walk(input, [path, value])
 		path == 1
 	}
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_path_in_ref if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		walk(input, [path, value])
 		input[path] == 1
 	}
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_path_in_ref_in_ref if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		walk(input, [path, value])
 		input[path[0]] == 1
 	}
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }

--- a/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context_test.rego
+++ b/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context_test.rego
@@ -6,12 +6,11 @@ import data.regal.config
 import data.regal.rules.performance["with-outside-test-context"] as rule
 
 test_fail_with_used_outside_test if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		not foo.deny with input as {}
 	}
 	`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "performance",
@@ -20,10 +19,10 @@ test_fail_with_used_outside_test if {
 		"location": {
 			"col": 16,
 			"file": "policy.rego",
-			"row": 7,
+			"row": 5,
 			"end": {
 				"col": 32,
-				"row": 7,
+				"row": 5,
 			},
 			"text": "\t\tnot foo.deny with input as {}",
 		},
@@ -36,23 +35,13 @@ test_fail_with_used_outside_test if {
 }
 
 test_success_with_used_in_test if {
-	module := ast.with_rego_v1(`
-	test_foo_deny if {
-		not foo.deny with input as {}
-	}
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy("test_foo_deny if not foo.deny with input as {}")
 
 	r == set()
 }
 
 test_success_with_used_in_todo_test if {
-	module := ast.with_rego_v1(`
-	todo_test_foo_deny if {
-		not foo.deny with input as {}
-	}
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy("todo_test_foo_deny if not foo.deny with input as {}")
 
 	r == set()
 }

--- a/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
+++ b/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment_test.rego
@@ -132,17 +132,16 @@ test_fail_object_comprehension_value_assignment_static_ref if {
 }
 
 test_success_not_flagging_function_call if {
-	module := ast.with_rego_v1(`comp := [x |
+	r := rule.report with input as ast.policy(`comp := [x |
 		some y in input
 		x := http.send({"method": "get", "url": sprintf("https://example.org/%s", [y])})
 	]`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_flagging_composite_values if {
-	module := ast.with_rego_v1(`comp := [x |
+	r := rule.report with input as ast.policy(`comp := [x |
 		some y in input
 		x := {
 			"foo": "bar",
@@ -150,45 +149,40 @@ test_success_not_flagging_composite_values if {
 		}
 	]`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_flagging_single_expression if {
-	module := ast.with_rego_v1(`comp := [x | x := input.foo[_].bar]`)
+	r := rule.report with input as ast.policy(`comp := [x | x := input.foo[_].bar]`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_flagging_dynamic_ref if {
-	module := ast.with_rego_v1(`f(x) := [1, x, 3]
+	r := rule.report with input as ast.policy(`f(x) := [1, x, 3]
 
 	find_vars(node) := [x |
 		some var in node
 		x := f(var)[_]
 	]`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_flagging_custom_function_call if {
-	module := ast.with_rego_v1(`rows := [row |
+	r := rule.report with input as ast.policy(`rows := [row |
 		some comment in comments
 		row := util.to_location_object(comment.location).row
 	]`)
 
-	r := rule.report with input as module
 	r == set()
 }
 
 test_success_not_flagging_assigned_comprehension if {
-	module := ast.with_rego_v1(`comp := [x |
+	r := rule.report with input as ast.policy(`comp := [x |
 		some var in input
 		x := [y | some y in var]
 	]`)
 
-	r := rule.report with input as module
 	r == set()
 }

--- a/bundle/regal/rules/style/default-over-not/default_over_not_test.rego
+++ b/bundle/regal/rules/style/default-over-not/default_over_not_test.rego
@@ -6,11 +6,10 @@ import data.regal.config
 import data.regal.rules.style["default-over-not"] as rule
 
 test_fail_default_over_not if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.with_rego_v1(`
 	user := input.user
 	user := "foo" if not input.user
 	`)
-	r := rule.report with input as module
 
 	r == {{
 		"category": "style",
@@ -35,19 +34,19 @@ test_fail_default_over_not if {
 }
 
 test_success_non_constant_value if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	user := input.user
 	user := var if not input.user
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }
 
 test_success_var_in_ref if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	user := input[x].user
 	user := "foo" if not input[x].user
 	`)
-	r := rule.report with input as module
+
 	r == set()
 }

--- a/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
+++ b/bundle/regal/rules/style/function-arg-return/function_arg_return_test.rego
@@ -58,7 +58,7 @@ test_fail_function_arg_return_value_multi_part_ref if {
 }
 
 test_success_function_arg_return_value_except_function if {
-	r := rule.report with input as ast.with_rego_v1(`foo := i if { indexof("foo", "o", i) }`)
+	r := rule.report with input as ast.policy(`foo := i if { indexof("foo", "o", i) }`)
 		with config.capabilities as capabilities.provided
 		with config.rules as {"style": {"function-arg-return": {"except-functions": ["indexof"]}}}
 

--- a/bundle/regal/rules/style/line-length/line_length_test.rego
+++ b/bundle/regal/rules/style/line-length/line_length_test.rego
@@ -30,7 +30,7 @@ foo == bar; bar == baz; [a, b, c, d, e, f] := [1, 2, 3, 4, 5, 6]; qux := [q | so
 }
 
 test_success_line_too_long_but_non_breakable_word if {
-	r := rule.report with input as ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 
 	# Long url: https://www.example.com/this/is/a/very/long/url/that/cannot/be/shortened
 	allow := true
@@ -72,7 +72,6 @@ test_fail_line_exceeds_120_characters_even_if_not_in_config if {
 	r := rule.report with input as ast.with_rego_v1(`# Long url: https://www.example.com/this/is/a/very/long/url/that/cannot/be/shortened/and/should/trigger/an/error/anyway/so/that/it/can/be/shortened
 	allow := true
 	`)
-		with config.rules as {"style": {"line-length": {"level": "error"}}}
 
 	r == {{
 		"category": "style",

--- a/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
+++ b/bundle/regal/rules/style/messy-rule/messy_rule_test.rego
@@ -6,20 +6,19 @@ import data.regal.config
 import data.regal.rules.style["messy-rule"] as rule
 
 test_success_non_messy_definition if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	foo if true
 
 	foo if 5 == 1
 
 	bar if false
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_fail_messy_definition if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	foo if true
 
 	bar if false
@@ -30,17 +29,17 @@ test_fail_messy_definition if {
 
 	r == expected_with_location({
 		"col": 2,
-		"row": 10,
+		"row": 8,
 		"end": {
 			"col": 15,
-			"row": 10,
+			"row": 8,
 		},
 		"text": "\tfoo if 5 == 1",
 	})
 }
 
 test_fail_messy_default_definition if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	default foo := true
 
 	bar if false
@@ -51,10 +50,10 @@ test_fail_messy_default_definition if {
 
 	r == expected_with_location({
 		"col": 2,
-		"row": 10,
+		"row": 8,
 		"end": {
 			"col": 15,
-			"row": 10,
+			"row": 8,
 		},
 		"text": "\tfoo if 5 == 1",
 	})
@@ -82,20 +81,19 @@ test_fail_messy_nested_rule_definition if {
 }
 
 test_success_non_incremental_nested_rule_definition if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	base.foo if true
 
 	bar if false
 
 	base.bar if 5 == 1
 	`)
-	r := rule.report with input as module
 
 	r == set()
 }
 
 test_success_non_messy_ref_head_rules if {
-	module := ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	keywords[foo.bar] contains "foo"
 
 	keywords[foo] contains "foo"
@@ -103,7 +101,6 @@ test_success_non_messy_ref_head_rules if {
 	keywords[foo.baz] contains "foo"
 	`)
 
-	r := rule.report with input as module
 	r == set()
 }
 

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package_test.rego
@@ -29,13 +29,11 @@ test_rule_empty_if_no_repetition if {
 }
 
 test_rule_violation_if_repetition if {
-	module := regal.parse_module("example.rego", `
+	r := rule.report with input as regal.parse_module("example.rego", `
     package policy.foo.bar
 
     bar := true
     `)
-
-	r := rule.report with input as module
 
 	r == {object.union(
 		base_result,
@@ -53,13 +51,11 @@ test_rule_violation_if_repetition if {
 }
 
 test_rule_violation_if_repetition_of_more_than_one_path_component if {
-	module := regal.parse_module("example.rego", `package policy.foo.bar.baz
+	r := rule.report with input as regal.parse_module("example.rego", `package policy.foo.bar.baz
     foo_bar_baz := true
 
     barBaz := 1
     `)
-
-	r := rule.report with input as module
 
 	r == {
 		object.union(base_result, {"location": {
@@ -80,15 +76,13 @@ test_rule_violation_if_repetition_of_more_than_one_path_component if {
 }
 
 test_rule_violation_if_repetition_multiple if {
-	module := regal.parse_module("example.rego", `
+	r := rule.report with input as regal.parse_module("example.rego", `
     package policy.foo.bar
 
     bar := true
     barNumber := 3
     barString := "string"
     `)
-
-	r := rule.report with input as module
 
 	r == {
 		object.union(base_result, {"location": {
@@ -116,13 +110,11 @@ test_rule_violation_if_repetition_multiple if {
 }
 
 test_rule_violation_if_repetition_in_function if {
-	module := regal.parse_module("example.rego", `
+	r := rule.report with input as regal.parse_module("example.rego", `
     package policy.foo.bar
 
     bar(_) := true
     `)
-
-	r := rule.report with input as module
 
 	r == {object.union(
 		base_result,
@@ -137,13 +129,11 @@ test_rule_violation_if_repetition_in_function if {
 }
 
 test_rule_violation_if_repetition_in_defaults if {
-	module := regal.parse_module("example.rego", `package policy.foo.bar
+	r := rule.report with input as regal.parse_module("example.rego", `package policy.foo.bar
 
     default bar(_) := true
     default barNumber := 3
     `)
-
-	r := rule.report with input as module
 
 	r == {
 		object.union(base_result, {"location": {
@@ -164,15 +154,13 @@ test_rule_violation_if_repetition_in_defaults if {
 }
 
 test_rule_violation_if_repetition_ref_head_rule if {
-	module := regal.parse_module("example.rego", `
+	r := rule.report with input as regal.parse_module("example.rego", `
 	package policy
 
 	import rego.v1
 
 	policy.decision contains "nope"
 	`)
-
-	r := rule.report with input as module
 
 	r == {object.union(base_result, {"location": {
 		"col": 2,

--- a/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule_test.rego
+++ b/bundle/regal/rules/style/trailing-default-rule/trailing_default_rule_test.rego
@@ -6,7 +6,7 @@ import data.regal.config
 import data.regal.rules.style["trailing-default-rule"] as rule
 
 test_success_default_declared_first if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	default foo := true
 
 	foo if true
@@ -17,7 +17,7 @@ test_success_default_declared_first if {
 }
 
 test_fail_default_declared_after if {
-	module := ast.with_rego_v1(`
+	module := ast.policy(`
 	foo if true
 
 	default foo := true
@@ -31,10 +31,10 @@ test_fail_default_declared_after if {
 		"location": {
 			"col": 2,
 			"file": "policy.rego",
-			"row": 8,
+			"row": 6,
 			"end": {
 				"col": 9,
-				"row": 8,
+				"row": 6,
 			},
 			"text": "\tdefault foo := true",
 		},

--- a/bundle/regal/rules/style/unnecessary-some/unnecessary_some_test.rego
+++ b/bundle/regal/rules/style/unnecessary-some/unnecessary_some_test.rego
@@ -36,26 +36,21 @@ test_fail_some_unnecessary_value if {
 }
 
 test_fail_some_unnecessary_key_value if {
-	module := ast.with_rego_v1(`
-	rule if {
-		some "x", 1 in {"x": 1}
-	}
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.with_rego_v1(`rule if some "x", 1 in {"x": 1}`)
 
 	r == {{
 		"category": "style",
 		"description": "Unnecessary use of `some`",
 		"level": "error",
 		"location": {
-			"col": 8,
-			"file": "policy.rego",
-			"row": 7,
+			"col": 14,
 			"end": {
-				"col": 26,
-				"row": 7,
+				"col": 32,
+				"row": 5,
 			},
-			"text": "\t\tsome \"x\", 1 in {\"x\": 1}",
+			"file": "policy.rego",
+			"row": 5,
+			"text": "rule if some \"x\", 1 in {\"x\": 1}",
 		},
 		"related_resources": [{
 			"description": "documentation",
@@ -66,40 +61,25 @@ test_fail_some_unnecessary_key_value if {
 }
 
 test_success_some_value_using_var if {
-	module := ast.with_rego_v1(`
-	rule if {
-		some var in input.vars
-	}
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`rule if some var in input.vars`)
 
 	r == set()
 }
 
 test_success_some_key_value_using_var_for_value if {
-	module := ast.with_rego_v1(`
-	rule if {
-		some "x", var in {"x": 1}
-	}
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`rule if some "x", var in {"x": 1}`)
 
 	r == set()
 }
 
 test_success_some_key_value_using_var_for_key if {
-	module := ast.with_rego_v1(`
-	rule if {
-		some var, 1 in {"x": 1}
-	}
-	`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`rule if some var, 1 in {"x": 1}`)
 
 	r == set()
 }
 
 test_success_just_in_head if {
-	r := rule.report with input as ast.with_rego_v1(`rule := [1 in []]`)
+	r := rule.report with input as ast.policy(`rule := [1 in []]`)
 
 	r == set()
 }

--- a/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
+++ b/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator_test.rego
@@ -209,22 +209,25 @@ test_success_partial_rule if {
 }
 
 test_success_using_if if {
-	r := rule.report with input as ast.with_rego_v1(`foo if 1 == 1`)
+	r := rule.report with input as ast.policy(`foo if 1 == 1`)
+
 	r == set()
 }
 
 test_success_ref_head_rule_if if {
-	r := rule.report with input as ast.with_rego_v1(`a.b.c if true`)
+	r := rule.report with input as ast.policy(`a.b.c if true`)
+
 	r == set()
 }
 
 test_success_ref_head_rule_with_var_if if {
-	r := rule.report with input as ast.with_rego_v1(`works[x] if x := 5`)
+	r := rule.report with input as ast.policy(`works[x] if x := 5`)
+
 	r == set()
 }
 
 test_fail_unification_in_else if {
-	r := rule.report with input as ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		input.x
 	} else = true if {
@@ -240,9 +243,9 @@ test_fail_unification_in_else if {
 				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 			}],
 			"title": "use-assignment-operator",
-			"location": {"col": 9, "file": "policy.rego", "row": 8, "text": "\t} else = true if {", "end": {
+			"location": {"col": 9, "file": "policy.rego", "row": 6, "text": "\t} else = true if {", "end": {
 				"col": 10,
-				"row": 8,
+				"row": 6,
 			}},
 			"level": "error",
 		},
@@ -254,9 +257,9 @@ test_fail_unification_in_else if {
 				"ref": config.docs.resolve_url("$baseUrl/$category/use-assignment-operator", "style"),
 			}],
 			"title": "use-assignment-operator",
-			"location": {"col": 9, "file": "policy.rego", "row": 10, "text": "\t} else = false", "end": {
+			"location": {"col": 9, "file": "policy.rego", "row": 8, "text": "\t} else = false", "end": {
 				"col": 10,
-				"row": 10,
+				"row": 8,
 			}},
 			"level": "error",
 		},
@@ -264,7 +267,7 @@ test_fail_unification_in_else if {
 }
 
 test_success_assignment_in_else if {
-	r := rule.report with input as ast.with_rego_v1(`
+	r := rule.report with input as ast.policy(`
 	allow if {
 		input.x
 	} else := true if {

--- a/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
+++ b/bundle/regal/rules/style/yoda-condition/yoda_condition_test.rego
@@ -56,26 +56,20 @@ test_fail_yoda_conditions_greater_and_less_than if {
 }
 
 test_success_no_yoda_condition if {
-	module := ast.policy(`rule if {
-		input.bar == "foo"
-	}`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`rule if input.bar == "foo"`)
+
 	r == set()
 }
 
 test_success_constants_on_both_sides if {
-	module := ast.policy(`rule if {
-		"foo" == "foo"
-	}`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`rule if "foo" == "foo"`)
+
 	r == set()
 }
 
 test_success_exclude_ref_with_vars if {
-	module := ast.policy(`rule if {
-		"foo" == input.bar[_]
-	}`)
-	r := rule.report with input as module
+	r := rule.report with input as ast.policy(`rule if "foo" == input.bar[_]`)
+
 	r == set()
 }
 

--- a/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
+++ b/bundle/regal/rules/testing/metasyntactic-variable/metasyntactic_variable_test.rego
@@ -6,9 +6,8 @@ import data.regal.config
 import data.regal.rules.testing["metasyntactic-variable"] as rule
 
 test_fail_rule_named_foo if {
-	module := ast.policy("foo := true")
+	r := rule.report with input as ast.policy("foo := true")
 
-	r := rule.report with input as module
 	r == {expected_with_location({
 		"col": 1,
 		"file": "policy.rego",
@@ -22,12 +21,11 @@ test_fail_rule_named_foo if {
 }
 
 test_fail_metasyntactic_vars if {
-	module := ast.policy(`allow if {
+	r := rule.report with input as ast.policy(`allow if {
 		fooBar := true
 		input[baz]
 	}`)
 
-	r := rule.report with input as module
 	r == {
 		expected_with_location({
 			"col": 3,
@@ -53,9 +51,8 @@ test_fail_metasyntactic_vars if {
 }
 
 test_fail_metasyntactic_vars_ref_head_strings if {
-	module := ast.policy(`foo.a.BAR.b.C.baz := true`)
+	r := rule.report with input as ast.policy(`foo.a.BAR.b.C.baz := true`)
 
-	r := rule.report with input as module
 	r == {
 		expected_with_location({
 			"col": 1,


### PR DESCRIPTION
Mostly just a way to kill some time between conversations here today :P 

- remove redundant `module` assignment
- replace ast.with_rego_v1 with ast.policy where that is easily done

There are still many tests like this that can be improved, but I'm tired of doing this now, so I'll get back to that at some later point.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->