### PR TITLE
lsp/completion/input: don't suggest 'input' following dot

### DIFF
--- a/bundle/regal/lsp/completion/providers/input/input.rego
+++ b/bundle/regal/lsp/completion/providers/input/input.rego
@@ -18,6 +18,10 @@ items contains item if {
 
 	startswith("input", word.text)
 
+	# input, as we mean it here, cannot follow dot (like data.input or input.input)
+	before := trim_suffix(line, word.text)
+	not endswith(before, ".")
+
 	item := {
 		"label": "input",
 		"kind": kind.keyword,

--- a/bundle/regal/lsp/completion/providers/input/input_test.rego
+++ b/bundle/regal/lsp/completion/providers/input/input_test.rego
@@ -34,3 +34,18 @@ allow if {
 		},
 	}}
 }
+
+test_no_input_completion_on_[typed] if {
+	template := `allow if {
+	%s
+}`
+
+	some typed in ["foo.", "data.", "input."]
+
+	policy := _with_header(sprintf(template, [typed]))
+
+	items := provider.items with input as util.input_with_location(policy, {"row": 6, "col": 1 + count(typed)})
+	items == set()
+}
+
+_with_header(policy) := concat("\n\n", ["package policy", "import rego.v1", policy])


### PR DESCRIPTION
While it's perhaps possible to have something like `data.foo.input.bar`, that `input` wouldn't be the same `input` as suggested here: we're explicitly documenting it as "the input document".

This should fix the situation where you can use suggestions to come up with

    input.input.input.input
