### PR TITLE
Small fixes before next release

### DIFF
--- a/bundle/regal/ast/ast.rego
+++ b/bundle/regal/ast/ast.rego
@@ -406,11 +406,6 @@ assignment_terms(terms) := [terms[1], terms[2]] if is_assignment(terms[0])
 rule_head_locations[name] contains {"row": loc.row, "col": loc.col} if {
 	some rule in input.rules
 
-	name := concat(".", [
-		"data",
-		package_name,
-		ref_static_to_string(rule.head.ref),
-	])
-
+	name := concat(".", ["data", package_name, ref_static_to_string(rule.head.ref)])
 	loc := util.to_location_object(rule.head.location)
 }

--- a/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
+++ b/bundle/regal/rules/performance/non-loop-expression/non_loop_expression.rego
@@ -49,8 +49,9 @@ _exprs[rule_index][row] contains expr if {
 # x = foo.bar[_]
 _loop_start_points[rule_index][loc.row] contains var if {
 	some rule_index
-	var := ast.found.vars[rule_index].assign[_]
 	term := _exprs[rule_index][_][_][_]
+
+	is_array(term)
 
 	last_term := regal.last(term)
 	last_term.type == "ref"
@@ -58,6 +59,8 @@ _loop_start_points[rule_index][loc.row] contains var if {
 	last := regal.last(last_term.value)
 	last.type == "var"
 	startswith(last.value, "$")
+
+	some var in ast.found.vars[rule_index].assign
 
 	loc := util.to_location_object(var.location)
 	loc.row == util.to_location_object(term[0].location).row

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -34,7 +34,7 @@ func (c *baseCache) Get(ref ast.Ref) ast.Value {
 		if node == nil {
 			return nil
 		} else if node.value != nil {
-			if len(ref) == 1 && ast.IsScalar(node.value) {
+			if len(ref[i:]) == 1 && ast.IsScalar(node.value) {
 				// If the node is a scalar, return the value directly
 				// and avoid an allocation when calling Find.
 				return node.value

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,32 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+// 2 allocs.
+func BenchmarkPut(b *testing.B) {
+	cache := NewBaseCache()
+	ref := ast.MustParseRef("data.foo.bar.baz")
+	value := ast.String("qux")
+
+	for range b.N {
+		cache.Put(ref, value)
+	}
+}
+
+// 0 allocs.
+func BenchmarkGet(b *testing.B) {
+	cache := NewBaseCache()
+	ref := ast.MustParseRef("data.foo.bar")
+	value := ast.NewObject(ast.Item(ast.StringTerm("baz"), ast.StringTerm("qux")))
+	cache.Put(ref, value)
+
+	r := ast.MustParseRef("data.foo.bar.baz")
+
+	for range b.N {
+		_ = cache.Get(r)
+	}
+}


### PR DESCRIPTION
The non-loop-expression reordering is the major change here, as it accounts for almost 700k allocations less! Which is of course ironic for that rule :P

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->