### PR TITLE
perf: various optimizations

### DIFF
--- a/bundle/regal/ast/ast_test.rego
+++ b/bundle/regal/ast/ast_test.rego
@@ -12,7 +12,7 @@ test_function_decls_multiple_same_name if {
 	f(y) := y if false
 	`
 	module := regal.parse_module("p.rego", policy)
-	custom := ast.function_decls(module.rules)
+	custom := ast.function_decls with input as module
 
 	# we only need to assert there wasn't a conflict in the above
 	# call, not what value was returned

--- a/bundle/regal/lsp/completion/location/location.rego
+++ b/bundle/regal/lsp/completion/location/location.rego
@@ -38,12 +38,9 @@ from_start_of_line_to_position(position) := {
 # description: |
 #   estimate where the location "ends" based on its text attribute,
 #   both line and column
-end_location_estimate(location) := end if {
-	lines := split(location.text, "\n")
-	end := {
-		"row": (location.row + count(lines)) - 1,
-		"col": count(regal.last(lines)),
-	}
+end_location_estimate(location) := {
+	"row": location.row + strings.count(location.text, "\n"),
+	"col": count(regex.replace(location.text, `.*\n`, "")),
 }
 
 # METADATA
@@ -54,10 +51,9 @@ find_rule(rules, row) := [rule |
 	some i, rule in rules
 
 	start_location := util.to_location_object(rule.location)
-	end_location := end_location_estimate(start_location)
 
 	row >= start_location.row
-	row <= end_location.row
+	row <= end_location_estimate(start_location).row
 ][0]
 
 # METADATA

--- a/bundle/regal/lsp/completion/providers/booleans/booleans.rego
+++ b/bundle/regal/lsp/completion/providers/booleans/booleans.rego
@@ -16,7 +16,6 @@ items contains item if {
 	words := regex.split(`\s+`, line)
 
 	words_on_line := count(words)
-
 	previous_word := words[words_on_line - 2]
 
 	previous_word in {"==", ":="}

--- a/bundle/regal/lsp/completion/providers/snippet/snippet.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet.rego
@@ -19,7 +19,6 @@ items contains item if {
 	line := input.regal.file.lines[position.line]
 
 	not endswith(trim_space(line), "=")
-
 	location.in_rule_body(line)
 
 	word := location.word_at(line, input.regal.context.location.col)
@@ -46,10 +45,9 @@ items contains item if {
 	line := input.regal.file.lines[position.line]
 
 	startswith("metadata", line)
-
 	word := location.word_at(line, input.regal.context.location.col)
 
-	items := {
+	some item in {
 		{
 			"label": "metadata annotation [title, description] (snippet)",
 			"kind": kind.snippet,
@@ -71,8 +69,6 @@ items contains item if {
 			"insertTextFormat": 2, # snippet
 		},
 	}
-
-	some item in items
 }
 
 _snippets := {

--- a/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
@@ -4,13 +4,9 @@ import data.regal.lsp.completion.providers.snippet as provider
 import data.regal.lsp.completion.providers.test_utils as util
 
 test_snippet_completion_on_typing_partial_prefix if {
-	policy := `package policy
-
-import rego.v1
-
-allow if {
+	policy := _with_header(`allow if {
 	e
-}`
+}`)
 	items := provider.items with input as util.input_with_location(policy, {"row": 6, "col": 2})
 	items == {
 		{
@@ -43,13 +39,9 @@ allow if {
 }
 
 test_snippet_completion_on_typing_full_prefix if {
-	policy := `package policy
-
-import rego.v1
-
-allow if {
+	policy := _with_header(`allow if {
 	every
-}`
+}`)
 	items := provider.items with input as util.input_with_location(policy, {"row": 6, "col": 6})
 	items == {
 		{
@@ -82,25 +74,16 @@ allow if {
 }
 
 test_snippet_completion_on_typing_no_repeat if {
-	policy := `package policy
-
-import rego.v1
-
-allow if {
+	policy := _with_header(`allow if {
 	some e in [1,2,3] some
-}
-`
+}`)
+
 	items := provider.items with input as util.input_with_location(policy, {"row": 6, "col": 21})
 	items == set()
 }
 
 test_snippet_completion_on_invoked if {
-	policy := `package policy
-
-import rego.v1
-
-allow if `
-	items := provider.items with input as util.input_with_location(policy, {"row": 5, "col": 10})
+	items := provider.items with input as util.input_with_location(_with_header(`allow if `), {"row": 5, "col": 10})
 	items == {
 		{
 			"detail": "every key-value iteration",
@@ -158,13 +141,7 @@ allow if `
 }
 
 test_metadata_snippet_completion if {
-	policy := `package policy
-
-import rego.v1
-
-
-`
-	items := provider.items with input as util.input_with_location(policy, {"row": 5, "col": 1})
+	items := provider.items with input as util.input_with_location(_with_header(``), {"row": 5, "col": 1})
 	items == {
 		{
 			"detail": "metadata annotation",
@@ -194,3 +171,5 @@ import rego.v1
 		},
 	}
 }
+
+_with_header(policy) := concat("\n\n", ["package policy", "import rego.v1", policy])

--- a/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
+++ b/bundle/regal/rules/bugs/impossible-not/impossible_not.rego
@@ -16,7 +16,7 @@ _multivalue_rules contains path if {
 	not rule.head.value
 
 	# ignore general ref head rules for now
-	every path in array.slice(rule.head.ref, 1, count(rule.head.ref)) {
+	every path in array.slice(rule.head.ref, 1, 100) {
 		path.type == "string"
 	}
 
@@ -121,7 +121,7 @@ _resolve(ref, _, imported_symbols) := concat(".", resolved) if {
 
 	resolved := array.concat(
 		imported_symbols[ref[0].value],
-		[part.value | some part in array.slice(ref, 1, count(ref))],
+		[part.value | some part in array.slice(ref, 1, 100)],
 	)
 }
 

--- a/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
+++ b/bundle/regal/rules/bugs/inconsistent-args/inconsistent_args.rego
@@ -8,7 +8,7 @@ import data.regal.result
 report contains violation if {
 	count(ast.functions) > 0
 
-	# Comprehension indexing
+	# comprehension indexing
 	function_args_by_name := {name: args_list |
 		some i
 		name := ast.ref_to_string(ast.functions[i].head.ref)
@@ -21,12 +21,9 @@ report contains violation if {
 	}
 
 	some name, args_list in function_args_by_name
+	not _arity_mismatch(args_list) # leave that to the compiler
 
-	# leave that to the compiler
-	not _arity_mismatch(args_list)
-
-	# "Partition" the args by their position
-	by_position := [s |
+	by_position := [s | # "partition" the args by their position
 		some i, _ in args_list[0]
 		s := [item[i] | some item in args_list]
 	]

--- a/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
+++ b/bundle/regal/rules/bugs/not-equals-in-loop/not_equals_in_loop.rego
@@ -15,7 +15,7 @@ report contains violation if {
 	terms[0].value[0].type == "var"
 	terms[0].value[0].value == "neq"
 
-	some neq_term in array.slice(terms, 1, count(terms))
+	some neq_term in array.slice(terms, 1, 100)
 	neq_term.type == "ref"
 
 	some value in neq_term.value

--- a/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice.rego
+++ b/bundle/regal/rules/bugs/time-now-ns-twice/time_now_ns_twice.rego
@@ -6,17 +6,16 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	# note: calls per _rule_index_, which is just what we want
-	some calls in ast.function_calls
+	some rule_index
+	ast.function_calls[rule_index][_].name == "time.now_ns"
 
 	time_now_calls := [call |
-		some call in calls
+		some call in ast.function_calls[rule_index]
 		call.name == "time.now_ns"
 	]
 
-	count(time_now_calls) > 1
-
-	some repeated in array.slice(time_now_calls, 1, count(time_now_calls))
+	some i, repeated in time_now_calls
+	i > 0
 
 	violation := result.fail(rego.metadata.chain(), result.location(repeated))
 }

--- a/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration.rego
+++ b/bundle/regal/rules/bugs/top-level-iteration/top_level_iteration.rego
@@ -17,7 +17,7 @@ report contains violation if {
 		part.type == "var"
 	]) == 0
 
-	some part in array.slice(rule.head.value.value, 1, 128)
+	some part in array.slice(rule.head.value.value, 1, 100)
 
 	part.type == "var"
 

--- a/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys.rego
+++ b/bundle/regal/rules/idiomatic/use-object-keys/use_object_keys.rego
@@ -46,7 +46,7 @@ report contains violation if {
 	ref := _ref(comprehension.value.body)
 
 	vars := [part |
-		some part in array.slice(ref, 1, 128)
+		some part in array.slice(ref, 1, 100)
 		part.type == "var"
 	]
 

--- a/bundle/regal/rules/imports/circular-import/circular_import.rego
+++ b/bundle/regal/rules/imports/circular-import/circular_import.rego
@@ -70,15 +70,11 @@ aggregate_report contains violation if {
 
 	some pkg in g # this will the only package
 
-	location := [e |
-		some e in _package_locations[pkg][pkg]
-	][0]
-
 	violation := result.fail(
 		rego.metadata.chain(),
 		{
 			"description": sprintf("Circular self-dependency in: %s", [pkg]),
-			"location": location,
+			"location": [e | some e in _package_locations[pkg][pkg]][0],
 		},
 	)
 }

--- a/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
+++ b/bundle/regal/rules/imports/prefer-package-imports/prefer_package_imports.rego
@@ -61,13 +61,6 @@ _resolves(path, pkg_paths) if count([path |
 	pkg_path == array.slice(path, 0, count(pkg_path))
 ]) > 0
 
-_ignored_import_paths contains path if {
+_ignored_import_paths contains split(trim_prefix(item, "data."), ".") if {
 	some item in config.rules.imports["prefer-package-imports"]["ignore-import-paths"]
-	path := [part |
-		some i, p in split(item, ".")
-		part := _normalize_part(i, p)
-	]
 }
-
-_normalize_part(0, part) := part if part != "data"
-_normalize_part(i, part) := part if i > 0

--- a/bundle/regal/rules/style/external-reference/external_reference.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference.rego
@@ -8,7 +8,7 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	fn_namespaces := {split(name, ".")[0] | some name in ast.all_function_names}
+	fn_namespaces := {regex.replace(name, `\..*`, "") | some name in ast.all_function_names}
 
 	some i
 	arg_vars := _args_vars(input.rules[i].head.args)

--- a/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
+++ b/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego
@@ -21,17 +21,11 @@ report contains violation if {
 	value.type == "ref"
 
 	vars_in_ref := ast.find_ref_vars(value)
-
 	count(vars_in_ref) > 0
 
-	num_output_vars := count([var |
-		some var in vars_in_ref
-
-		# we don't need the location of each var, but using the first
-		# ref will do, and will hopefully help with caching the result
-		ast.is_output_var(rule, var)
-	])
-
+	# we don't need the location of each var, but using the first
+	# ref will do, and will hopefully help with caching the result
+	num_output_vars := count([ast.is_output_var(rule, var) | some var in vars_in_ref])
 	num_output_vars != 0
 	num_output_vars < cfg["ignore-nesting-level"]
 

--- a/bundle/regal/rules/style/rule-length/rule_length_test.rego
+++ b/bundle/regal/rules/style/rule-length/rule_length_test.rego
@@ -73,7 +73,7 @@ test_success_rule_longer_than_configured_max_length_but_comments if {
 	`)
 
 	r := rule.report with input as module with config.rules as {"style": {"rule-length": {
-		"max-rule-length": 2,
+		"max-rule-length": 3,
 		"count-comments": false,
 	}}}
 	r == set()

--- a/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
+++ b/bundle/regal/rules/style/rule-name-repeats-package/rule_name_repeats_package.rego
@@ -19,23 +19,12 @@ report contains violation if {
 	violation := result.fail(rego.metadata.chain(), result.location(rule.head.ref[0]))
 }
 
-_titleize(str) := upper(str) if count(str) == 1
-
-_titleize(str) := concat("", array.concat([upper(chrs[0])], array.slice(chrs, 1, count(chrs)))) if {
-	chrs := regex.split(``, str)
-	count(chrs) > 1
-}
-
-_num_package_path_components := count(ast.package_path)
-
 _possible_path_component_combinations contains combination if {
-	some end in numbers.range(1, _num_package_path_components)
+	num_package_path_components := count(ast.package_path)
 
-	combination := array.slice(
-		ast.package_path,
-		_num_package_path_components - end,
-		_num_package_path_components,
-	)
+	some end in numbers.range(1, num_package_path_components)
+
+	combination := array.slice(ast.package_path, num_package_path_components - end, num_package_path_components)
 }
 
 _possible_offending_prefixes contains concat("_", combination) if {
@@ -49,6 +38,7 @@ _possible_offending_prefixes contains concat("", formatted_combination) if {
 
 	formatted_combination := array.concat([combination[0]], [w |
 		some word in util.rest(combination)
-		w := _titleize(word)
+
+		w := regex.replace(word, `^[a-z]`, upper(substring(word, 0, 1)))
 	])
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -728,7 +728,7 @@ import data.unresolved`,
 	}
 }
 
-// 1026018375 ns/op	3086348312 B/op	59359755 allocs/op
+// 1014243250 ns/op	3038609032 B/op	58135767 allocs/op
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	conf, err := config.FromPath(filepath.Join("..", "..", ".regal", "config.yaml"))
@@ -758,7 +758,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 	}
 }
 
-// 986385125 ns/op	3034152352 B/op	58220573 allocs/op
+// 949510938 ns/op	2982001764 B/op	57011741 allocs/op
 // ...
 func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 	conf, err := config.FromPath(filepath.Join("..", "..", ".regal", "config.yaml"))


### PR DESCRIPTION
- My new favorite trick! Using `regex.replace` to extract values out from a text instead of `split`-ing a string on a delimiter. This is surprisingly *much* cheaper
- Use fixed max length of 100 in array.slice instead of `count`, where appropriate (like when slicing terms)
- Simplify and/or inline some custom functions

About 1.2 million allocations saved (see benchmark in PR for details)

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->