### PR TITLE
lsp: Correctly close lsp net.Pipes

### DIFF
--- a/internal/lsp/server_test.go
+++ b/internal/lsp/server_test.go
@@ -129,13 +129,12 @@ func createAndInitServer(
 		jsonrpc2.HandlerWithError(clientHandler),
 	)
 
-	go func() {
-		<-ctx.Done()
-		// we need only close the pipe connections as the jsonrpc2.Conn accept
-		// the ctx
-		_ = netConnClient.Close()
-		_ = netConnServer.Close()
-	}()
+	t.Cleanup(func() {
+		connClient.Close()
+		connServer.Close()
+		netConnClient.Close()
+		netConnServer.Close()
+	})
 
 	ls.SetConn(connServer)
 


### PR DESCRIPTION
We were getting this error a lot:

> jsonrpc2: protocol error: io: read/write on closed pipe etc.

But the tests were passing.

```
$ go test -v ./internal/lsp -run "TestRulesWithMetadataNotReportedForMissingMeta|TestLanguageServerCustomRule|TestTemplateWorkerRaceConditionWithDidOpen" 2>&1 | grep -c pipe
0
```

Was 3, approx

```
$ go test -v ./internal/lsp -run "TestRulesWithMetadataNotReportedForMissingMeta|TestLanguageServerCustomRule|TestTemplateWorkerRaceConditionWithDidOpen" 2>&1 | grep -c pipe
3
```
