### PR TITLE
Provide development option to load bundle from disk

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -2,15 +2,68 @@ package bundle
 
 import (
 	"embed"
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+
+	"github.com/open-policy-agent/opa/v1/bundle"
 
 	rio "github.com/styrainc/regal/internal/io"
 )
 
 // Bundle FS will include the tests as well, but since that has negligible impact on the size of the binary,
-// it's preferable to filter them out from the bundle than to e.g. create a separate directory for tests
-//
-//go:embed *
-var Bundle embed.FS
+// it's preferable to filter them out from the bundle than to e.g. create a separate directory for tests.
+var (
+	//go:embed *
+	regalBundle    embed.FS
+	devPath        = os.Getenv("REGAL_BUNDLE_PATH")
+	lastErrMsg     = atomic.Pointer[string]{}
+	EmbeddedBundle = sync.OnceValue(func() *bundle.Bundle {
+		return rio.MustLoadRegalBundleFS(regalBundle)
+	})
+	successLogOnce = sync.OnceFunc(func() {
+		fmt.Fprintln(os.Stderr, "Successfully loaded development bundle")
+	})
+)
 
-// LoadedBundle contains the loaded contents of the Bundle.
-var LoadedBundle = rio.MustLoadRegalBundleFS(Bundle)
+func init() {
+	if devPath != "" {
+		fmt.Fprintln(os.Stderr, "REGAL_BUNDLE_PATH set. Will attempt using development bundle from:", devPath)
+	}
+}
+
+// LoadedBundle contains the Regal bundle.
+func LoadedBundle() *bundle.Bundle {
+	// For development, allow bundle to be loaded dynamically from path instead
+	// of the normal one embedded in the compiled binary. This allows editing e.g.
+	// LSP policies while the language server is running. This should be considered
+	// *very* experimental at this point.
+	if devPath != "" {
+		b, err := rio.LoadRegalBundlePath(devPath)
+		if err == nil {
+			if last := lastErrMsg.Load(); last != nil {
+				lastErrMsg.Store(nil)
+
+				fmt.Fprintln(os.Stderr, "development bundle back to a good state, no longer using embedded bundle")
+			}
+
+			successLogOnce()
+
+			return b
+		}
+
+		// Avoid flooding the console/logs with the same error message
+		if curr, last := err.Error(), lastErrMsg.Load(); last == nil || *last != curr {
+			fmt.Fprintf(os.Stderr, "error loading development bundle from %s:\n%v\n", devPath, err)
+
+			lastErrMsg.Store(&curr)
+		}
+
+		// Now fallback to the embedded bundle if the development path fails, as the bundle may
+		// be requested at any time (and very frequently!) from the various LSP commands, and we
+		// don't want a broken language server while developing!
+	}
+
+	return EmbeddedBundle()
+}

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -248,7 +248,7 @@ func lint(args []string, params *lintParams) (result report.Report, err error) {
 
 	regal = regal.WithUserConfig(userConfig)
 
-	go updateCheckAndWarn(params, &rbundle.LoadedBundle, &userConfig)
+	go updateCheckAndWarn(params, rbundle.LoadedBundle(), &userConfig)
 
 	regal, err = regal.Prepare(ctx)
 	if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -154,12 +154,14 @@ func opaTest(args []string) int {
 		return 1
 	}
 
+	regalBundle := rbundle.LoadedBundle()
+
 	if err := store.Write(
 		ctx,
 		txn,
 		storage.AddOp,
 		storage.MustParsePath("/regal"),
-		rbundle.LoadedBundle.Data["regal"],
+		regalBundle.Data["regal"],
 	); err != nil {
 		panic(err)
 	}
@@ -181,7 +183,7 @@ func opaTest(args []string) int {
 		WithEnablePrintStatements(!testParams.benchmark).
 		WithSchemas(compile.RegalSchemaSet()).
 		WithUseTypeCheckAnnotations(true).
-		WithModuleLoader(moduleLoader(&rbundle.LoadedBundle)).
+		WithModuleLoader(moduleLoader(regalBundle)).
 		WithRewriteTestRules(testParams.varValues)
 
 	if testParams.threshold > 0 && !testParams.coverage {

--- a/internal/compile/compile_bench_test.go
+++ b/internal/compile/compile_bench_test.go
@@ -9,7 +9,7 @@ import (
 // 16	  66555594 ns/op	50239492 B/op	 1083664 allocs/op - main
 // 18	  62569440 ns/op	38723015 B/op	  944277 allocs/op - compiler-optimizations pr
 func BenchmarkCompileBundle(b *testing.B) {
-	bndl := bundle.LoadedBundle
+	bndl := bundle.LoadedBundle()
 
 	compiler := NewCompilerWithRegalBuiltins()
 

--- a/internal/io/io_test.go
+++ b/internal/io/io_test.go
@@ -35,3 +35,15 @@ func TestFindManifestLocations(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkLoadRegalBundlePath(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for b.Loop() {
+		_, err := LoadRegalBundlePath("../../bundle")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/lsp/completions/providers/policy.go
+++ b/internal/lsp/completions/providers/policy.go
@@ -4,51 +4,46 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/open-policy-agent/opa/v1/ast"
-	"github.com/open-policy-agent/opa/v1/rego"
 	"github.com/open-policy-agent/opa/v1/storage"
 
-	rbundle "github.com/styrainc/regal/bundle"
 	rio "github.com/styrainc/regal/internal/io"
 	"github.com/styrainc/regal/internal/lsp/cache"
-	rego2 "github.com/styrainc/regal/internal/lsp/rego"
+	"github.com/styrainc/regal/internal/lsp/rego"
 	"github.com/styrainc/regal/internal/lsp/types"
 	"github.com/styrainc/regal/internal/lsp/uri"
-	"github.com/styrainc/regal/pkg/builtins"
-	"github.com/styrainc/regal/pkg/roast/encoding"
 	"github.com/styrainc/regal/pkg/roast/transform"
 )
 
+const completionsQuery = "completions := data.regal.lsp.completion.items"
+
 // Policy provides suggestions that have been determined by Rego policy.
-type Policy struct {
-	pq rego.PreparedEvalQuery
-}
+type Policy struct{}
 
 // NewPolicy creates a new Policy provider. This provider is distinctly different from the other providers
 // as it acts like the entrypoint for all Rego-based providers, and not a single provider "function" like
 // the Go providers do.
 func NewPolicy(ctx context.Context, store storage.Store) *Policy {
-	pq, err := prepareQuery(ctx, store, "completions := data.regal.lsp.completion.items")
-	if err != nil {
-		panic(fmt.Sprintf("failed preparing query for static bundle: %v", err))
+	if err := rego.StoreCachedQuery(ctx, completionsQuery, store); err != nil {
+		log.Fatalf("failed to start policy completions provider: %v", err)
 	}
 
-	return &Policy{
-		pq: *pq,
-	}
+	return &Policy{}
 }
 
 func (*Policy) Name() string {
 	return "policy"
 }
 
-func (p *Policy) Run(
+func (*Policy) Run(
 	ctx context.Context,
 	c *cache.Cache,
 	params types.CompletionParams,
 	opts *Options,
 ) ([]types.CompletionItem, error) {
+	// TODO: Merge this into the rego package
 	if opts == nil {
 		return nil, errors.New("options must be provided")
 	}
@@ -59,7 +54,7 @@ func (p *Policy) Run(
 	}
 
 	// input.regal.context
-	location := rego2.LocationFromPosition(params.Position)
+	location := rego.LocationFromPosition(params.Position)
 	regalContext := ast.NewObject(
 		ast.Item(ast.InternedTerm("location"), ast.ObjectTerm(
 			ast.Item(ast.InternedTerm("row"), ast.InternedTerm(location.Row)),
@@ -94,49 +89,11 @@ func (p *Policy) Run(
 
 	input := ast.NewObject(ast.Item(ast.InternedTerm("regal"), ast.NewTerm(regalObj)))
 
-	result, err := rego2.QueryRegalBundle(ctx, input, p.pq)
-	if err != nil {
-		return nil, fmt.Errorf("failed querying regal bundle: %w", err)
-	}
+	var completions []types.CompletionItem
 
-	completions := make([]types.CompletionItem, 8)
-
-	if err := encoding.JSONRoundTrip(result["completions"], &completions); err != nil {
-		return nil, fmt.Errorf("failed converting completions: %w", err)
+	if err := rego.CachedQueryEval(ctx, completionsQuery, input, &completions); err != nil {
+		return nil, fmt.Errorf("failed querying for completion suggestions: %w", err)
 	}
 
 	return completions, nil
-}
-
-func prepareQuery(ctx context.Context, store storage.Store, query string) (*rego.PreparedEvalQuery, error) {
-	regoArgs := prepareRegoArgs(store, ast.MustParseBody(query))
-
-	txn, err := store.NewTransaction(ctx, storage.WriteParams)
-	if err != nil {
-		return nil, fmt.Errorf("failed creating transaction: %w", err)
-	}
-
-	regoArgs = append(regoArgs, rego.Transaction(txn))
-
-	// Note that we currently don't provide metrics or profiling here, and
-	// most likely we should — need to consider how to best make that conditional
-	// and how to present it if enabled.
-	pq, err := rego.New(regoArgs...).PrepareForEval(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed preparing query: %s, %w", query, err)
-	}
-
-	if err = store.Commit(ctx, txn); err != nil {
-		return nil, fmt.Errorf("failed committing transaction: %w", err)
-	}
-
-	return &pq, nil
-}
-
-func prepareRegoArgs(store storage.Store, query ast.Body) []func(*rego.Rego) {
-	return append([]func(*rego.Rego){
-		rego.Store(store),
-		rego.ParsedQuery(query),
-		rego.ParsedBundle("regal", &rbundle.LoadedBundle),
-	}, builtins.RegalBuiltinRegoFuncs...)
 }

--- a/internal/lsp/completions/refs/used.go
+++ b/internal/lsp/completions/refs/used.go
@@ -44,7 +44,7 @@ func prepareQuery() (*rego.PreparedEvalQuery, error) {
 	}
 
 	regoArgs := append([]func(*rego.Rego){
-		rego.ParsedBundle("regal", &rbundle.LoadedBundle),
+		rego.ParsedBundle("regal", rbundle.LoadedBundle()),
 		rego.ParsedBundle("internal", &dataBundle),
 		rego.ParsedQuery(refNamesQuery),
 	}, builtins.RegalBuiltinRegoFuncs...)

--- a/internal/lsp/rego/rego.go
+++ b/internal/lsp/rego/rego.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
+	"os"
+	"regexp"
+	"strings"
 
 	"github.com/open-policy-agent/opa/v1/ast"
+	"github.com/open-policy-agent/opa/v1/bundle"
 	"github.com/open-policy-agent/opa/v1/rego"
+	"github.com/open-policy-agent/opa/v1/storage"
 
 	rbundle "github.com/styrainc/regal/bundle"
 	"github.com/styrainc/regal/internal/lsp/clients"
@@ -16,22 +20,29 @@ import (
 	"github.com/styrainc/regal/pkg/roast/encoding"
 	"github.com/styrainc/regal/pkg/roast/rast"
 	"github.com/styrainc/regal/pkg/roast/transform"
+	"github.com/styrainc/regal/pkg/roast/util/concurrent"
 )
 
 var (
-	emptyResult = rego.Result{}
-
-	errNoResults          = errors.New("no results returned from evaluation")
-	errExcpectedOneResult = errors.New("expected exactly one result from evaluation")
-	errExcpectedOneExpr   = errors.New("expected exactly one expression in result")
-
-	keywordsPreparedQuery          *rego.PreparedEvalQuery
-	ruleHeadLocationsPreparedQuery *rego.PreparedEvalQuery
-	codeLensPreparedQuery          *rego.PreparedEvalQuery
-	codeActionPreparedQuery        *rego.PreparedEvalQuery
-
-	preparedQueriesInitOnce sync.Once
+	emptyResult            = rego.Result{}
+	errNoResults           = errors.New("no results returned from evaluation")
+	errExcpectedOneResult  = errors.New("expected exactly one result from evaluation")
+	errExcpectedOneExpr    = errors.New("expected exactly one expression in result")
+	keywordsQuery          = "data.regal.ast.keywords"
+	codeLensQuery          = "data.regal.lsp.codelens.lenses"
+	codeActionQuery        = "data.regal.lsp.codeaction.actions"
+	ruleHeadLocationsQuery = "data.regal.ast.rule_head_locations"
+	prepared               = concurrent.MapOf(make(map[string]*cachedQuery, 5))
+	simpleRefPattern       = regexp.MustCompile(`^[a-zA-Z\.]$`)
 )
+
+type regoOptions = []func(*rego.Rego)
+
+type cachedQuery struct {
+	body     ast.Body
+	prepared *rego.PreparedEvalQuery
+	store    storage.Store
+}
 
 func init() {
 	ast.InternStringTerm(
@@ -40,6 +51,12 @@ func init() {
 		"textDocument", "context", "range", "uri", "diagnostics", "only", "triggerKind", "codeDescription",
 		"message", "severity", "source", "code", "data", "title", "command", "kind", "isPreferred",
 	)
+}
+
+type policy struct {
+	module   *ast.Module
+	fileName string
+	contents string
 }
 
 type BuiltInCall struct {
@@ -78,6 +95,15 @@ type RegalContext struct {
 type CodeActionInput struct {
 	Regal  RegalContext           `json:"regal"`
 	Params types.CodeActionParams `json:"params"`
+}
+
+func (c CodeActionInput) String() string { // For debugging only
+	s, err := encoding.JSON().MarshalToString(&c)
+	if err != nil {
+		return fmt.Sprintf("CodeActionInput marshalling error: %v", err)
+	}
+
+	return s
 }
 
 func PositionFromLocation(loc *ast.Location) types.Position {
@@ -124,11 +150,7 @@ func AllBuiltinCalls(module *ast.Module, builtins map[string]*ast.Builtin) []Bui
 				return false
 			}
 
-			builtinCalls = append(builtinCalls, BuiltInCall{
-				Builtin:  b,
-				Location: terms[0].Location,
-				Args:     terms[1:],
-			})
+			builtinCalls = append(builtinCalls, BuiltInCall{Builtin: b, Location: terms[0].Location, Args: terms[1:]})
 		}
 
 		return false
@@ -139,102 +161,92 @@ func AllBuiltinCalls(module *ast.Module, builtins map[string]*ast.Builtin) []Bui
 	return builtinCalls
 }
 
-type policy struct {
-	module   *ast.Module
-	fileName string
-	contents string
-}
-
-func initialize() {
-	keywordsPreparedQuery = createPreparedQuery("data.regal.ast.keywords")
-	codeLensPreparedQuery = createPreparedQuery("data.regal.lsp.codelens.lenses")
-	codeActionPreparedQuery = createPreparedQuery("data.regal.lsp.codeaction.actions")
-	ruleHeadLocationsPreparedQuery = createPreparedQuery("data.regal.ast.rule_head_locations")
-}
-
 // AllKeywords returns all keywords in the module.
 func AllKeywords(ctx context.Context, fileName, contents string, module *ast.Module) (map[string][]KeywordUse, error) {
-	preparedQueriesInitOnce.Do(initialize)
-
 	var keywords map[string][]KeywordUse
 
-	value, err := queryToValue(ctx, keywordsPreparedQuery, policy{module, fileName, contents}, keywords)
+	err := policyToValue(ctx, keywordsQuery, policy{module, fileName, contents}, &keywords)
 	if err != nil {
-		return nil, fmt.Errorf("failed querying code lenses: %w", err)
+		return nil, fmt.Errorf("failed querying for all keywords: %w", err)
 	}
 
-	return value, nil
+	return keywords, nil
 }
 
 // AllRuleHeadLocations returns mapping of rules names to the head locations.
 func AllRuleHeadLocations(ctx context.Context, fileName, contents string, module *ast.Module) (RuleHeads, error) {
-	preparedQueriesInitOnce.Do(initialize)
-
 	var ruleHeads RuleHeads
 
-	value, err := queryToValue(ctx, ruleHeadLocationsPreparedQuery, policy{module, fileName, contents}, ruleHeads)
+	err := policyToValue(ctx, ruleHeadLocationsQuery, policy{module, fileName, contents}, &ruleHeads)
 	if err != nil {
-		return nil, fmt.Errorf("failed querying code lenses: %w", err)
+		return nil, fmt.Errorf("failed querying for rule head locations: %w", err)
 	}
 
-	return value, nil
+	return ruleHeads, nil
 }
 
 // CodeLenses returns all code lenses in the module.
 func CodeLenses(ctx context.Context, uri, contents string, module *ast.Module) ([]types.CodeLens, error) {
-	preparedQueriesInitOnce.Do(initialize)
-
 	var codeLenses []types.CodeLens
 
-	value, err := queryToValue(ctx, codeLensPreparedQuery, policy{module, uri, contents}, codeLenses)
+	err := policyToValue(ctx, codeLensQuery, policy{module, uri, contents}, &codeLenses)
 	if err != nil {
 		return nil, fmt.Errorf("failed querying code lenses: %w", err)
 	}
 
-	return value, nil
+	return codeLenses, nil
 }
 
 // CodeActions returns all code actions in the module.
 // Note that at least as of now, no code actions depend on the data in the module, so
 // it is not passed as part of the input. This could change in the future.
 func CodeActions(ctx context.Context, input CodeActionInput) ([]types.CodeAction, error) {
-	preparedQueriesInitOnce.Do(initialize)
-
 	var codeActions []types.CodeAction
 
-	value, err := queryToValueWithParsedInput(ctx, codeActionPreparedQuery, rast.StructToValue(input), codeActions)
+	err := CachedQueryEval(ctx, codeActionQuery, rast.StructToValue(input), &codeActions)
 	if err != nil {
-		return nil, fmt.Errorf("failed querying code lenses: %w", err)
+		return nil, fmt.Errorf("failed querying code actions: %w", err)
 	}
 
-	return value, nil
+	return codeActions, nil
 }
 
-func queryToValue[T any](ctx context.Context, pq *rego.PreparedEvalQuery, policy policy, toValue T) (T, error) {
+func policyToValue[T any](ctx context.Context, query string, policy policy, toValue *T) error {
 	input, err := transform.ToAST(policy.fileName, policy.contents, policy.module, false)
 	if err != nil {
-		return toValue, fmt.Errorf("failed to prepare input: %w", err)
+		return fmt.Errorf("failed to prepare input: %w", err)
 	}
 
-	return queryToValueWithParsedInput(ctx, pq, input, toValue)
+	return CachedQueryEval(ctx, query, input, toValue)
 }
 
-func queryToValueWithParsedInput[T any](
-	ctx context.Context,
-	pq *rego.PreparedEvalQuery,
-	input ast.Value,
-	toValue T,
-) (T, error) {
-	result, err := toValidResult(pq.Eval(ctx, rego.EvalParsedInput(input)))
+func CachedQueryEval[T any](ctx context.Context, query string, input ast.Value, toValue *T) error {
+	cq, err := getOrSetCachedQuery(ctx, query, nil)
 	if err != nil {
-		return toValue, err
+		return fmt.Errorf("failed preparing query: %w", err)
 	}
 
-	if err := encoding.JSONRoundTrip(result.Expressions[0].Value, &toValue); err != nil {
-		return toValue, fmt.Errorf("failed unmarshaling code lenses: %w", err)
+	result, err := toValidResult(cq.prepared.Eval(ctx, rego.EvalParsedInput(input)))
+	if err != nil {
+		return err
 	}
 
-	return toValue, nil
+	// TODO: let's do something more roubust than this. but fine for now
+	fromValue := result.Expressions[0].Value
+	if strings.Contains(query, "=") {
+		// We don't know the name of the binding here, so just assume there's only one
+		for _, v := range result.Bindings {
+			fromValue = v
+
+			break
+		}
+	}
+
+	if err := encoding.JSONRoundTrip(fromValue, toValue); err != nil {
+		return fmt.Errorf("failed unmarshaling value: %w", err)
+	}
+
+	return nil
 }
 
 func toValidResult(rs rego.ResultSet, err error) (rego.Result, error) {
@@ -252,44 +264,126 @@ func toValidResult(rs rego.ResultSet, err error) (rego.Result, error) {
 	return rs[0], nil
 }
 
-func QueryRegalBundle(ctx context.Context, input ast.Value, pq rego.PreparedEvalQuery) (map[string]any, error) {
-	result, err := pq.Eval(ctx, rego.EvalParsedInput(input))
-	if err != nil {
-		return nil, fmt.Errorf("failed evaluating query: %w", err)
-	}
+func prepareQueryArgs(
+	ctx context.Context,
+	query ast.Body,
+	store storage.Store,
+	regalBundle *bundle.Bundle,
+) (regoOptions, storage.Transaction) {
+	var txn storage.Transaction
 
-	if len(result) == 0 {
-		return nil, errNoResults
-	}
-
-	return result[0].Bindings, nil
-}
-
-func createArgs(args ...func(*rego.Rego)) []func(*rego.Rego) {
-	always := append([]func(*rego.Rego){
-		rego.ParsedBundle("regal", &rbundle.LoadedBundle),
-		rego.StoreReadAST(true),
+	args := append([]func(*rego.Rego){
+		rego.ParsedQuery(query),
+		rego.ParsedBundle("regal", regalBundle),
 	}, builtins.RegalBuiltinRegoFuncs...)
 
-	return append(always, args...)
-}
-
-func createPreparedQuery(query string) *rego.PreparedEvalQuery {
-	args := createArgs(rego.ParsedQuery(rast.RefStringToBody(query)))
-
-	pq, err := rego.New(args...).PrepareForEval(context.Background())
-	if err != nil {
-		panic(fmt.Sprintf("failed to prepare query %s: %v", query, err))
+	if store != nil {
+		txn, _ = store.NewTransaction(ctx, storage.WriteParams)
+		args = append(args, rego.Store(store), rego.Transaction(txn))
+	} else {
+		args = append(args, rego.StoreReadAST(true))
 	}
 
-	return &pq
+	return args, txn
 }
 
-func (c CodeActionInput) String() string { // For debugging only
-	s, err := encoding.JSON().MarshalToString(&c)
-	if err != nil {
-		return fmt.Sprintf("CodeActionInput marshalling error: %v", err)
+func getOrSetCachedQuery(ctx context.Context, query string, store storage.Store) (*cachedQuery, error) {
+	cq, ok := prepared.Get(query)
+	if !ok {
+		parsedQuery := ParseQuery(query)
+
+		pq, err := prepareQuery(ctx, parsedQuery, store)
+		if err != nil {
+			return nil, fmt.Errorf("failed preparing query %q: %w", query, err)
+		}
+
+		cq = &cachedQuery{body: parsedQuery, prepared: pq, store: store}
+
+		prepared.Set(query, cq)
+
+		return cq, nil
 	}
 
-	return s
+	if isBundleDevelopmentMode() {
+		// In dev mode, we always prepare the query to ensure changes in the bundle are reflected
+		// immediately. We can however reuse the query and the store (if set).
+		pq, err := prepareQuery(ctx, cq.body, cq.store)
+		if err != nil {
+			return nil, fmt.Errorf("failed preparing query %q: %w", query, err)
+		}
+
+		cq.prepared = pq
+	}
+
+	return cq, nil
+}
+
+func StoreCachedQuery(ctx context.Context, query string, store storage.Store) error {
+	parsedQuery := ParseQuery(query)
+
+	pq, err := prepareQuery(ctx, parsedQuery, store)
+	if err != nil {
+		return fmt.Errorf("failed preparing query %q: %w", query, err)
+	}
+
+	prepared.Set(query, &cachedQuery{body: parsedQuery, prepared: pq, store: store})
+
+	return nil
+}
+
+func prepareQuery(ctx context.Context, query ast.Body, store storage.Store) (*rego.PreparedEvalQuery, error) {
+	args, txn := prepareQueryArgs(ctx, query, store, rbundle.LoadedBundle())
+
+	// Note that we currently don't provide metrics or profiling here, and
+	// most likely we should — need to consider how to best make that conditional
+	// and how to present it if enabled.
+	pq, err := rego.New(args...).PrepareForEval(ctx)
+	if err != nil {
+		if store != nil {
+			store.Abort(ctx, txn)
+		}
+
+		if isBundleDevelopmentMode() {
+			// Try falling back to the embedded bundle, or else we'll
+			// easily have errors popping up as notifications, making it
+			// really hard to fix the issue that broke the query (like a parse error)
+			args, txn = prepareQueryArgs(ctx, query, store, rbundle.EmbeddedBundle())
+			if pq, err = rego.New(args...).PrepareForEval(ctx); err == nil {
+				if store != nil && txn != nil {
+					if err = store.Commit(ctx, txn); err != nil {
+						return nil, err
+					}
+				}
+
+				return &pq, nil
+			}
+
+			if store != nil {
+				store.Abort(ctx, txn)
+			}
+		}
+
+		return nil, err
+	}
+
+	if store != nil && txn != nil {
+		if err = store.Commit(ctx, txn); err != nil {
+			return nil, err
+		}
+	}
+
+	return &pq, nil
+}
+
+func ParseQuery(query string) ast.Body {
+	// Try cheap parsing if possible
+	if simpleRefPattern.MatchString(query) {
+		return rast.RefStringToBody(query)
+	}
+
+	return ast.MustParseBody(query)
+}
+
+func isBundleDevelopmentMode() bool {
+	return os.Getenv("REGAL_BUNDLE_PATH") != ""
 }

--- a/pkg/linter/linter_test.go
+++ b/pkg/linter/linter_test.go
@@ -840,7 +840,7 @@ func BenchmarkRegalNoEnabledRulesPrepareOnce(b *testing.B) {
 // meaning you do NOT want to do this more than occasionally. You may however find it helpful to use this with
 // a single, or handful of rules to get a better idea of how long they take to run, and relative to each other.
 func BenchmarkEachRule(b *testing.B) {
-	conf, err := config.LoadConfigWithDefaultsFromBundle(&bundle.LoadedBundle, nil)
+	conf, err := config.LoadConfigWithDefaultsFromBundle(bundle.LoadedBundle(), nil)
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
This allows live editing of Rego in the language server, and see the result propagated to the UI right away. A very nice development experience!

This is however very much experimental at this point, and only by setting an `REGAL_BUNDLE_PATH` to point at the bundle path will this be enabled. Most likely a few issues left to resolve here, but let's take it from here!

If we start using this often, we'll also want to optimize bundle loading too, as that happens *very* frequently. Perhaps we could have a file watcher notify us of changes or something like that, and only refresh the bundle when that happens. @charlieegan3 let's talk about that some time :)

https://github.com/user-attachments/assets/40b96ef7-d180-42d8-9c4a-d35a4306f8de

