### PR TITLE
Apply modernize fixes

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -411,7 +411,7 @@ func formatError(format string, err error) error {
 	// currently, JSON and SARIF will get the same generic JSON error format
 	switch format {
 	case formatJSON, formatSarif:
-		bs, err := json.MarshalIndent(map[string]interface{}{
+		bs, err := json.MarshalIndent(map[string]any{
 			"errors": []string{err.Error()},
 		}, "", "  ")
 		if err != nil {

--- a/internal/dap/logger.go
+++ b/internal/dap/logger.go
@@ -21,7 +21,7 @@ func NewDebugLogger(localLogger logging.Logger, level logging.Level) *DebugLogge
 	}
 }
 
-func (l *DebugLogger) Debug(fmt string, a ...interface{}) {
+func (l *DebugLogger) Debug(fmt string, a ...any) {
 	if l == nil {
 		return
 	}
@@ -31,7 +31,7 @@ func (l *DebugLogger) Debug(fmt string, a ...interface{}) {
 	l.send(logging.Debug, fmt, a...)
 }
 
-func (l *DebugLogger) Info(fmt string, a ...interface{}) {
+func (l *DebugLogger) Info(fmt string, a ...any) {
 	if l == nil {
 		return
 	}
@@ -41,7 +41,7 @@ func (l *DebugLogger) Info(fmt string, a ...interface{}) {
 	l.send(logging.Info, fmt, a...)
 }
 
-func (l *DebugLogger) Error(fmt string, a ...interface{}) {
+func (l *DebugLogger) Error(fmt string, a ...any) {
 	if l == nil {
 		return
 	}
@@ -51,7 +51,7 @@ func (l *DebugLogger) Error(fmt string, a ...interface{}) {
 	l.send(logging.Error, fmt, a...)
 }
 
-func (l *DebugLogger) Warn(fmt string, a ...interface{}) {
+func (l *DebugLogger) Warn(fmt string, a ...any) {
 	if l == nil {
 		return
 	}
@@ -61,7 +61,7 @@ func (l *DebugLogger) Warn(fmt string, a ...interface{}) {
 	l.send(logging.Warn, fmt, a...)
 }
 
-func (l *DebugLogger) WithFields(map[string]interface{}) logging.Logger {
+func (l *DebugLogger) WithFields(map[string]any) logging.Logger {
 	if l == nil {
 		return nil
 	}
@@ -116,7 +116,7 @@ func (l *DebugLogger) SetLevelFromString(level string) {
 	}
 }
 
-func (l *DebugLogger) send(level logging.Level, fmt string, a ...interface{}) {
+func (l *DebugLogger) send(level logging.Level, fmt string, a ...any) {
 	if l == nil || l.ProtocolManager == nil || !l.remoteEnabled || level > l.level {
 		return
 	}

--- a/internal/lsp/bundles/cache.go
+++ b/internal/lsp/bundles/cache.go
@@ -87,15 +87,7 @@ func (c *Cache) Refresh() ([]string, error) {
 
 	// remove any bundles that are no longer present on disk
 	for root := range c.bundles {
-		found := false
-
-		for _, foundRoot := range foundBundleRoots {
-			if root == foundRoot {
-				found = true
-
-				break
-			}
-		}
+		found := slices.Contains(foundBundleRoots, root)
 
 		if !found {
 			delete(c.bundles, root)

--- a/internal/lsp/commands/parse_test.go
+++ b/internal/lsp/commands/parse_test.go
@@ -20,7 +20,7 @@ func TestParse(t *testing.T) {
 		"extract target only": {
 			ExecuteCommandParams: types.ExecuteCommandParams{
 				Command:   "example",
-				Arguments: []interface{}{"target"},
+				Arguments: []any{"target"},
 			},
 			ParseOptions:     ParseOptions{TargetArgIndex: 0},
 			ExpectedTarget:   "target",
@@ -29,7 +29,7 @@ func TestParse(t *testing.T) {
 		"extract target and location": {
 			ExecuteCommandParams: types.ExecuteCommandParams{
 				Command:   "example",
-				Arguments: []interface{}{"target", "1", 2}, // different types for testing, but should be strings
+				Arguments: []any{"target", "1", 2}, // different types for testing, but should be strings
 			},
 			ParseOptions:     ParseOptions{TargetArgIndex: 0, RowArgIndex: 1, ColArgIndex: 2},
 			ExpectedTarget:   "target",
@@ -38,7 +38,7 @@ func TestParse(t *testing.T) {
 		"extract from JSON": {
 			ExecuteCommandParams: types.ExecuteCommandParams{
 				Command:   "example",
-				Arguments: []interface{}{"target", "1", 2}, // different types for testing, but should be strings
+				Arguments: []any{"target", "1", 2}, // different types for testing, but should be strings
 			},
 			ParseOptions:     ParseOptions{TargetArgIndex: 0, RowArgIndex: 1, ColArgIndex: 2},
 			ExpectedTarget:   "target",
@@ -91,7 +91,7 @@ func TestParse_Errors(t *testing.T) {
 		"error extracting target": {
 			ExecuteCommandParams: types.ExecuteCommandParams{
 				Command:   "example",
-				Arguments: []interface{}{}, // empty and so nothing can be extracted
+				Arguments: []any{}, // empty and so nothing can be extracted
 			},
 			ParseOptions:  ParseOptions{TargetArgIndex: 0},
 			ExpectedError: "no args supplied",

--- a/internal/lsp/completions/providers/policy_test.go
+++ b/internal/lsp/completions/providers/policy_test.go
@@ -89,9 +89,9 @@ foo := true
 import data.example
 `)
 
-	store := inmem.NewFromObject(map[string]interface{}{
-		"workspace": map[string]interface{}{
-			"parsed": map[string]interface{}{
+	store := inmem.NewFromObject(map[string]any{
+		"workspace": map[string]any{
+			"parsed": map[string]any{
 				"file:///file1.rego": file1,
 				"file:///file2.rego": file2,
 			},

--- a/internal/lsp/completions/providers/ruleheadkeyword_test.go
+++ b/internal/lsp/completions/providers/ruleheadkeyword_test.go
@@ -2,6 +2,7 @@ package providers
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/styrainc/regal/internal/lsp/cache"
@@ -43,15 +44,7 @@ deny` + " "
 	}
 
 	for _, comp := range completions {
-		found := false
-
-		for _, label := range expectedLabels {
-			if comp.Label == label {
-				found = true
-
-				break
-			}
-		}
+		found := slices.Contains(expectedLabels, comp.Label)
 
 		if !found {
 			t.Fatalf("Expected label to be one of %v, got: %v", expectedLabels, comp.Label)

--- a/internal/lsp/completions/refs/used.go
+++ b/internal/lsp/completions/refs/used.go
@@ -79,7 +79,7 @@ func UsedInModule(ctx context.Context, module *ast.Module) ([]string, error) {
 		return []string{}, nil
 	}
 
-	foundRefs, ok := rs[0].Expressions[0].Value.([]interface{})
+	foundRefs, ok := rs[0].Expressions[0].Value.([]any)
 	if !ok {
 		return nil, fmt.Errorf("unexpected type %T", rs[0].Expressions[0].Value)
 	}

--- a/internal/lsp/connection.go
+++ b/internal/lsp/connection.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/sourcegraph/jsonrpc2"
 
@@ -53,31 +54,19 @@ type ConnectionLoggingConfig struct {
 
 func (cfg *ConnectionLoggingConfig) ShouldLog(method string) bool {
 	if len(cfg.IncludeMethods) > 0 {
-		for _, m := range cfg.IncludeMethods {
-			if m == method {
-				return true
-			}
-		}
-
-		return false
+		return slices.Contains(cfg.IncludeMethods, method)
 	}
 
-	for _, m := range cfg.ExcludeMethods {
-		if m == method {
-			return false
-		}
-	}
-
-	return true
+	return !slices.Contains(cfg.ExcludeMethods, method)
 }
 
-type ConnectionHandlerFunc func(context.Context, *jsonrpc2.Conn, *jsonrpc2.Request) (result interface{}, err error)
+type ConnectionHandlerFunc func(context.Context, *jsonrpc2.Conn, *jsonrpc2.Request) (result any, err error)
 
 type connectionLogger struct {
 	writer io.Writer
 }
 
-func (c *connectionLogger) Printf(format string, v ...interface{}) {
+func (c *connectionLogger) Printf(format string, v ...any) {
 	fmt.Fprintf(c.writer, format, v...)
 }
 

--- a/internal/lsp/opa/tokens/tokens.go
+++ b/internal/lsp/opa/tokens/tokens.go
@@ -6,6 +6,8 @@
 
 package tokens
 
+import "maps"
+
 // Token represents a single Rego source code token
 // for use by the Parser.
 type Token int
@@ -140,8 +142,6 @@ var keywords = map[string]Token{
 // Keywords returns a copy of the default string -> Token keyword map.
 func Keywords() map[string]Token {
 	cpy := make(map[string]Token, len(keywords))
-	for k, v := range keywords {
-		cpy[k] = v
-	}
+	maps.Copy(cpy, keywords)
 	return cpy
 }

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -59,7 +59,7 @@ func LocationFromPosition(pos types.Position) *ast.Location {
 func AllBuiltinCalls(module *ast.Module, builtins map[string]*ast.Builtin) []BuiltInCall {
 	builtinCalls := make([]BuiltInCall, 0)
 
-	callVisitor := ast.NewGenericVisitor(func(x interface{}) bool {
+	callVisitor := ast.NewGenericVisitor(func(x any) bool {
 		var terms []*ast.Term
 
 		switch node := x.(type) {

--- a/internal/lsp/store_test.go
+++ b/internal/lsp/store_test.go
@@ -14,7 +14,7 @@ import (
 
 type illegalResolver struct{}
 
-func (illegalResolver) Resolve(ref ast.Ref) (interface{}, error) {
+func (illegalResolver) Resolve(ref ast.Ref) (any, error) {
 	return nil, fmt.Errorf("illegal value: %v", ref)
 }
 


### PR DESCRIPTION
Not a whole lot of them, but the contains checks are nice! I wish this would integrate with golangci-lint, but for now I don't think the overhead of running this separately in CI is worth it, as I don't expect us to have many things to fix in future code.

```
go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix ./...
```

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->