### PR TITLE
fix: improve snippets suggestion condition

### DIFF
--- a/bundle/regal/lsp/completion/providers/snippet/snippet.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet.rego
@@ -18,10 +18,13 @@ items contains item if {
 	position := location.to_position(input.regal.context.location)
 	line := input.regal.file.lines[position.line]
 
-	not endswith(trim_space(line), "=")
 	location.in_rule_body(line)
 
 	word := location.word_at(line, input.regal.context.location.col)
+	before := trim_suffix(line, word.text)
+
+	# match empty line, or line ending with `if` or `|` plus whitespace
+	regex.match(`^\s+$|if\s+$|\|\s+$`, before)
 
 	some label, snippet in _snippets
 

--- a/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
+++ b/bundle/regal/lsp/completion/providers/snippet/snippet_test.rego
@@ -82,6 +82,19 @@ test_snippet_completion_on_typing_no_repeat if {
 	items == set()
 }
 
+test_no_snippet_completion_on_[typed] if {
+	template := `allow if {
+	%s
+}`
+
+	some typed in ["i", "in", "inp", "inpu", "input", "input.", "input.x"]
+
+	policy := _with_header(sprintf(template, [typed]))
+
+	items := provider.items with input as util.input_with_location(policy, {"row": 6, "col": 1 + count(typed)})
+	items == set()
+}
+
 test_snippet_completion_on_invoked if {
 	items := provider.items with input as util.input_with_location(_with_header(`allow if `), {"row": 5, "col": 10})
 	items == {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -12,7 +12,7 @@ func BenchmarkPut(b *testing.B) {
 	ref := ast.MustParseRef("data.foo.bar.baz")
 	value := ast.String("qux")
 
-	for range b.N {
+	for b.Loop() {
 		cache.Put(ref, value)
 	}
 }
@@ -26,7 +26,7 @@ func BenchmarkGet(b *testing.B) {
 
 	r := ast.MustParseRef("data.foo.bar.baz")
 
-	for range b.N {
+	for b.Loop() {
 		_ = cache.Get(r)
 	}
 }

--- a/pkg/builtins/builtins_test.go
+++ b/pkg/builtins/builtins_test.go
@@ -19,7 +19,7 @@ func BenchmarkRegalLast(b *testing.B) {
 
 	var res *ast.Term
 
-	for range b.N {
+	for b.Loop() {
 		var err error
 
 		res, err = builtins.RegalLast(bctx, arr)
@@ -42,7 +42,7 @@ func BenchmarkRegalLastEmptyArr(b *testing.B) {
 
 	var err error
 
-	for range b.N {
+	for b.Loop() {
 		_, err = builtins.RegalLast(bctx, arr)
 	}
 

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -743,7 +743,7 @@ func BenchmarkRegalLintingItself(b *testing.B) {
 
 	var rep report.Report
 
-	for range b.N {
+	for b.Loop() {
 		rep, err = linter.Lint(b.Context())
 		if err != nil {
 			b.Fatal(err)
@@ -772,7 +772,7 @@ func BenchmarkRegalLintingItselfPrepareOnce(b *testing.B) {
 
 	var rep report.Report
 
-	for range b.N {
+	for b.Loop() {
 		rep, err = linter.Lint(ctx)
 		if err != nil {
 			b.Fatal(err)
@@ -796,7 +796,7 @@ func BenchmarkRegalNoEnabledRules(b *testing.B) {
 
 	var rep report.Report
 
-	for range b.N {
+	for b.Loop() {
 		rep, err = linter.Lint(b.Context())
 		if err != nil {
 			b.Fatal(err)
@@ -821,7 +821,7 @@ func BenchmarkRegalNoEnabledRulesPrepareOnce(b *testing.B) {
 
 	var rep report.Report
 
-	for range b.N {
+	for b.Loop() {
 		rep, err = linter.Lint(b.Context())
 		if err != nil {
 			b.Fatal(err)
@@ -866,7 +866,7 @@ func BenchmarkEachRule(b *testing.B) {
 
 				var rep report.Report
 
-				for range b.N {
+				for b.Loop() {
 					rep, err = linter.WithEnabledRules(ruleName).Lint(ctx)
 					if err != nil {
 						b.Fatal(err)


### PR DESCRIPTION
While most editors seemed to be capable of filtering out these suggestions by themselves, not all did. And we should obviously not send suggestions that aren't valid in any case.

Fixes #1588