### PR TITLE
docs: Update links to opa docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/github/StyraInc/regal/graph/badge.svg?token=EQK01YF3X3)](https://codecov.io/github/StyraInc/regal)
 [![Downloads](https://img.shields.io/github/downloads/styrainc/regal/total.svg)](https://github.com/StyraInc/regal/releases)
 
-Regal is a linter and language server for [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/), making
+Regal is a linter and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/), making
 your Rego magnificent, and you the ruler of rules!
 
 With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
@@ -601,7 +601,7 @@ Note: the `rego-version` attribute in the configuration file has precedence over
 
 While many projects consider the project's root directory (in editors often referred to as **workspace**) their
 "main" directory for policies, some projects may contain code from other languages, policy "subprojects", or multiple
-[bundles](https://www.openpolicyagent.org/docs/latest/management-bundles/). While most of Regal's features works
+[bundles](https://www.openpolicyagent.org/docs/management-bundles/). While most of Regal's features works
 independently of this — linting, for example, doesn't consider where in a workspace policies are located as long as
 those locations aren't [ignored](#ignoring-files-globally) — some features, like automatically
 [fixing](https://docs.styra.com/regal/fixing) violations, benefit from knowing when a project contains multiple roots.
@@ -637,7 +637,7 @@ in which the command was run.
 ## Capabilities
 
 By default, Regal will lint your policies using the
-[capabilities](https://www.openpolicyagent.org/docs/latest/deployments/#capabilities) of the latest version of OPA
+[capabilities](https://www.openpolicyagent.org/docs/deployments/#capabilities) of the latest version of OPA
 known to Regal (i.e. the latest version of OPA at the time Regal was released). Sometimes you might want to tell Regal
 that some rules aren't applicable to your project (yet!). As an example, if you're running OPA v0.46.0, you likely won't
 be helped by the [custom-has-key](https://docs.styra.com/regal/rules/idiomatic/custom-has-key-construct) rule, as it
@@ -751,7 +751,7 @@ are:
 
 OPA itself provides a "linter" of sorts, via the `opa check` command and its `--strict` flag. This checks the provided
 Rego files not only for syntax errors, but also for OPA
-[strict mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode) violations. Most of the strict
+[strict mode](https://www.openpolicyagent.org/docs/policy-language/#strict-mode) violations. Most of the strict
 mode checks from before OPA 1.0 have now been made default checks in OPA, and only two additional checks are currently
 provided by the `--strict` flag. Those are both important checks not covered by Regal though, so our recommendation is
 to run `opa check --strict` against your policies before linting with Regal.

--- a/bundle/regal/lsp/completion/providers/input/input.rego
+++ b/bundle/regal/lsp/completion/providers/input/input.rego
@@ -39,7 +39,7 @@ _doc := `# input
 It is a special keyword that allows you to access the data sent to OPA at evaluation time.
 
 To see more examples of how to use 'input', check out the
-[policy language documentation](https://www.openpolicyagent.org/docs/latest/policy-language/).
+[policy language documentation](https://www.openpolicyagent.org/docs/policy-language/).
 
 You can also experiment with input in the [Rego Playground](https://play.openpolicyagent.org/).
 `

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,10 +18,10 @@ When running Regal against a directory, like `regal lint my-policies/`, Regal do
   [forbids shadowing](https://docs.styra.com/regal/rules/bugs/rule-shadows-builtin) (i.e. using the same name as)
   built-in functions and operators.
 - Since rule bodies aren’t necessarily flat, but may contain nested bodies of constructs such as
-  [comprehensions](https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions) or
-  [every](https://www.openpolicyagent.org/docs/latest/policy-language/#every-keyword) blocks, many linter rules need to
+  [comprehensions](https://www.openpolicyagent.org/docs/policy-language/#comprehensions) or
+  [every](https://www.openpolicyagent.org/docs/policy-language/#every-keyword) blocks, many linter rules need to
   traverse all expressions in order to find what they are looking for. This is normally done with the help of the
-  built-in [walk](https://www.openpolicyagent.org/docs/latest/policy-reference/#graph) function.
+  built-in [walk](https://www.openpolicyagent.org/docs/policy-reference/#graph) function.
 - Traversing huge AST structures — and some policies contain millions of AST nodes! — takes time. This isn’t noticeable
   when linting a single file, but for some of the largest policy repositories out there, with several thousands of
   policy files and tests, the cost may be prohibitive. To alleviate this, Regal is implemented to process files

--- a/docs/custom-rules.md
+++ b/docs/custom-rules.md
@@ -120,7 +120,7 @@ convention on any policy in a repository. Packages may be named anything, but mu
 organization (Acme Corp). So `package acme.corp.policy` should be allowed, but not `package policy` or
 `package policy.acme.corp`. One exception: policy authors should be allowed to write policy for the `system.log` package
 provided by OPA to allow
-[masking](https://www.openpolicyagent.org/docs/latest/management-decision-logs/#masking-sensitive-data) sensitive data
+[masking](https://www.openpolicyagent.org/docs/management-decision-logs/#masking-sensitive-data) sensitive data
 from decision logs.
 
 An example policy to implement this requirement might look something like this:
@@ -160,7 +160,7 @@ Starting from top to bottom, these are the components comprising our custom rule
 1. The package of custom rules **must** start with `custom.regal.rules`, followed by the category of the rule, and the
    title (which is commonly quoted as rule names use `-` for spaces).
 1. The `data.regal.result` provides some helpers for formatting the result of a violation for inclusion in a report.
-1. Regal rules make heavy use of [metadata annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations)
+1. Regal rules make heavy use of [metadata annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations)
    in order to document the purpose of the rule, along with any other
    information that could potentially be useful. All rule packages **must** have
    a `description`. Providing links to additional documentation under

--- a/docs/opa-one-dot-zero.md
+++ b/docs/opa-one-dot-zero.md
@@ -64,8 +64,8 @@ effort.
 
 ## Related Resources
 
-- OPA Docs: [Upgrading to v1.0](https://www.openpolicyagent.org/docs/latest/v0-upgrade/)
-- OPA Docs: [v0 Backwards Compatibility](https://www.openpolicyagent.org/docs/latest/v0-compatibility/)
+- OPA Docs: [Upgrading to v1.0](https://www.openpolicyagent.org/docs/v0-upgrade/)
+- OPA Docs: [v0 Backwards Compatibility](https://www.openpolicyagent.org/docs/v0-compatibility/)
 - Styra Blog: [Renovating Rego](https://www.styra.com/blog/renovating-rego/)
 - OPA Blog: [OPA 1.0 Is Coming, Here's What You Need to Know](https://blog.openpolicyagent.org/opa-1-0-is-coming-heres-what-you-need-to-know-c8fb0d258368)
 - OPA Blog: [Announcing OPA 1.0: A New Standard for Policy as Code](https://blog.openpolicyagent.org/announcing-opa-1-0-a-new-standard-for-policy-as-code-a6d8427ee828)

--- a/docs/rules/bugs/annotation-without-metadata.md
+++ b/docs/rules/bugs/annotation-without-metadata.md
@@ -29,7 +29,7 @@ allow if {
 
 A comment that starts with `<annotation-attribute>:` but is not part of a metadata block is likely a mistake. Add
 `# METADATA` above the line to turn it into a
-[metadata](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations) block.
+[metadata](https://www.openpolicyagent.org/docs/policy-language/#annotations) block.
 
 ## Configuration Options
 
@@ -45,7 +45,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations)
+- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/annotation-without-metadata/annotation_without_metadata.rego)
 
 ## Community

--- a/docs/rules/bugs/deprecated-builtin.md
+++ b/docs/rules/bugs/deprecated-builtin.md
@@ -137,7 +137,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode)
+- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/policy-language/#strict-mode)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/deprecated-builtin/deprecated_builtin.rego)
 
 ## Community

--- a/docs/rules/bugs/invalid-metadata-attribute.md
+++ b/docs/rules/bugs/invalid-metadata-attribute.md
@@ -24,15 +24,15 @@ package router
 ## Rationale
 
 Metadata comments should follow the schema expected by
-[annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations). Custom attributes, like
+[annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations). Custom attributes, like
 `category` above, should be placed under the `custom` key, which is a map of arbitrary key-value pairs.
 
 While arbitrary attributes are accepted, they will not be treated as metadata annotations but regular comments, and as
 such won't be available to other tools that
-[process annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#accessing-annotations).
+[process annotations](https://www.openpolicyagent.org/docs/policy-language/#accessing-annotations).
 These tools include built-in functions like
-[rego.metadata.rule](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-rego-regometadatarule) and
-[rego.metadata.chain](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-rego-regometadatachain).
+[rego.metadata.rule](https://www.openpolicyagent.org/docs/policy-reference/#builtin-rego-regometadatarule) and
+[rego.metadata.chain](https://www.openpolicyagent.org/docs/policy-reference/#builtin-rego-regometadatachain).
 
 ## Configuration Options
 
@@ -48,8 +48,8 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations)
-- OPA Docs: [Accessing Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#accessing-annotations)
+- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations)
+- OPA Docs: [Accessing Annotations](https://www.openpolicyagent.org/docs/policy-language/#accessing-annotations)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/invalid-metadata-attribute/invalid_metadata_attribute.rego)
 
 ## Community

--- a/docs/rules/bugs/rule-shadows-builtin.md
+++ b/docs/rules/bugs/rule-shadows-builtin.md
@@ -34,7 +34,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
+- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/policy-reference/#built-in-functions)
 - OPA Repo: [builtin_metadata.json](https://github.com/open-policy-agent/opa/blob/main/builtin_metadata.json)
 - Regal Docs: [var-shadows-builtin](https://docs.styra.com/regal/rules/bugs/var-shadows-builtin)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/rule-shadows-builtin/rule_shadows_builtin.rego)

--- a/docs/rules/bugs/sprintf-arguments-mismatch.md
+++ b/docs/rules/bugs/sprintf-arguments-mismatch.md
@@ -60,7 +60,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Built-in Functions: `sprintf`](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-strings-sprintf)
+- OPA Docs: [Built-in Functions: `sprintf`](https://www.openpolicyagent.org/docs/policy-reference/#builtin-strings-sprintf)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/sprintf-arguments-mismatch/sprintf_arguments_mismatch.rego)
 
 ## Community

--- a/docs/rules/bugs/time-now-ns-twice.md
+++ b/docs/rules/bugs/time-now-ns-twice.md
@@ -26,7 +26,7 @@ To use the tools OPA provides for measuring performance.
 
 An important property of Rego is that it makes policy evaluation _predictable_. Using the same input to query OPA for a
 decision multiple times should result in the same decision being made each time! A few built-in functions, like
-`http.send`, or [time.now_ns](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-time-timenow_ns) are
+`http.send`, or [time.now_ns](https://www.openpolicyagent.org/docs/policy-reference/#builtin-time-timenow_ns) are
 however not **deterministic**. This means that repeated queries to policies where such functions are used may result in
 different decisions being made. For example, a policy that validates JSON Web Tokens would normally check if the current
 time is past the expiry value of the token, and deny any request where a token is found to be expired.
@@ -43,7 +43,7 @@ same way they'd normally do it using a traditional programming language (that is
 work, OPA provides several tools to help measure performance, and learning how to use them well is the best way to
 understand the performance characteristics of policy evaluation.
 
-See the [performance](https://www.openpolicyagent.org/docs/latest/policy-performance/) section of the OPA docs for an
+See the [performance](https://www.openpolicyagent.org/docs/policy-performance/) section of the OPA docs for an
 introduction to these tools, as well as advice on how to write performant policies.
 
 ## Configuration Options
@@ -60,8 +60,8 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [time.now_ns](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-time-timenow_ns)
-- OPA Docs: [Policy Performance](https://www.openpolicyagent.org/docs/latest/policy-performance/)
+- OPA Docs: [time.now_ns](https://www.openpolicyagent.org/docs/policy-reference/#builtin-time-timenow_ns)
+- OPA Docs: [Policy Performance](https://www.openpolicyagent.org/docs/policy-performance/)
 
 ## Community
 

--- a/docs/rules/bugs/unused-output-variable.md
+++ b/docs/rules/bugs/unused-output-variable.md
@@ -63,7 +63,7 @@ allow if {
 }
 ```
 
-And a [strict mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode) check for unused
+And a [strict mode](https://www.openpolicyagent.org/docs/policy-language/#strict-mode) check for unused
 variables defined in assignment (`:=`), or as a function arguments:
 
 ```rego
@@ -94,7 +94,7 @@ rules:
 ## Related Resources
 
 - Regal Docs: [prefer-some-in-iteration](https://docs.styra.com/regal/rules/style/prefer-some-in-iteration)
-- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode)
+- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/policy-language/#strict-mode)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/unused-output-variable/unused_output_variable.rego)
 
 ## Community

--- a/docs/rules/bugs/var-shadows-builtin.md
+++ b/docs/rules/bugs/var-shadows-builtin.md
@@ -46,7 +46,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
+- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/policy-reference/#built-in-functions)
 - OPA Repo: [builtin_metadata.json](https://github.com/open-policy-agent/opa/blob/main/builtin_metadata.json)
 - Regal Docs: [rule-shadows-builtin](https://docs.styra.com/regal/rules/bugs/rule-shadows-builtin)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/var-shadows-builtin/var_shadows_builtin.rego)

--- a/docs/rules/bugs/zero-arity-function.md
+++ b/docs/rules/bugs/zero-arity-function.md
@@ -23,7 +23,7 @@ first_user := input.users[0]
 Zero-arity functions, or functions without arguments, aren't treated as functions by Rego, but as regular rules. For
 that reason, they should also be expressed as such. One potential benefit of using functions over rules is that
 functions don't contribute to the
-[document](https://www.openpolicyagent.org/docs/latest/philosophy/#the-opa-document-model) when a package is evaluated,
+[document](https://www.openpolicyagent.org/docs/philosophy/#the-opa-document-model) when a package is evaluated,
 and as such sometimes used to "hide" information from the result of evaluation. Whether this is a good practice or not,
 it importantly *doesn't work* with zero-arity functions, as they are treated as rules and *do* contribute to the
 document.
@@ -49,7 +49,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [The OPA Document Model](https://www.openpolicyagent.org/docs/latest/philosophy/#the-opa-document-model)
+- OPA Docs: [The OPA Document Model](https://www.openpolicyagent.org/docs/philosophy/#the-opa-document-model)
 - OPA Issues: [Allow user-defined zero-argument functions in Rego](https://github.com/open-policy-agent/opa/issues/6315)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/bugs/zero-arity-function/zero_arity_function.rego)
 

--- a/docs/rules/custom/forbidden-function-call.md
+++ b/docs/rules/custom/forbidden-function-call.md
@@ -7,11 +7,11 @@
 ## Description
 
 This custom rule allows providing Regal a list of
-[built-in functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions) that should be
+[built-in functions](https://www.openpolicyagent.org/docs/policy-reference/#built-in-functions) that should be
 considered forbidden. Any call to a function in the list will be reported as a violation.
 
 Another, more advanced, option to achieve the same result is the
-[capabilities](https://www.openpolicyagent.org/docs/latest/deployments/#capabilities) feature in OPA. While a more
+[capabilities](https://www.openpolicyagent.org/docs/deployments/#capabilities) feature in OPA. While a more
 capable option, allowing things like:
 
 - Adding new custom built-in functions that OPA should be aware of
@@ -45,8 +45,8 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Capabilities](https://www.openpolicyagent.org/docs/latest/deployments/#capabilities)
-- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
+- OPA Docs: [Capabilities](https://www.openpolicyagent.org/docs/deployments/#capabilities)
+- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/policy-reference/#built-in-functions)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/custom/forbidden-function-call/forbidden_function_call.rego)
 
 ## Community

--- a/docs/rules/custom/missing-metadata.md
+++ b/docs/rules/custom/missing-metadata.md
@@ -71,8 +71,8 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Metadata](https://www.openpolicyagent.org/docs/latest/policy-language/#metadata)
-- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations)
+- OPA Docs: [Metadata](https://www.openpolicyagent.org/docs/policy-language/#metadata)
+- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations)
 - Rego Style Guide: [Use Metadata Annotations](https://docs.styra.com/opa/rego-style-guide#use-metadata-annotations)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/custom/missing-metadata/missing_metadata.rego)
 

--- a/docs/rules/idiomatic/ambiguous-scope.md
+++ b/docs/rules/idiomatic/ambiguous-scope.md
@@ -55,7 +55,7 @@ allow if public_resource
 ## Rationale
 
 The default scope for metadata annotating a rule is the `rule` scope, which
-"[applies to the individual rule statement](https://www.openpolicyagent.org/docs/latest/policy-language/#scope)" only.
+"[applies to the individual rule statement](https://www.openpolicyagent.org/docs/policy-language/#scope)" only.
 This default is sensible for a rule defined only once, but is somewhat ambiguous for a rule defined incrementally, like
 the `allow` rule in the examples above. Was the intention really to annotate that single definition, or the rule as
 whole? Most likely the latter, and that's what the `document` scope is for.
@@ -81,7 +81,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations)
+- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations)
 - Regal Docs: [no-defined-entrypoint](https://docs.styra.com/regal/rules/idiomatic/no-defined-entrypoint)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/ambiguous-scope/ambiguous_scope.rego)
 

--- a/docs/rules/idiomatic/custom-has-key-construct.md
+++ b/docs/rules/idiomatic/custom-has-key-construct.md
@@ -25,7 +25,7 @@ mfa if "mfa" in object.keys(input.claims)
 ## Rationale
 
 Checking if a key exists in an object (regardless of the attribute's value) used to be done using custom functions. With
-the introduction of the [object.keys](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-object-objectkeys)
+the introduction of the [object.keys](https://www.openpolicyagent.org/docs/policy-reference/#builtin-object-objectkeys)
 (OPA [v0.47.0](https://github.com/open-policy-agent/opa/releases/tag/v0.47.0)) function, this is no longer necessary,
 and using the built-in function together with `in` should be preferred.
 

--- a/docs/rules/idiomatic/directory-package-mismatch.md
+++ b/docs/rules/idiomatic/directory-package-mismatch.md
@@ -80,7 +80,7 @@ Whichever way you choose is up to you. Consistency is key!
 ### Bundles
 
 While directory structure doesn't matter to OPA when parsing _policies_, directories parsed as
-[bundles](https://www.openpolicyagent.org/docs/latest/management-bundles/) will read _data_ (`data.json` or
+[bundles](https://www.openpolicyagent.org/docs/management-bundles/) will read _data_ (`data.json` or
 `data.yaml`) files and insert the data in the `data` document tree based on the directory structure relative
 to the bundle root. Having policies structured in the same manner provides a uniform experience, and makes it
 easier to understand where both policies and data come from.
@@ -135,7 +135,7 @@ rules:
 
 - Rego Style Guide: [Package name should match file location](https://docs.styra.com/opa/rego-style-guide#package-name-should-match-file-location)
 - Regal Docs: [test-outside-test-package](https://docs.styra.com/regal/rules/testing/test-outside-test-package)
-- OPA Docs: [Bundles](https://www.openpolicyagent.org/docs/latest/management-bundles/)
+- OPA Docs: [Bundles](https://www.openpolicyagent.org/docs/management-bundles/)
 - Styra Docs: [Styra DAS](https://docs.styra.com/das)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/directory-package-mismatch/directory_package_mismatch.rego)
 

--- a/docs/rules/idiomatic/no-defined-entrypoint.md
+++ b/docs/rules/idiomatic/no-defined-entrypoint.md
@@ -58,7 +58,7 @@ rule that is meant to be queried for decisions from the outside. While it might 
 rules are meant to be queried, adding an extra line of two of metadata will help make it obvious to others.
 
 Marking a package or rule via an
-[entrypoint annotation attribute](https://www.openpolicyagent.org/docs/latest/policy-language/#entrypoint) not only
+[entrypoint annotation attribute](https://www.openpolicyagent.org/docs/policy-language/#entrypoint) not only
 provides good documentation for others, but also unlocks programmatic possibilities, like:
 
 1. Your policy library may be compiled to WebAssembly without extra entrypoint arguments
@@ -83,8 +83,8 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Metadata](https://www.openpolicyagent.org/docs/latest/policy-language/#metadata)
-- OPA Docs: [Entrypoint](https://www.openpolicyagent.org/docs/latest/policy-language/#entrypoint)
+- OPA Docs: [Metadata](https://www.openpolicyagent.org/docs/policy-language/#metadata)
+- OPA Docs: [Entrypoint](https://www.openpolicyagent.org/docs/policy-language/#entrypoint)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/no-defined-entrypoint/no_defined_entrypoint.rego)
 
 ## Community

--- a/docs/rules/idiomatic/non-raw-regex-pattern.md
+++ b/docs/rules/idiomatic/non-raw-regex-pattern.md
@@ -29,7 +29,7 @@ additionally makes them easier to identify as such.
 ## Limitations
 
 This rule currently only scans regex string literals in the place of the `pattern` argument of the various
-[regex built-in functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#regex). It will not **not**
+[regex built-in functions](https://www.openpolicyagent.org/docs/policy-reference/#regex). It will not **not**
 try to "resolve" patterns assigned to variables. The following example would as such not render a warning:
 
 ```rego
@@ -57,7 +57,7 @@ rules:
 ## Related Resources
 
 - Rego Style Guide: [Use raw strings for regex patterns](https://github.com/StyraInc/rego-style-guide#use-raw-strings-for-regex-patterns)
-- OPA Docs: [Regex Functions Reference](https://www.openpolicyagent.org/docs/latest/policy-reference/#regex)
+- OPA Docs: [Regex Functions Reference](https://www.openpolicyagent.org/docs/policy-reference/#regex)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/non-raw-regex-pattern/non_raw_regex_pattern.rego)
 
 ## Community

--- a/docs/rules/idiomatic/prefer-set-or-object-rule.md
+++ b/docs/rules/idiomatic/prefer-set-or-object-rule.md
@@ -140,9 +140,9 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Generating Sets](https://www.openpolicyagent.org/docs/latest/policy-language/#generating-sets)
-- OPA Docs: [Generating Objects](https://www.openpolicyagent.org/docs/latest/policy-language/#generating-objects)
-- OPA Docs: [Comprehensions](https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions)
+- OPA Docs: [Generating Sets](https://www.openpolicyagent.org/docs/policy-language/#generating-sets)
+- OPA Docs: [Generating Objects](https://www.openpolicyagent.org/docs/policy-language/#generating-objects)
+- OPA Docs: [Comprehensions](https://www.openpolicyagent.org/docs/policy-language/#comprehensions)
 - Styra Blog: [Five Things You Didn't Know About OPA](https://www.styra.com/blog/five-things-you-didnt-know-about-opa/)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/prefer-set-or-object-rule/prefer_set_or_object_rule.rego)
 

--- a/docs/rules/idiomatic/single-item-in.md
+++ b/docs/rules/idiomatic/single-item-in.md
@@ -38,7 +38,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Use indexed statements](https://www.openpolicyagent.org/docs/latest/policy-performance/#use-indexed-statements)
+- OPA Docs: [Use indexed statements](https://www.openpolicyagent.org/docs/policy-performance/#use-indexed-statements)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/single-item-in/single_item_in.rego)
 
 ## Community

--- a/docs/rules/idiomatic/use-contains.md
+++ b/docs/rules/idiomatic/use-contains.md
@@ -76,7 +76,7 @@ rules:
 ## Related Resources
 
 - Regal Docs: [use-if](https://docs.styra.com/regal/rules/idiomatic/use-if)
-- OPA Docs: [Future Keywords](https://www.openpolicyagent.org/docs/latest/policy-language/#future-keywords)
+- OPA Docs: [Future Keywords](https://www.openpolicyagent.org/docs/policy-language/#future-keywords)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/use-contains/use_contains.rego)
 
 ## Community

--- a/docs/rules/idiomatic/use-if.md
+++ b/docs/rules/idiomatic/use-if.md
@@ -72,7 +72,7 @@ rules:
 ## Related Resources
 
 - Regal Docs: [use-contains](https://docs.styra.com/regal/rules/idiomatic/use-contains)
-- OPA Docs: [Future Keywords](https://www.openpolicyagent.org/docs/latest/policy-language/#future-keywords)
+- OPA Docs: [Future Keywords](https://www.openpolicyagent.org/docs/policy-language/#future-keywords)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/use-if/use_if.rego)
 
 ## Community

--- a/docs/rules/idiomatic/use-object-keys.md
+++ b/docs/rules/idiomatic/use-object-keys.md
@@ -25,7 +25,7 @@ keys := object.keys(input.object)
 ## Rationale
 
 Instead of using a set comprehension to collect keys from an object, prefer to use the built-in function
-[object.keys](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-object-objectkeys).
+[object.keys](https://www.openpolicyagent.org/docs/policy-reference/#builtin-object-objectkeys).
 This option is both more declarative and better conveys the intent of the code.
 
 ## Configuration Options
@@ -42,7 +42,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [object.keys](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-object-objectkeys)
+- OPA Docs: [object.keys](https://www.openpolicyagent.org/docs/policy-reference/#builtin-object-objectkeys)
 
 ## Community
 

--- a/docs/rules/idiomatic/use-some-for-output-vars.md
+++ b/docs/rules/idiomatic/use-some-for-output-vars.md
@@ -106,7 +106,7 @@ rules:
 ## Related Resources
 
 - Rego Style Guide: [Don't use undeclared variables](https://github.com/StyraInc/rego-style-guide#dont-use-undeclared-variables)
-- OPA Docs: [The `some` keyword](https://www.openpolicyagent.org/docs/latest/policy-language/#some-keyword)
+- OPA Docs: [The `some` keyword](https://www.openpolicyagent.org/docs/policy-language/#some-keyword)
 - Wikipedia: [Unification](https://en.wikipedia.org/wiki/Unification_(computer_science))
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/use-some-for-output-vars/use_some_for_output_vars.rego)
 

--- a/docs/rules/idiomatic/use-strings-count.md
+++ b/docs/rules/idiomatic/use-strings-count.md
@@ -37,7 +37,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [strings.count](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-strings-stringscount)
+- OPA Docs: [strings.count](https://www.openpolicyagent.org/docs/policy-reference/#builtin-strings-stringscount)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/idiomatic/use-strings-count/use_strings_count.rego)
 
 ## Community

--- a/docs/rules/imports/avoid-importing-input.md
+++ b/docs/rules/imports/avoid-importing-input.md
@@ -73,7 +73,7 @@ rules:
 ## Related Resources
 
 - Rego Style Guide: [Avoid importing `input`](https://github.com/StyraInc/rego-style-guide#avoid-importing-input)
-- OPA Docs: [Terraform Tutorial](https://www.openpolicyagent.org/docs/latest/terraform)
+- OPA Docs: [Terraform Tutorial](https://www.openpolicyagent.org/docs/terraform)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/imports/avoid-importing-input/avoid_importing_input.rego)
 
 ## Community

--- a/docs/rules/imports/import-shadows-builtin.md
+++ b/docs/rules/imports/import-shadows-builtin.md
@@ -70,7 +70,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/latest/policy-reference/#built-in-functions)
+- OPA Docs: [Built-in Functions](https://www.openpolicyagent.org/docs/policy-reference/#built-in-functions)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/imports/import-shadows-builtin/import_shadows_builtin.rego)
 
 ## Community

--- a/docs/rules/imports/import-shadows-import.md
+++ b/docs/rules/imports/import-shadows-import.md
@@ -52,7 +52,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/latest/policy-language/#strict-mode)
+- OPA Docs: [Strict Mode](https://www.openpolicyagent.org/docs/policy-language/#strict-mode)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/imports/import-shadows-import/import_shadows_import.rego)
 
 ## Community

--- a/docs/rules/imports/unresolved-import.md
+++ b/docs/rules/imports/unresolved-import.md
@@ -55,8 +55,8 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Imports](https://www.openpolicyagent.org/docs/latest/policy-language/#imports)
-- OPA Docs: [Collaboration Using Import](https://www.openpolicyagent.org/docs/latest/faq/#collaboration-using-import)
+- OPA Docs: [Imports](https://www.openpolicyagent.org/docs/policy-language/#imports)
+- OPA Docs: [Collaboration Using Import](https://www.openpolicyagent.org/docs/faq/#collaboration-using-import)
 - OPA Issues: [Missing import should create error](https://github.com/open-policy-agent/opa/issues/491)
   - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/imports/unresolved-import/unresolved_import.rego)
 

--- a/docs/rules/imports/unresolved-reference.md
+++ b/docs/rules/imports/unresolved-reference.md
@@ -40,8 +40,8 @@ rules:
 ## Related Resources
 
 - Unresolved Import Rule: [unresolved-import](./unresolved-import)
-- OPA Docs: [Imports](https://www.openpolicyagent.org/docs/latest/policy-language/#imports)
-- OPA Docs: [Collaboration Using Import](https://www.openpolicyagent.org/docs/latest/faq/#collaboration-using-import)
+- OPA Docs: [Imports](https://www.openpolicyagent.org/docs/policy-language/#imports)
+- OPA Docs: [Collaboration Using Import](https://www.openpolicyagent.org/docs/faq/#collaboration-using-import)
 - OPA Issues: [Missing import should create error](https://github.com/open-policy-agent/opa/issues/491)
 
 ## Community

--- a/docs/rules/performance/with-outside-test-context.md
+++ b/docs/rules/performance/with-outside-test-context.md
@@ -84,7 +84,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [With Keyword](https://www.openpolicyagent.org/docs/latest/policy-language/#with-keyword)
+- OPA Docs: [With Keyword](https://www.openpolicyagent.org/docs/policy-language/#with-keyword)
 - Styra Blog: [Dynamic Policy Composition for OPA](https://www.styra.com/blog/dynamic-policy-composition-for-opa/)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/performance/with-outside-test-context/with_outside_test_context.rego)
 

--- a/docs/rules/style/chained-rule-body.md
+++ b/docs/rules/style/chained-rule-body.md
@@ -54,7 +54,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Incremental Definitions](https://www.openpolicyagent.org/docs/latest/policy-language/#incremental-definitions)
+- OPA Docs: [Incremental Definitions](https://www.openpolicyagent.org/docs/policy-language/#incremental-definitions)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/chained-rule-body/chained_rule_body.rego)
 
 ## Community

--- a/docs/rules/style/comprehension-term-assignment.md
+++ b/docs/rules/style/comprehension-term-assignment.md
@@ -72,7 +72,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Comprehensions](https://www.openpolicyagent.org/docs/latest/policy-language/#comprehensions)
+- OPA Docs: [Comprehensions](https://www.openpolicyagent.org/docs/policy-language/#comprehensions)
 - Regal Docs: [pointless-reassignment](https://docs.styra.com/regal/rules/style/pointless-reassignment)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/comprehension-term-assignment/comprehension_term_assignment.rego)
 

--- a/docs/rules/style/default-over-else.md
+++ b/docs/rules/style/default-over-else.md
@@ -30,7 +30,7 @@ The `else` keyword has a single purpose in Rego — to allow a policy author to 
 several `else`-clauses are chained or not, it's common to use a last "fallback" `else` to cover all cases not covered by
 the conditions in the preceding `else`-bodies. A kind of "catch all", or "default" condition. This is useful, but Rego
 arguably provides a more idiomatic construct for default assignment: the
-[default keyword](https://www.openpolicyagent.org/docs/latest/policy-language/#default-keyword).
+[default keyword](https://www.openpolicyagent.org/docs/policy-language/#default-keyword).
 
 While the end result is the same, default assignment has the benefit of more clearly — and **before** the conditional
 assignments — communicating what the *safe* option is. This is particularly important for
@@ -93,7 +93,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Default Keyword](https://www.openpolicyagent.org/docs/latest/policy-language/#default-keyword)
+- OPA Docs: [Default Keyword](https://www.openpolicyagent.org/docs/policy-language/#default-keyword)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/default-over-else/default_over_else.rego)
 
 ## Community

--- a/docs/rules/style/default-over-not.md
+++ b/docs/rules/style/default-over-not.md
@@ -43,7 +43,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Default Keyword](https://www.openpolicyagent.org/docs/latest/policy-language/#default-keyword)
+- OPA Docs: [Default Keyword](https://www.openpolicyagent.org/docs/policy-language/#default-keyword)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/default-over-not/default_over_not.rego)
 
 ## Community

--- a/docs/rules/style/detached-metadata.md
+++ b/docs/rules/style/detached-metadata.md
@@ -47,8 +47,8 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations)
-- OPA Docs: [Accessing Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#accessing-annotations)
+- OPA Docs: [Annotations](https://www.openpolicyagent.org/docs/policy-language/#annotations)
+- OPA Docs: [Accessing Annotations](https://www.openpolicyagent.org/docs/policy-language/#accessing-annotations)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/detached-metadata/detached_metadata.rego)
 
 ## Community

--- a/docs/rules/style/mixed-iteration.md
+++ b/docs/rules/style/mixed-iteration.md
@@ -68,7 +68,7 @@ rules:
 ## Related Resources
 
 - Regal Docs: [prefer-some-in-iteration](https://docs.styra.com/regal/rules/style/prefer-some-in-iteration)
-- OPA Docs: [Membership and iteration](https://www.openpolicyagent.org/docs/latest/policy-language/#membership-and-iteration-in)
+- OPA Docs: [Membership and iteration](https://www.openpolicyagent.org/docs/policy-language/#membership-and-iteration-in)
 
 ## Community
 

--- a/docs/rules/style/opa-fmt.md
+++ b/docs/rules/style/opa-fmt.md
@@ -35,7 +35,7 @@ indent_size = 4
 OPA 1.0 makes Rego v1 the default. This change mandated some changes to the
 functionality of the `opa fmt` command and a number of new options for working
 with mixed version code bases. See the
-[OPA documentation](https://www.openpolicyagent.org/docs/latest/cli/#opa-fmt)
+[OPA documentation](https://www.openpolicyagent.org/docs/cli/#opa-fmt)
 for the command's options.
 
 In Regal, a v0 file will have the `opa-fmt` violation unless it's been formatted
@@ -61,7 +61,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [CLI Reference `opa fmt`](https://www.openpolicyagent.org/docs/latest/cli/#opa-fmt)
+- OPA Docs: [CLI Reference `opa fmt`](https://www.openpolicyagent.org/docs/cli/#opa-fmt)
 
 ## Community
 

--- a/docs/rules/style/prefer-some-in-iteration.md
+++ b/docs/rules/style/prefer-some-in-iteration.md
@@ -132,8 +132,8 @@ rules:
 
 - Rego Style Guide: [Prefer some .. in for iteration](https://github.com/StyraInc/rego-style-guide#prefer-some--in-for-iteration)
 - Regal Docs: [Use `some` to declare output variables](https://docs.styra.com/regal/rules/idiomatic/use-some-for-output-vars)
-- OPA Docs: [Membership and Iteration: `in`](https://www.openpolicyagent.org/docs/latest/policy-language/#membership-and-iteration-in)
-- OPA Docs: [Some Keyword](https://www.openpolicyagent.org/docs/latest/policy-language/#some-keyword)
+- OPA Docs: [Membership and Iteration: `in`](https://www.openpolicyagent.org/docs/policy-language/#membership-and-iteration-in)
+- OPA Docs: [Some Keyword](https://www.openpolicyagent.org/docs/policy-language/#some-keyword)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/prefer-some-in-iteration/prefer_some_in_iteration.rego)
 
 ## Community

--- a/docs/rules/style/unnecessary-some.md
+++ b/docs/rules/style/unnecessary-some.md
@@ -52,7 +52,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Membership and iteration: `in`](https://www.openpolicyagent.org/docs/latest/policy-language/#membership-and-iteration-in)
+- OPA Docs: [Membership and iteration: `in`](https://www.openpolicyagent.org/docs/policy-language/#membership-and-iteration-in)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/unnecessary-some/unnecessary_some.rego)
 
 ## Community

--- a/docs/rules/style/use-assignment-operator.md
+++ b/docs/rules/style/use-assignment-operator.md
@@ -80,7 +80,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Equality: Assignment, Comparison, and Unification](https://www.openpolicyagent.org/docs/latest/policy-language/#equality-assignment-comparison-and-unification)
+- OPA Docs: [Equality: Assignment, Comparison, and Unification](https://www.openpolicyagent.org/docs/policy-language/#equality-assignment-comparison-and-unification)
 - Rego Style Guide: [Don't use unification operator for assignment or comparison](https://github.com/StyraInc/rego-style-guide#dont-use-unification-operator-for-assignment-or-comparison)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/style/use-assignment-operator/use_assignment_operator.rego)
 

--- a/docs/rules/testing/dubious-print-sprintf.md
+++ b/docs/rules/testing/dubious-print-sprintf.md
@@ -56,7 +56,7 @@ rules:
 ## Related Resources
 
 - Regal Docs: [Call to `print` or `trace` function](https://docs.styra.com/regal/rules/testing/print-or-trace-call)
-- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/latest/policy-testing/)
+- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/policy-testing/)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/testing/dubious-print-sprintf/dubious_print_sprintf.rego)
 
 ## Community

--- a/docs/rules/testing/file-missing-test-suffix.md
+++ b/docs/rules/testing/file-missing-test-suffix.md
@@ -24,7 +24,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/latest/policy-testing/)
+- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/policy-testing/)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/testing/file-missing-test-suffix/file_missing_test_suffix.rego)
 
 ## Community

--- a/docs/rules/testing/identically-named-tests.md
+++ b/docs/rules/testing/identically-named-tests.md
@@ -54,7 +54,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/latest/policy-testing/)
+- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/policy-testing/)
 - OPA GitHub: [Support running of individual test rules sharing same name](https://github.com/open-policy-agent/opa/issues/5766)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/testing/identically-named-tests/identically_named_tests.rego)
 

--- a/docs/rules/testing/print-or-trace-call.md
+++ b/docs/rules/testing/print-or-trace-call.md
@@ -40,8 +40,8 @@ rules:
 ## Related Resources
 
 - OPA Blog: [Introducing the OPA print function](https://blog.openpolicyagent.org/introducing-the-opa-print-function-809da6a13aee)
-- OPA Docs: [Policy Reference: Debugging](https://www.openpolicyagent.org/docs/latest/policy-reference/#debugging)
-- OPA Docs: [Decision Logs](https://www.openpolicyagent.org/docs/latest/management-decision-logs/)
+- OPA Docs: [Policy Reference: Debugging](https://www.openpolicyagent.org/docs/policy-reference/#debugging)
+- OPA Docs: [Decision Logs](https://www.openpolicyagent.org/docs/management-decision-logs/)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/testing/print-or-trace-call/print_or_trace_call.rego)
 
 ## Community

--- a/docs/rules/testing/test-outside-test-package.md
+++ b/docs/rules/testing/test-outside-test-package.md
@@ -50,7 +50,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/latest/policy-testing/)
+- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/policy-testing/)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/testing/test-outside-test-package/test_outside_test_package.rego)
 
 ## Community

--- a/docs/rules/testing/todo-test.md
+++ b/docs/rules/testing/todo-test.md
@@ -35,7 +35,7 @@ rules:
 
 ## Related Resources
 
-- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/latest/policy-testing/)
+- OPA Docs: [Policy Testing](https://www.openpolicyagent.org/docs/policy-testing/)
 - GitHub: [Source Code](https://github.com/StyraInc/regal/blob/main/bundle/regal/rules/testing/todo-test/todo_test.rego)
 
 ## Community

--- a/internal/lsp/completions/refs/defined.go
+++ b/internal/lsp/completions/refs/defined.go
@@ -105,7 +105,7 @@ func DefinedInModule(module *ast.Module, builtins map[string]*ast.Builtin) map[s
 func defaultDescription(name string) string {
 	return fmt.Sprintf(`# %s
 
-See [METADATA Documentation](https://www.openpolicyagent.org/docs/latest/policy-language/#metadata)
+See [METADATA Documentation](https://www.openpolicyagent.org/docs/policy-language/#metadata)
 to add more detail.`, name)
 }
 

--- a/internal/lsp/hover/hover.go
+++ b/internal/lsp/hover/hover.go
@@ -56,7 +56,7 @@ func CreateHoverContent(builtin *ast.Builtin) string {
 	}
 
 	link := fmt.Sprintf(
-		"https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-%s-%s",
+		"https://www.openpolicyagent.org/docs/policy-reference/#builtin-%s-%s",
 		rego.BuiltinCategory(builtin),
 		strings.ReplaceAll(builtin.Name, ".", ""),
 	)

--- a/internal/lsp/hover/testdata/hover/graphreachable.md
+++ b/internal/lsp/hover/testdata/hover/graphreachable.md
@@ -1,4 +1,4 @@
-### [graph.reachable](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-graph-graphreachable)
+### [graph.reachable](https://www.openpolicyagent.org/docs/policy-reference/#builtin-graph-graphreachable)
 
 ```rego
 output := graph.reachable(graph, initial)

--- a/internal/lsp/hover/testdata/hover/indexof.md
+++ b/internal/lsp/hover/testdata/hover/indexof.md
@@ -1,4 +1,4 @@
-### [indexof](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-strings-indexof)
+### [indexof](https://www.openpolicyagent.org/docs/policy-reference/#builtin-strings-indexof)
 
 ```rego
 output := indexof(haystack, needle)

--- a/internal/lsp/hover/testdata/hover/jsonfilter.md
+++ b/internal/lsp/hover/testdata/hover/jsonfilter.md
@@ -1,4 +1,4 @@
-### [json.filter](https://www.openpolicyagent.org/docs/latest/policy-reference/#builtin-object-jsonfilter)
+### [json.filter](https://www.openpolicyagent.org/docs/policy-reference/#builtin-object-jsonfilter)
 
 ```rego
 filtered := json.filter(object, paths)


### PR DESCRIPTION
We have moved the OPA docs to a new location and these are now the correct links that don't need redirects.
