### PR TITLE
Some doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 <!-- markdownlint-disable MD041 -->
 
-Regal is a linter and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/), making
-your Rego magnificent, and you the ruler of rules!
+Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
+making your Rego magnificent, and you the ruler of rules!
 
 With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
 development, whether you're an experienced Rego developer or just starting out.
@@ -80,7 +80,7 @@ See the [adopters](https://docs.styra.com/regal/adopters) file for more Regal us
 **MacOS and Linux**
 
 ```shell
-brew install styrainc/packages/regal
+brew install regal
 ```
 
 <details>
@@ -291,8 +291,8 @@ The current Roadmap items are all related to the preparation for
 - [ ] [Rego API: Provide a stable and well-documented Rego API (#1555)](https://github.com/StyraInc/regal/issues/1555)
 - [ ] [Go API: Audit and reduce the public Go API surface (#1556)](https://github.com/StyraInc/regal/issues/1556)
 - [ ] [Custom Rules: Tighten up Authoring experience (#1559)](https://github.com/StyraInc/regal/issues/1559)
-- [ ] [docs: Improve automated documentation generation (#1557)](https://github.com/StyraInc/regal/issues/1557)
-- [ ] [docs: Break down README into smaller units (#1558)](https://github.com/StyraInc/regal/issues/1558)
+- [x] [docs: Improve automated documentation generation (#1557)](https://github.com/StyraInc/regal/issues/1557)
+- [x] [docs: Break down README into smaller units (#1558)](https://github.com/StyraInc/regal/issues/1558)
 - [ ] [lsp: Support a JetBrains LSP client (#1560)](https://github.com/StyraInc/regal/issues/1560)
 
 If there's something you'd like to have added to the roadmap, either open an issue, or reach out in the community Slack!

--- a/build/lsp/go.mod
+++ b/build/lsp/go.mod
@@ -1,6 +1,6 @@
 module github.com/styrainc/regal/dev/ws
 
-go 1.24.4
+go 1.24.5
 
 replace github.com/styrainc/regal => ../..
 

--- a/build/ws/go.mod
+++ b/build/ws/go.mod
@@ -1,6 +1,6 @@
 module github.com/styrainc/regal/dev/ws
 
-go 1.24.4
+go 1.24.5
 
 replace github.com/styrainc/regal => ../..
 

--- a/docs/adopters.md
+++ b/docs/adopters.md
@@ -46,7 +46,7 @@ Projects and products that integrate Regal into their offerings.
 
 The following package managers include Regal in their repositories, either natively or via plugins.
 
-- [Homebrew](https://brew.sh/) via Styra's [homebrew-packages](https://github.com/StyraInc/homebrew-packages)
+- [Homebrew](https://brew.sh/) via the [regal](https://formulae.brew.sh/formula/regal) formula
 - [asdf](https://asdf-vm.com/) via [asdf-regal](https://github.com/asdf-community/asdf-regal)
 - [mise](https://mise.jdx.dev/) via its [aqua](https://aquaproj.github.io/) backend and [aqua's regal definition](https://github.com/aquaproj/aqua-registry/tree/main/pkgs/StyraInc/regal)
 - [pkgsrc](https://www.pkgsrc.se/) and the [regal](https://pkgsrc.se/devel/regal) package
@@ -55,12 +55,22 @@ The following package managers include Regal in their repositories, either nativ
 
 ## Companies and Organizations
 
-Companies and organizations using Regal (not counting organizations behind the open source projects listed above).
+Some companies and organizations using Regal.
 
 <!-- cspell:disable -->
+- [ARMO](https://www.armosec.io)
+- [Aqua Security](https://www.aquasec.com)
 - [Atlassian](https://www.atlassian.com)
 - [Bankdata](https://www.bankdata.dk)
+- [CISA](https://www.cisa.gov)
+- [Elastic](https://www.elastic.co)
+- [Google](https://www.google.com)
+- [Microsoft](https://www.microsoft.com)
+- [Ministry of Justice](https://www.gov.uk/government/organisations/ministry-of-justice)
 - [Miro](https://miro.com)
+- [OpenCV](https://opencv.org)
+- [Red Hat](https://www.redhat.com)
+- [Spacelift](https://www.spacelift.io)
 - [Stacklok](https://stacklok.com)
 - [Styra](https://www.styra.com)
 - [UNIwise](https://uniwise.eu/)

--- a/docs/readme-sections/getting-started.md
+++ b/docs/readme-sections/getting-started.md
@@ -7,7 +7,7 @@
 **MacOS and Linux**
 
 ```shell
-brew install styrainc/packages/regal
+brew install regal
 ```
 
 <details>

--- a/docs/readme-sections/intro.md
+++ b/docs/readme-sections/intro.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD041 -->
 
-Regal is a linter and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/), making
-your Rego magnificent, and you the ruler of rules!
+Regal is a linter, debugger and language server for [Rego](https://www.openpolicyagent.org/docs/policy-language/),
+making your Rego magnificent, and you the ruler of rules!
 
 With its extensive set of linter rules, documentation and editor integrations, Regal is the perfect companion for policy
 development, whether you're an experienced Rego developer or just starting out.

--- a/docs/readme-sections/roadmap.md
+++ b/docs/readme-sections/roadmap.md
@@ -9,8 +9,8 @@ The current Roadmap items are all related to the preparation for
 - [ ] [Rego API: Provide a stable and well-documented Rego API (#1555)](https://github.com/StyraInc/regal/issues/1555)
 - [ ] [Go API: Audit and reduce the public Go API surface (#1556)](https://github.com/StyraInc/regal/issues/1556)
 - [ ] [Custom Rules: Tighten up Authoring experience (#1559)](https://github.com/StyraInc/regal/issues/1559)
-- [ ] [docs: Improve automated documentation generation (#1557)](https://github.com/StyraInc/regal/issues/1557)
-- [ ] [docs: Break down README into smaller units (#1558)](https://github.com/StyraInc/regal/issues/1558)
+- [x] [docs: Improve automated documentation generation (#1557)](https://github.com/StyraInc/regal/issues/1557)
+- [x] [docs: Break down README into smaller units (#1558)](https://github.com/StyraInc/regal/issues/1558)
 - [ ] [lsp: Support a JetBrains LSP client (#1560)](https://github.com/StyraInc/regal/issues/1560)
 
 If there's something you'd like to have added to the roadmap, either open an issue, or reach out in the community Slack!

--- a/e2e/testbuild/go.mod
+++ b/e2e/testbuild/go.mod
@@ -1,10 +1,12 @@
 module github.com/styrainc/regal/e2e/testbuild
 
-go 1.24.3
+go 1.24.5
+
+replace github.com/styrainc/regal => ../../
 
 require (
-	github.com/open-policy-agent/opa v1.5.1-0.20250627085034-d3e83fbd7735
-	github.com/styrainc/regal v0.34.1
+	github.com/open-policy-agent/opa v1.6.0
+	github.com/styrainc/regal v0.0.0-00010101000000-000000000000
 )
 
 require (
@@ -36,7 +38,7 @@ require (
 	github.com/gdamore/tcell v1.1.4 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
-	github.com/go-git/go-git/v5 v5.16.0 // indirect
+	github.com/go-git/go-git/v5 v5.16.2 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -89,7 +91,7 @@ require (
 	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/spf13/viper v1.20.1 // indirect
-	github.com/styrainc/roast v0.14.1-0.20250627114319-677c9037669a // indirect
+	github.com/styrainc/roast v0.15.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.2 // indirect
 	github.com/vektah/gqlparser/v2 v2.5.28 // indirect
@@ -125,5 +127,3 @@ require (
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
-
-replace github.com/styrainc/regal => ../../

--- a/e2e/testbuild/go.sum
+++ b/e2e/testbuild/go.sum
@@ -98,8 +98,8 @@ github.com/go-git/go-billy/v5 v5.6.2 h1:6Q86EsPXMa7c3YZ3aLAQsMA0VlWmy43r6FHqa/UN
 github.com/go-git/go-billy/v5 v5.6.2/go.mod h1:rcFC2rAsp/erv7CMz9GczHcuD0D32fWzH+MJAU+jaUU=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399 h1:eMje31YglSBqCdIqdhKBW8lokaMrL3uTkpGYlE2OOT4=
 github.com/go-git/go-git-fixtures/v4 v4.3.2-0.20231010084843-55a94097c399/go.mod h1:1OCfN199q1Jm3HZlxleg+Dw/mwps2Wbk9frAWm+4FII=
-github.com/go-git/go-git/v5 v5.16.0 h1:k3kuOEpkc0DeY7xlL6NaaNg39xdgQbtH5mwCafHO9AQ=
-github.com/go-git/go-git/v5 v5.16.0/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
+github.com/go-git/go-git/v5 v5.16.2 h1:fT6ZIOjE5iEnkzKyxTHK1W4HGAsPhqEqiSAssSO77hM=
+github.com/go-git/go-git/v5 v5.16.2/go.mod h1:4Ge4alE/5gPs30F2H1esi2gPd69R0C39lolkucHBOp8=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -196,8 +196,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.34.1 h1:EUMJIKUjM8sKjYbtxQI9A4z2o+rruxnzNvpknOXie6k=
 github.com/onsi/gomega v1.34.1/go.mod h1:kU1QgUvBDLXBJq618Xvm2LUX6rSAfRaFRTcdOeDLwwY=
-github.com/open-policy-agent/opa v1.5.1-0.20250627085034-d3e83fbd7735 h1:R1hCXHWNuQY5/nUmSKys6jvKUDJp1Xa4q7iC7i6MtPw=
-github.com/open-policy-agent/opa v1.5.1-0.20250627085034-d3e83fbd7735/go.mod h1:zFmw4P+W62+CWGYRDDswfVYSCnPo6oYaktQnfIaRFC4=
+github.com/open-policy-agent/opa v1.6.0 h1:/S/cnNQJ2MUMNzizHPbisTWBHowmLkPrugY5jjkPlRQ=
+github.com/open-policy-agent/opa v1.6.0/go.mod h1:zFmw4P+W62+CWGYRDDswfVYSCnPo6oYaktQnfIaRFC4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
@@ -273,8 +273,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/styrainc/roast v0.14.1-0.20250627114319-677c9037669a h1:0GbmlsRbZlBc50eGsyjbOrubvGiqWGnsgaN88fxe+Y8=
-github.com/styrainc/roast v0.14.1-0.20250627114319-677c9037669a/go.mod h1:THmzBFNFeei9eC86/esYsHjjhMYHkeXa4CcBrJa/bjk=
+github.com/styrainc/roast v0.15.0 h1:cEjm6AfIPp0Z6fTVHK+kW5pWevekmZ69H4XlEcXrTRk=
+github.com/styrainc/roast v0.15.0/go.mod h1:jQH3mOwoaOHrwgtj5B91dOHlfWaEE+lgLV6H+UAaYGo=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tchap/go-patricia/v2 v2.3.2 h1:xTHFutuitO2zqKAQ5rCROYgUb7Or/+IC3fts9/Yc7nM=

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/styrainc/regal
 
-go 1.24.3
+go 1.24.5
 
 require (
 	dario.cat/mergo v1.0.2
@@ -13,6 +13,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-dap v0.12.0
+	github.com/gorilla/websocket v1.5.0
 	github.com/jstemmer/go-junit-report/v2 v2.1.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-policy-agent/opa v1.6.0
@@ -58,7 +59,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/google/pprof v0.0.0-20250422154841-e1f9c1950416 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gowebpki/jcs v1.0.1 // indirect
 	github.com/hashicorp/hcl/v2 v2.23.0 // indirect
 	github.com/hjson/hjson-go v3.3.0+incompatible // indirect


### PR DESCRIPTION
- Since the `brew` package is now available as an official Homebrew formula, we now recommend using that instead. Later, we should also look into [deprecating](https://docs.brew.sh/Deprecating-Disabling-and-Removing-Formulae#deprecate-and-disable-reasons) the styrainc formula, so that users will get notified when using the old one.
- Roadmap progress update
- Bump Go versions and some other minor fixes in our go.mod files
- Update adopters.md with more companies and organizations

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->