### PR TITLE
perf: Rego optimizations to avoid alloactions

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -62,7 +62,7 @@ builtin_names := object.keys(config.capabilities.builtins)
 # description: |
 #   set containing the namespaces of all built-in functions (given the active capabilities),
 #   like "http" in `http.send` or "sum" in `sum``
-builtin_namespaces contains split(name, ".")[0] if some name in builtin_names
+builtin_namespaces contains regex.replace(name, `\..*`, "") if some name in builtin_names
 
 # METADATA
 # description: |
@@ -341,6 +341,14 @@ all_functions := object.union(config.capabilities.builtins, function_decls)
 #   set containing all available built-in and custom function names in the
 #   scope of the input AST
 all_function_names := object.keys(all_functions)
+
+# METADATA
+# description: set containing the namespaces of all functions, built-in and custom
+all_function_namespaces := builtin_namespaces | custom_function_namespaces
+
+# METADATA
+# description: set containing the namespaces of all custom functions
+custom_function_namespaces contains regex.replace(name, `\..*`, "") if some name in object.keys(function_decls)
 
 # METADATA
 # description: |

--- a/bundle/regal/ast/comments.rego
+++ b/bundle/regal/ast/comments.rego
@@ -48,16 +48,13 @@ annotations := array.concat(
 #   found in input AST, indexed by the row they're at
 ignore_directives[row] := rules if {
 	some comment in comments_decoded
-	text := trim_space(comment.text)
 
-	i := indexof(text, "regal ignore:")
-	i != -1
+	contains(comment.text, "regal ignore:")
 
-	list := regex.replace(substring(text, i + 13, -1), `\s`, "")
 	loc := util.to_location_object(comment.location)
-
 	row := loc.row + 1
-	rules := split(list, ",")
+
+	rules := regex.split(`,\s*`, trim_space(regex.replace(comment.text, `^.*regal ignore:\s*(\S+)`, "$1")))
 }
 
 # METADATA

--- a/bundle/regal/ast/search.rego
+++ b/bundle/regal/ast/search.rego
@@ -103,11 +103,9 @@ _find_vars(value, last) := {"term": find_term_vars(function_ret_args(fn_name, va
 	value[0].value[0].type == "var"
 	value[0].value[0].value != "assign"
 
-	fn_name := ref_to_string(value[0].value)
+	fn_name := ref_static_to_string(value[0].value)
 
-	not contains(fn_name, "$")
-	fn_name in all_function_names
-	function_ret_in_args(fn_name, value)
+	function_ret_in_args(all_function_names[fn_name], value)
 }
 
 # `=` isn't necessarily assignment, and only considering the variable on the

--- a/bundle/regal/main/main.rego
+++ b/bundle/regal/main/main.rego
@@ -14,7 +14,7 @@ import data.regal.util
 
 # METADATA
 # description: set of all notices returned from linter rules
-lint.notices := _notices if "lint" in input.regal.operations
+lint.notices contains _grouped_notices[_][_][_] if "lint" in input.regal.operations
 
 # METADATA
 # description: map of all ignore directives encountered when linting
@@ -45,8 +45,6 @@ _rules_to_run[category] contains title if {
 	not config.ignored_rule(category, title)
 	not config.excluded_file(category, title, relative_filename)
 }
-
-_notices contains _grouped_notices[_][_][_]
 
 _grouped_notices[category][title] contains notice if {
 	some category, title
@@ -163,12 +161,12 @@ aggregate_report contains violation if {
 	# regal ignore:with-outside-test-context
 	some violation in data.regal.rules[category][title].aggregate_report with input as input_for_rule
 
-	# some aggregate violations won't have a location at all, like no-defined-entrypoint
-	file := object.get(violation, ["location", "file"], "")
-
-	ignore_directives := object.get(input.ignore_directives, file, {})
-
-	not _ignored(violation, util.keys_to_numbers(ignore_directives))
+	not _ignored(violation, util.keys_to_numbers(object.get(
+		input.ignore_directives,
+		# some aggregate violations won't have a location at all, like no-defined-entrypoint
+		object.get(violation, ["location", "file"], ""),
+		{},
+	)))
 }
 
 # METADATA
@@ -192,10 +190,8 @@ aggregate_report contains violation if {
 	# regal ignore:with-outside-test-context
 	some violation in data.custom.regal.rules[category][title].aggregate_report with input as input_for_rule
 
-	# for custom rules, we can't assume that the author included
-	# a location in the violation, although they _really_ should
-	file := object.get(violation, ["location", "file"], "")
-	ignore_directives := object.get(input, ["ignore_directives", file], {})
+	# don't assume that the author included a location in the violation, although they really should
+	ignore_directives := object.get(input, ["ignore_directives", object.get(violation, ["location", "file"], "")], {})
 
 	not _ignored(violation, util.keys_to_numbers(ignore_directives))
 }

--- a/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute.rego
+++ b/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute.rego
@@ -8,14 +8,13 @@ import data.regal.result
 report contains violation if {
 	some block in ast.comments.blocks
 
-	startswith(trim_space(block[0].text), "METADATA")
+	regex.match(`^\s*METADATA`, block[0].text)
 
-	text := concat("\n", [entry.text |
+	some attribute in object.keys(yaml.unmarshal(concat("\n", [entry.text |
 		some i, entry in block
 		i > 0
-	])
+	])))
 
-	some attribute in object.keys(yaml.unmarshal(text))
 	not attribute in ast.comments.metadata_attributes
 
 	violation := result.fail(rego.metadata.chain(), result.location([line |

--- a/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator.rego
+++ b/bundle/regal/rules/idiomatic/use-in-operator/use_in_operator.rego
@@ -6,7 +6,11 @@ import data.regal.ast
 import data.regal.result
 
 report contains violation if {
-	some terms in _eq_exprs_terms
+	terms := input.rules[_].body[_].terms
+
+	terms[0].type == "ref"
+	terms[0].value[0].type == "var"
+	terms[0].value[0].value in {"eq", "equal"}
 
 	nl_terms := _non_loop_term(terms)
 	count(nl_terms) == 1
@@ -17,14 +21,6 @@ report contains violation if {
 	# Use the non-loop term position to determine the
 	# location of the loop term (3 is the count of terms)
 	violation := result.fail(rego.metadata.chain(), result.location(terms[3 - nlt.pos]))
-}
-
-_eq_exprs_terms contains terms if {
-	terms := input.rules[_].body[_].terms
-
-	terms[0].type == "ref"
-	terms[0].value[0].type == "var"
-	terms[0].value[0].value in {"eq", "equal"}
 }
 
 _non_loop_term(terms) := [{"pos": i + 1, "term": term} |

--- a/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
+++ b/bundle/regal/rules/imports/unresolved-reference/unresolved_reference.rego
@@ -14,10 +14,10 @@ aggregate contains entry if {
 	entry := result.aggregate(rego.metadata.chain(), {
 		"exported_rules": exported,
 		"expanded_refs": _all_full_path_refs,
-		"prefix_tree": {prefix_path |
+		"prefix_tree": {["data"]} | {prefix_path |
 			some rule_name in exported
 			rule_path := split(rule_name, ".")
-			some i in numbers.range(1, count(rule_path))
+			some i in numbers.range(2, count(rule_path))
 			prefix_path := array.slice(rule_path, 0, i)
 		},
 	})

--- a/bundle/regal/rules/style/detached-metadata/detached_metadata.rego
+++ b/bundle/regal/rules/style/detached-metadata/detached_metadata.rego
@@ -9,7 +9,7 @@ import data.regal.util
 report contains violation if {
 	some i, block in ast.comments.blocks
 
-	startswith(trim_space(block[0].text), "METADATA")
+	regex.match(`^\s*METADATA`, block[0].text)
 
 	last_row := util.to_location_object(regal.last(block).location).row
 
@@ -30,11 +30,11 @@ _annotation_at_row(row) := annotation if {
 # detached metadata is allowed only if another metadata block follows
 # directly after the metadata block
 _allow_detached(last_row, i, blocks, lines) if {
-	next_block := blocks[i + 1]
+	next_block_start := blocks[i + 1][0]
 
-	startswith(trim_space(next_block[0].text), "METADATA")
+	regex.match(`^\s*METADATA`, next_block_start.text)
 
-	next_block_row := util.to_location_object(next_block[0].location).row
+	next_block_row := util.to_location_object(next_block_start.location).row
 	lines_between := array.slice(lines, last_row, next_block_row - 1)
 
 	every line in lines_between {

--- a/bundle/regal/rules/style/external-reference/external_reference.rego
+++ b/bundle/regal/rules/style/external-reference/external_reference.rego
@@ -8,14 +8,12 @@ import data.regal.result
 import data.regal.util
 
 report contains violation if {
-	fn_namespaces := {regex.replace(name, `\..*`, "") | some name in ast.all_function_names}
-
 	some i
 	arg_vars := _args_vars(input.rules[i].head.args)
 	own_vars := {value | value := ast.found.vars[ast.rule_index_strings[i]][_][_].value}
 
 	# note: parens added by opa fmt 🤦
-	allowed_refs := (arg_vars | own_vars) | fn_namespaces
+	allowed_refs := (arg_vars | own_vars) | ast.all_function_namespaces
 
 	external := [value |
 		some node in ["head", "body", "else"]

--- a/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment.rego
+++ b/bundle/regal/rules/style/no-whitespace-comment/no_whitespace_comment.rego
@@ -9,10 +9,10 @@ import data.regal.result
 report contains violation if {
 	some comment in ast.comments_decoded
 
-	not _whitespace_comment(comment.text)
+	not regex.match(`^[\s#]*$|^#*[\s]+.*$`, comment.text)
+	not _excepted(comment.text)
 
 	violation := result.fail(rego.metadata.chain(), result.location(comment))
 }
 
-_whitespace_comment(text) if regex.match(`^(#*)(\s+.*|$)`, text)
-_whitespace_comment(text) if regex.match(config.rules.style["no-whitespace-comment"]["except-pattern"], text)
+_excepted(text) if regex.match(config.rules.style["no-whitespace-comment"]["except-pattern"], text)

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -728,7 +728,7 @@ import data.unresolved`,
 	}
 }
 
-// 1035519750 ns/op	3059417808 B/op	58536544 allocs/op
+// 968805333 ns/op	2970674744 B/op	56876788 allocs/op
 // ...
 func BenchmarkRegalLintingItself(b *testing.B) {
 	conf, err := config.FromPath(filepath.Join("..", "..", ".regal", "config.yaml"))


### PR DESCRIPTION
A bit of everything really, but mostly try to avoid/defer code that allocates wherever possible, and try to replace some built-in calls that allocate with equivalent calls that don't.

**main vs. change**
```
1038017000 ns/op    3059460456 B/op    58499170 allocs/op
 968805333 ns/op    2970674744 B/op    56876788 allocs/op
```

Down by about ~2.4 million allocs and ~2% allocated space.

For the first time since I started benchmarking, ns/op is now below a second, and with some margin even! That means each benchmark now runs `regal lint bundle` 2 times instead of just one, as the first run is now under the one second threshold. Neat!

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->