### PR TITLE
internal/io: add FindInputPath when the content isn't needed

### DIFF
--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -84,11 +84,32 @@ func ExcludeTestFilter() filter.LoaderFilter {
 	}
 }
 
+// FindInputPath consults the filesystem and returns the input.json or input.yaml closes to the
+// file provided as arguments.
+func FindInputPath(file string, workspacePath string) string {
+	relative := strings.TrimPrefix(file, workspacePath)
+	components := strings.Split(filepath.Dir(relative), PathSeparator)
+
+	for i := range components {
+		current := components[:len(components)-i]
+		for _, ext := range []string{"json", "yaml"} { // NB(sr): "yml"?
+			inputPath := filepath.Join(workspacePath, filepath.Join(current...), "input."+ext)
+			_, err := os.Stat(inputPath)
+			if err == nil {
+				return inputPath
+			}
+		}
+
+	}
+
+	return ""
+}
+
 // FindInput finds input.json or input.yaml file in workspace closest to the file, and returns
 // both the location and the contents of the file (as map), or an empty string and nil if not found.
 // Note that:
 // - This function doesn't do error handling. If the file can't be read, nothing is returned.
-// - While the input data theoritcally could be anything JSON/YAML value, we only support an object.
+// - While the input data theoretically could be anything JSON/YAML value, we only support an object.
 func FindInput(file string, workspacePath string) (string, map[string]any) {
 	relative := strings.TrimPrefix(file, workspacePath)
 	components := strings.Split(filepath.Dir(relative), PathSeparator)

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -92,14 +92,16 @@ func FindInputPath(file string, workspacePath string) string {
 
 	for i := range components {
 		current := components[:len(components)-i]
-		for _, ext := range []string{"json", "yaml"} { // NB(sr): "yml"?
-			inputPath := filepath.Join(workspacePath, filepath.Join(current...), "input."+ext)
+		prefix := filepath.Join(append([]string{workspacePath}, current...)...)
+
+		for _, ext := range []string{"json", "yaml", "yml"} {
+			inputPath := filepath.Join(prefix, "input."+ext)
+
 			_, err := os.Stat(inputPath)
 			if err == nil {
 				return inputPath
 			}
 		}
-
 	}
 
 	return ""

--- a/internal/lsp/eval_test.go
+++ b/internal/lsp/eval_test.go
@@ -103,15 +103,16 @@ func TestFindInputPath(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		fileType    string
+		fileExt     string
 		fileContent string
 	}{
 		{"json", `{"x": true}`},
 		{"yaml", "x: true"},
+		{"yml", "x: true"},
 	}
 
 	for _, tc := range cases {
-		t.Run(tc.fileType, func(t *testing.T) {
+		t.Run(tc.fileExt, func(t *testing.T) {
 			t.Parallel()
 
 			tmpDir := t.TempDir()
@@ -122,20 +123,20 @@ func TestFindInputPath(t *testing.T) {
 			testutil.MustMkdirAll(t, workspacePath, "foo", "bar")
 
 			if path := rio.FindInputPath(file, workspacePath); path != "" {
-				t.Fatalf("did not expect to find input.%s", tc.fileType)
+				t.Fatalf("did not expect to find input.%s", tc.fileExt)
 			}
 
-			createWithContent(t, tmpDir+"/workspace/foo/bar/input."+tc.fileType, tc.fileContent)
+			createWithContent(t, tmpDir+"/workspace/foo/bar/input."+tc.fileExt, tc.fileContent)
 
-			if path, exp := rio.FindInputPath(file, workspacePath), workspacePath+"/foo/bar/input."+tc.fileType; path != exp {
+			if path, exp := rio.FindInputPath(file, workspacePath), workspacePath+"/foo/bar/input."+tc.fileExt; path != exp {
 				t.Errorf(`expected input at %s, got %s`, exp, path)
 			}
 
-			testutil.MustRemove(t, tmpDir+"/workspace/foo/bar/input."+tc.fileType)
+			testutil.MustRemove(t, tmpDir+"/workspace/foo/bar/input."+tc.fileExt)
 
-			createWithContent(t, tmpDir+"/workspace/input."+tc.fileType, tc.fileContent)
+			createWithContent(t, tmpDir+"/workspace/input."+tc.fileExt, tc.fileContent)
 
-			if path, exp := rio.FindInputPath(file, workspacePath), workspacePath+"/input."+tc.fileType; path != exp {
+			if path, exp := rio.FindInputPath(file, workspacePath), workspacePath+"/input."+tc.fileExt; path != exp {
 				t.Errorf(`expected input at %s, got %s`, exp, path)
 			}
 		})

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -756,7 +756,7 @@ func (l *LanguageServer) StartCommandWorker(ctx context.Context) { //nolint:main
 					break
 				}
 
-				inputPath, _ := rio.FindInput(uri.ToPath(l.clientIdentifier, file), l.workspacePath())
+				inputPath := rio.FindInputPath(uri.ToPath(l.clientIdentifier, file), l.workspacePath())
 
 				responseParams := map[string]any{
 					"type":        "opa-debug",


### PR DESCRIPTION
This is in preparation of some refactoring for io.FindInput(), which I'd like to make somehow aware of the cached files... but I think it's an OK change as-is. A bit of duplication, but less work when we don't care for the file content.
