### PR TITLE
Fix missing source.explore code action

### DIFF
--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -2,6 +2,7 @@ ignore:
   files:
     - e2e/*
     - pkg/*
+    - "**/testdata/**"
 
 rules:
   custom:

--- a/internal/lsp/handle_text_document_code_action_test.go
+++ b/internal/lsp/handle_text_document_code_action_test.go
@@ -58,6 +58,123 @@ func TestHandleTextDocumentCodeAction(t *testing.T) {
 		},
 	}
 
+	actualAction := invokeHandleTextDocumentCodeAction(t, l, params)
+
+	assertExpectedCodeAction(t, expectedAction, actualAction)
+
+	expArgs, actualArgs := *expectedAction.Command.Arguments, *actualAction.Command.Arguments
+	if exp, got := len(expArgs), len(actualArgs); exp != got {
+		t.Fatalf("expected %d arguments, got %d", exp, got)
+	}
+
+	var expDecoded, actualDecoded map[string]any
+
+	if err := encoding.JSON().Unmarshal([]byte(expArgs[0].(string)), &expDecoded); err != nil {
+		t.Fatalf("failed to unmarshal expected arguments: %v", err)
+	}
+
+	if err := encoding.JSON().Unmarshal([]byte(actualArgs[0].(string)), &actualDecoded); err != nil {
+		t.Fatalf("failed to unmarshal actual arguments: %v", err)
+	}
+
+	if !reflect.DeepEqual(expDecoded, actualDecoded) {
+		t.Errorf("expected Command.Arguments to be %v, got %v", expDecoded, actualDecoded)
+	}
+}
+
+func TestHandleTextDocumentCodeActionSourceExplorer(t *testing.T) {
+	t.Parallel()
+
+	webServer := &web.Server{}
+	webServer.SetBaseURL("http://foo.bar")
+
+	l := &LanguageServer{
+		clientIdentifier:            clients.IdentifierVSCode,
+		clientInitializationOptions: types.InitializationOptions{},
+		webServer:                   webServer,
+		workspaceRootURI:            "file:///foo",
+	}
+
+	uri := "file:///foo/example.rego"
+
+	params := types.CodeActionParams{
+		TextDocument: types.TextDocumentIdentifier{URI: uri},
+		Context:      types.CodeActionContext{},
+		Range: types.Range{
+			Start: types.Position{Line: 2, Character: 4},
+			End:   types.Position{Line: 2, Character: 10},
+		},
+	}
+
+	expectedAction := types.CodeAction{
+		Title: "Explore compiler stages for this policy",
+		Kind:  "source.explore",
+		Command: types.Command{
+			Title:     "Explore compiler stages for this policy",
+			Command:   "vscode.open",
+			Tooltip:   "Explore compiler stages for this policy",
+			Arguments: toAnySlice("http://foo.bar/explorer/example.rego"),
+		},
+	}
+
+	actualAction := invokeHandleTextDocumentCodeAction(t, l, params)
+
+	assertExpectedCodeAction(t, expectedAction, actualAction)
+
+	expArgs, actualArgs := *expectedAction.Command.Arguments, *actualAction.Command.Arguments
+	if exp, got := len(expArgs), len(actualArgs); exp != got {
+		t.Fatalf("expected %d arguments, got %d", exp, got)
+	}
+}
+
+func assertExpectedCodeAction(t *testing.T, expected, actual types.CodeAction) {
+	t.Helper()
+
+	if expected.Title != actual.Title {
+		t.Errorf("expected Title %q, got %q", expected.Title, actual.Title)
+	}
+
+	if expected.Kind != actual.Kind {
+		t.Errorf("expected Kind %q, got %q", expected.Kind, actual.Kind)
+	}
+
+	if len(expected.Diagnostics) != len(actual.Diagnostics) {
+		t.Errorf("expected %d diagnostics, got %d", len(expected.Diagnostics), len(actual.Diagnostics))
+	}
+
+	if expected.IsPreferred == nil && actual.IsPreferred != nil { //nolint:gocritic
+		t.Error("expected IsPreferred to be nil")
+	} else if expected.IsPreferred != nil && actual.IsPreferred == nil {
+		t.Error("expected IsPreferred to be non-nil")
+	} else if expected.IsPreferred != nil && actual.IsPreferred != nil && *expected.IsPreferred != *actual.IsPreferred {
+		t.Errorf("expected IsPreferred to be %v, got %v", *expected.IsPreferred, *actual.IsPreferred)
+	}
+
+	if expected.Command.Command != actual.Command.Command {
+		t.Errorf("expected Command %q, got %q", expected.Command.Command, actual.Command.Command)
+	}
+
+	if expected.Command.Title != actual.Command.Title {
+		t.Errorf("expected Command.Title %q, got %q", expected.Command.Title, actual.Command.Title)
+	}
+
+	if expected.Command.Tooltip != actual.Command.Tooltip {
+		t.Errorf("expected Command.Tooltip %q, got %q", expected.Command.Tooltip, actual.Command.Tooltip)
+	}
+
+	// Just check nilness here, and leave the actual content to the test.
+	if expected.Command.Arguments == nil && actual.Command.Arguments != nil {
+		t.Error("expected Command.Arguments to be nil")
+	} else if expected.Command.Arguments != nil && actual.Command.Arguments == nil {
+		t.Error("expected Command.Arguments to be non-nil")
+	}
+}
+
+func invokeHandleTextDocumentCodeAction(
+	t *testing.T, l *LanguageServer, params types.CodeActionParams,
+) types.CodeAction {
+	t.Helper()
+
 	result, err := l.handleTextDocumentCodeAction(t.Context(), params)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -72,50 +189,7 @@ func TestHandleTextDocumentCodeAction(t *testing.T) {
 		t.Fatalf("Expected %d action, got %d", exp, got)
 	}
 
-	actualAction := actions[0]
-
-	if exp, got := expectedAction.Title, actualAction.Title; exp != got {
-		t.Fatalf("expected Title %q, got %q", exp, got)
-	}
-
-	if exp, got := expectedAction.Kind, actualAction.Kind; exp != got {
-		t.Fatalf("expected Kind %q, got %q", exp, got)
-	}
-
-	if exp, got := len(expectedAction.Diagnostics), len(actualAction.Diagnostics); exp != got {
-		t.Fatalf("expected %d diagnostics, got %d", exp, got)
-	}
-
-	if exp, got := *expectedAction.IsPreferred, *actualAction.IsPreferred; actualAction.IsPreferred == nil || exp != got {
-		t.Fatalf("expected IsPreferred to be %v, got %v", exp, actualAction.IsPreferred)
-	}
-
-	if exp, got := expectedAction.Command.Command, actualAction.Command.Command; exp != got {
-		t.Fatalf("expected Command %q, got %q", exp, got)
-	}
-
-	if actualAction.Command.Arguments == nil {
-		t.Fatal("expected Command.Arguments to be non-nil")
-	}
-
-	expArgs, actualArgs := *expectedAction.Command.Arguments, *actualAction.Command.Arguments
-	if exp, got := len(expArgs), len(actualArgs); exp != got {
-		t.Fatalf("expected %d arguments, got %d", exp, got)
-	}
-
-	var expDecoded, actualDecoded map[string]any
-
-	if err = encoding.JSON().Unmarshal([]byte(expArgs[0].(string)), &expDecoded); err != nil {
-		t.Fatalf("failed to unmarshal expected arguments: %v", err)
-	}
-
-	if err = encoding.JSON().Unmarshal([]byte(actualArgs[0].(string)), &actualDecoded); err != nil {
-		t.Fatalf("failed to unmarshal actual arguments: %v", err)
-	}
-
-	if !reflect.DeepEqual(expDecoded, actualDecoded) {
-		t.Errorf("expected Command.Arguments to be %v, got %v", expDecoded, actualDecoded)
-	}
+	return actions[0]
 }
 
 // 63243 ns/op	   59576 B/op	    1110 allocs/op - the OPA JSON roundtrip method

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -64,20 +64,13 @@ type Environment struct {
 }
 
 type RegalContext struct {
-	Client           Client `json:"client"`
-	WebServerBaseURI string `json:"web_server_base_uri"`
-	WorkspaceRootURI string `json:"workspace_root_uri"`
+	Client      Client      `json:"client"`
+	Environment Environment `json:"environment"`
 }
 
 type CodeActionInput struct {
 	Regal  RegalContext           `json:"regal"`
 	Params types.CodeActionParams `json:"params"`
-}
-
-type CodeActionContext struct {
-	Client           clients.Identifier `json:"client"`
-	WebServerBaseURI string             `json:"web_server_base_uri"`
-	WorkspaceRootURI string             `json:"workspace_root_uri"`
 }
 
 func PositionFromLocation(loc *ast.Location) types.Position {
@@ -292,4 +285,13 @@ func createPreparedQuery(query string) *rego.PreparedEvalQuery {
 	}
 
 	return &pq
+}
+
+func (c CodeActionInput) String() string { // For debugging only
+	s, err := encoding.JSON().MarshalToString(&c)
+	if err != nil {
+		return fmt.Sprintf("CodeActionInput marshalling error: %v", err)
+	}
+
+	return s
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1627,8 +1627,10 @@ func (l *LanguageServer) handleTextDocumentCodeAction(ctx context.Context, param
 				Identifier:            l.clientIdentifier,
 				InitializationOptions: &l.clientInitializationOptions,
 			},
-			WebServerBaseURI: l.webServer.GetBaseURL(),
-			WorkspaceRootURI: l.workspaceRootURI,
+			Environment: rego.Environment{
+				WebServerBaseURI: l.webServer.GetBaseURL(),
+				WorkspaceRootURI: l.workspaceRootURI,
+			},
 		},
 		Params: params,
 	})


### PR DESCRIPTION
This went missing without us noticing :( Due to the input not being what the policy expected (and even verified at compile time). We should look into how to leverage those schemas for runtime checks, as that could save a lot of time troubleshooting. But for now, fixing the issue and adding a regression test for the handler.

<!--
Thank you for submitting a pull request to Regal!

If you're new to contributing to the project, some tips and pointers are provided in the
contributing](https://github.com/StyraInc/regal/blob/main/docs/CONTRIBUTING.md) docs. If you find anything missing, or
not made clear enough, that's a bug, and we'd appreciate hearing about it!

If you want to ask questions before submitting your PR, or want to discuss Regal in general, please feel free to join
us in the `#regal` channel in the [Styra Community Slack](https://inviter.co/styra).
-->