### PR TITLE
Add Regal bundle compilation benchmark

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -80,6 +80,7 @@ linters:
       - path: '(.+)_test\.go'
         linters:
           - forcetypeassert
+          - godot
     generated: lax
     presets:
       - comments

--- a/internal/compile/compile_bench_test.go
+++ b/internal/compile/compile_bench_test.go
@@ -1,0 +1,21 @@
+package compile
+
+import (
+	"testing"
+
+	"github.com/styrainc/regal/bundle"
+)
+
+// 16	  66555594 ns/op	50239492 B/op	 1083664 allocs/op - main
+// 18	  62569440 ns/op	38723015 B/op	  944277 allocs/op - compiler-optimizations pr
+func BenchmarkCompileBundle(b *testing.B) {
+	bndl := bundle.LoadedBundle
+
+	compiler := NewCompilerWithRegalBuiltins()
+
+	for b.Loop() {
+		if compiler.Compile(bndl.ParsedModules("regal")); len(compiler.Errors) > 0 {
+			b.Fatal(compiler.Errors)
+		}
+	}
+}


### PR DESCRIPTION
This is really testing OPA rather than Regal, but since it's a good test case for improving OPA for Regal, it belongs here.

Used in https://github.com/open-policy-agent/opa/pull/7740

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->