### PR TITLE
lsp: fix didOpen templating race

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -984,7 +984,7 @@ func (l *LanguageServer) StartWorkspaceStateWorker(ctx context.Context) {
 	}
 }
 
-// StartWebServer starts the web server that serves explorer
+// StartWebServer starts the web server that serves explorer.
 func (l *LanguageServer) StartWebServer(ctx context.Context) {
 	l.webServer.Start(ctx)
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1059,7 +1059,7 @@ func (l *LanguageServer) loadEnabledRulesFromConfig(ctx context.Context, cfg con
 
 // processTemplateJob handles the templating of a newly created Rego file.
 func (l *LanguageServer) processTemplateJob(ctx context.Context, job lintFileJob) error {
-	l.logf(log.LevelMessage, "Template worker received job: %s (reason: %s)", job.URI, job.Reason)
+	l.logf(log.LevelDebug, "template worker received job: %s (reason: %s)", job.URI, job.Reason)
 
 	// mark file as being templated to prevent race conditions
 	l.templatingFiles.Set(job.URI, true)
@@ -1090,10 +1090,6 @@ func (l *LanguageServer) processTemplateJob(ctx context.Context, job lintFileJob
 		TextDocument: types.OptionalVersionedTextDocumentIdentifier{URI: job.URI},
 		Edits:        ComputeEdits("", newContents),
 	})
-
-	// set the cache contents so that the fix can access this content
-	// when renaming the file if required.
-	l.cache.SetFileContents(job.URI, newContents)
 
 	// determine if a rename is needed based on the new file contents.
 	// renameParams will be empty if there are no renames needed


### PR DESCRIPTION
Fixes https://github.com/StyraInc/regal/issues/1608

Extract StartTemplateWorker body into processTemplateJob method to make it possible to test.

It might be good to implement more general locking and unlocking of file contents if we make more modifications but for now, I think this is ok as it addresses the main issue in question.